### PR TITLE
Add KV cache quantization params to ServerManager and setup_backend

### DIFF
--- a/src/forge/server.py
+++ b/src/forge/server.py
@@ -62,6 +62,8 @@ class ServerManager:
         self._current_mode: str | None = None
         self._current_ctx: int | None = None
         self._current_flags: tuple[str, ...] = ()
+        self._current_cache_type_k: str | None = None
+        self._current_cache_type_v: str | None = None
 
     # ── start / stop ────────────────────────────────────────────
 
@@ -72,10 +74,13 @@ class ServerManager:
         mode: str = "native",
         extra_flags: list[str] | None = None,
         ctx_override: int | None = None,
+        cache_type_k: str | None = None,
+        cache_type_v: str | None = None,
     ) -> None:
         """Start a llama-server/llamafile process.
 
-        No-op if the same model + mode + ctx + extra_flags is already running.
+        No-op if the same model + mode + ctx + extra_flags + cache types
+        is already running.
         For ``backend="ollama"`` this is always a no-op.
 
         For ``backend="llamafile"``, the llamafile runtime binary is
@@ -88,6 +93,10 @@ class ServerManager:
             mode: ``"native"`` or ``"prompt"``.
             extra_flags: Additional CLI flags (e.g. ``["--reasoning-format", "auto"]``).
             ctx_override: If set, pass ``-c <value>`` to the server.
+            cache_type_k: KV cache quantization type for keys
+                          (e.g. ``"q8_0"``, ``"q4_0"``).
+            cache_type_v: KV cache quantization type for values
+                          (e.g. ``"q8_0"``, ``"q4_0"``).
         """
         if self._backend == "ollama":
             return
@@ -99,6 +108,8 @@ class ServerManager:
             and self._current_mode == mode
             and self._current_ctx == ctx_override
             and self._current_flags == flags
+            and self._current_cache_type_k == cache_type_k
+            and self._current_cache_type_v == cache_type_v
         ):
             return
 
@@ -133,6 +144,10 @@ class ServerManager:
             cmd.extend(extra_flags)
         if ctx_override is not None:
             cmd.extend(["-c", str(ctx_override)])
+        if cache_type_k is not None:
+            cmd.extend(["--cache-type-k", cache_type_k])
+        if cache_type_v is not None:
+            cmd.extend(["--cache-type-v", cache_type_v])
 
         self._proc = subprocess.Popen(
             cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
@@ -143,6 +158,8 @@ class ServerManager:
         self._current_mode = mode
         self._current_ctx = ctx_override
         self._current_flags = flags
+        self._current_cache_type_k = cache_type_k
+        self._current_cache_type_v = cache_type_v
 
     async def stop(self) -> None:
         """Stop the current server / unload the Ollama model."""
@@ -164,6 +181,8 @@ class ServerManager:
             self._current_mode = None
             self._current_ctx = None
             self._current_flags = ()
+            self._current_cache_type_k = None
+            self._current_cache_type_v = None
             await asyncio.sleep(3)  # let VRAM clear
 
     # ── /props + context ────────────────────────────────────────
@@ -249,6 +268,8 @@ class ServerManager:
         budget_mode: BudgetMode = BudgetMode.BACKEND,
         manual_tokens: int | None = None,
         extra_flags: list[str] | None = None,
+        cache_type_k: str | None = None,
+        cache_type_v: str | None = None,
     ) -> int:
         """Start server with the specified budget mode and return the resolved budget.
 
@@ -268,6 +289,10 @@ class ServerManager:
             budget_mode: How to determine context budget.
             manual_tokens: Required for MANUAL mode.
             extra_flags: Additional server CLI flags.
+            cache_type_k: KV cache quantization type for keys
+                          (e.g. ``"q8_0"``, ``"q4_0"``).
+            cache_type_v: KV cache quantization type for values
+                          (e.g. ``"q8_0"``, ``"q4_0"``).
 
         Returns:
             Resolved budget in tokens (ready for ContextManager).
@@ -285,17 +310,26 @@ class ServerManager:
 
         if budget_mode == BudgetMode.FORGE_FAST:
             # Phase 1: start with auto-tune to discover max
-            await self.start(model, gguf_path, mode, extra_flags, ctx_override=None)
+            await self.start(
+                model, gguf_path, mode, extra_flags, ctx_override=None,
+                cache_type_k=cache_type_k, cache_type_v=cache_type_v,
+            )
             full_ctx = await self.get_server_context()
             half_ctx = full_ctx // 2
 
             # Phase 2: restart with half context
-            await self.start(model, gguf_path, mode, extra_flags, ctx_override=half_ctx)
+            await self.start(
+                model, gguf_path, mode, extra_flags, ctx_override=half_ctx,
+                cache_type_k=cache_type_k, cache_type_v=cache_type_v,
+            )
             return await self.resolve_budget(budget_mode)
 
         # BACKEND / FORGE_FULL / MANUAL
         ctx_override = manual_tokens if budget_mode == BudgetMode.MANUAL else None
-        await self.start(model, gguf_path, mode, extra_flags, ctx_override=ctx_override)
+        await self.start(
+            model, gguf_path, mode, extra_flags, ctx_override=ctx_override,
+            cache_type_k=cache_type_k, cache_type_v=cache_type_v,
+        )
         return await self.resolve_budget(budget_mode, manual_tokens)
 
     def _ollama_vram_tier_budget(self) -> int:
@@ -360,6 +394,8 @@ async def setup_backend(
     extra_flags: list[str] | None = None,
     compact_threshold: float = 0.75,
     on_compact: Callable[[CompactEvent], None] | None = None,
+    cache_type_k: str | None = None,
+    cache_type_v: str | None = None,
 ) -> tuple[ServerManager, ContextManager]:
     """One-call setup: start backend, resolve budget, create ContextManager.
 
@@ -368,6 +404,11 @@ async def setup_backend(
     in sync with the resolved budget.  For llama-server / llamafile the
     context size is baked into the server process via ``-c``, so the
     client parameter is ignored.
+
+    KV cache quantization (``cache_type_k`` / ``cache_type_v``) reduces
+    VRAM usage per token, effectively increasing usable context for the
+    same GPU memory.  Common values: ``"q8_0"`` (~50% savings vs F16),
+    ``"q4_0"`` (~75% savings).  Only applies to llama-server / llamafile.
 
     Example usage::
 
@@ -394,6 +435,8 @@ async def setup_backend(
         budget_mode=budget_mode,
         manual_tokens=manual_tokens,
         extra_flags=extra_flags,
+        cache_type_k=cache_type_k,
+        cache_type_v=cache_type_v,
     )
 
     # Ollama: wire num_ctx so every request uses the resolved budget

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -286,6 +286,62 @@ class TestServerManagerStart:
         args = mock_popen.call_args[0][0]
         assert str(tmp_path / "llamafile-0.9.2.exe") in args
 
+    @pytest.mark.asyncio
+    async def test_start_with_cache_type_k_v(self) -> None:
+        sm = ServerManager(backend="llamaserver", port=8080)
+        mock_proc = MagicMock()
+        with (
+            patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
+        ):
+            await sm.start(
+                "llama3", "/models/llama3.gguf",
+                cache_type_k="q8_0", cache_type_v="q8_0",
+            )
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--cache-type-k" in cmd
+        assert "q8_0" in cmd
+        assert "--cache-type-v" in cmd
+        # Flags appear in order
+        k_idx = cmd.index("--cache-type-k")
+        v_idx = cmd.index("--cache-type-v")
+        assert cmd[k_idx + 1] == "q8_0"
+        assert cmd[v_idx + 1] == "q8_0"
+
+    @pytest.mark.asyncio
+    async def test_start_without_cache_type_omits_flags(self) -> None:
+        sm = ServerManager(backend="llamaserver", port=8080)
+        mock_proc = MagicMock()
+        with (
+            patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
+        ):
+            await sm.start("llama3", "/models/llama3.gguf")
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--cache-type-k" not in cmd
+        assert "--cache-type-v" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_start_restarts_on_cache_type_change(self) -> None:
+        sm = ServerManager(backend="llamaserver", port=8080)
+        mock_proc = MagicMock()
+        with (
+            patch("forge.server.subprocess.Popen", return_value=mock_proc),
+            patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
+            patch("forge.server.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await sm.start("llama3", "/models/llama3.gguf", cache_type_k="q8_0")
+            assert sm._current_cache_type_k == "q8_0"
+
+            # Same config — should reuse (no restart)
+            await sm.start("llama3", "/models/llama3.gguf", cache_type_k="q8_0")
+
+            # Different cache type — should restart
+            await sm.start("llama3", "/models/llama3.gguf", cache_type_k="q4_0")
+            assert sm._current_cache_type_k == "q4_0"
+
 
 # ── ServerManager.stop() ────────────────────────────────────────
 
@@ -355,6 +411,8 @@ class TestServerManagerStop:
         assert sm._current_mode is None
         assert sm._current_ctx is None
         assert sm._current_flags == ()
+        assert sm._current_cache_type_k is None
+        assert sm._current_cache_type_v is None
 
 
 # ── ServerManager.get_server_context() ──────────────────────────
@@ -530,6 +588,7 @@ class TestStartWithBudget:
 
         mock_start.assert_called_once_with(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
+            cache_type_k=None, cache_type_v=None,
         )
         assert result == 13568
 
@@ -548,6 +607,7 @@ class TestStartWithBudget:
 
         mock_start.assert_called_once_with(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=8000,
+            cache_type_k=None, cache_type_v=None,
         )
         assert result == 8000
 
@@ -574,6 +634,7 @@ class TestStartWithBudget:
 
         mock_start.assert_called_once_with(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
+            cache_type_k=None, cache_type_v=None,
         )
         assert result == 13568
 
@@ -599,10 +660,12 @@ class TestStartWithBudget:
         # Phase 1: start without -c
         mock_start.assert_any_call(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
+            cache_type_k=None, cache_type_v=None,
         )
         # Phase 2: restart with half (13568 // 2 = 6784)
         mock_start.assert_any_call(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=6784,
+            cache_type_k=None, cache_type_v=None,
         )
         assert result == 6784
 


### PR DESCRIPTION
## Summary

- Add `cache_type_k` and `cache_type_v` params to `ServerManager.start()`, `start_with_budget()`, and `setup_backend()`
- Passes `--cache-type-k` / `--cache-type-v` flags to llama-server when set
- Cache type included in reuse check — changing cache type triggers a server restart
- 3 new unit tests (flag generation, omission when None, restart on change), 59/59 passing

## Results

Tested with Ministral-3-8B-Reasoning-2512-Q4_K_M on a single GPU:

| Cache type | n_ctx (auto-tuned) | Eval regression |
|-----------|-------------------|-----------------|
| F16 (default) | 36,864 | baseline |
| Q8_0 | 68,608 (1.86x) | none |

Q8 KV cache nearly doubles usable context for the same VRAM. This matters especially for code-assist workloads (forge-code) where the model reads multiple files and accumulates tool call history across turns.

Closes #16 

## Test plan

- [x] 59/59 unit tests passing (56 existing + 3 new)
- [x] Managed mode smoke test: `setup_backend()` with `cache_type_k="q8_0"` starts llama-server with correct flags, auto-tunes to 68,608 tokens
- [x] Comparison test: same model without cache quant auto-tunes to 36,864
- [x] Full eval run (29 scenarios, Ministral 8B): no regression with q8 cache
