### PR TITLE
Add slot_id to LlamafileClient and n_slots to ServerManager

### DIFF
--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -133,6 +133,7 @@ class LlamafileClient:
         timeout: float = 300.0,
         think: bool | None = None,
         cache_prompt: bool = True,
+        slot_id: int | None = None,
     ) -> None:
         self.base_url = base_url
         self.model = model
@@ -141,11 +142,17 @@ class LlamafileClient:
         self._http = httpx.AsyncClient(timeout=timeout)
         self._think: bool = think if think is not None else True  # auto = capture
         self._cache_prompt = cache_prompt
+        self._slot_id = slot_id
 
         if mode in ("native", "prompt"):
             self.resolved_mode: str | None = mode
         else:
             self.resolved_mode = None
+
+    def _apply_slot_id(self, body: dict[str, Any]) -> None:
+        """Inject slot_id into a request body if configured."""
+        if self._slot_id is not None:
+            body["slot_id"] = self._slot_id
 
     def _resolve_reasoning(
         self, accumulated_reasoning: str, accumulated_content: str
@@ -203,6 +210,7 @@ class LlamafileClient:
             "stream": True,
             "cache_prompt": self._cache_prompt,
         }
+        self._apply_slot_id(body)
 
         if mode == "native":
             prepared = _merge_consecutive(messages)
@@ -390,6 +398,7 @@ class LlamafileClient:
             "temperature": self.temperature,
             "cache_prompt": self._cache_prompt,
         }
+        self._apply_slot_id(body)
         if tools:
             body["tools"] = [format_tool(t) for t in tools]
 
@@ -454,6 +463,7 @@ class LlamafileClient:
             "temperature": self.temperature,
             "cache_prompt": self._cache_prompt,
         }
+        self._apply_slot_id(body)
 
         resp = await self._http.post(
             f"{self.base_url}/chat/completions", json=body

--- a/src/forge/server.py
+++ b/src/forge/server.py
@@ -64,6 +64,7 @@ class ServerManager:
         self._current_flags: tuple[str, ...] = ()
         self._current_cache_type_k: str | None = None
         self._current_cache_type_v: str | None = None
+        self._current_n_slots: int | None = None
 
     # ── start / stop ────────────────────────────────────────────
 
@@ -76,11 +77,12 @@ class ServerManager:
         ctx_override: int | None = None,
         cache_type_k: str | None = None,
         cache_type_v: str | None = None,
+        n_slots: int | None = None,
     ) -> None:
         """Start a llama-server/llamafile process.
 
         No-op if the same model + mode + ctx + extra_flags + cache types
-        is already running.
+        + slots is already running.
         For ``backend="ollama"`` this is always a no-op.
 
         For ``backend="llamafile"``, the llamafile runtime binary is
@@ -97,6 +99,8 @@ class ServerManager:
                           (e.g. ``"q8_0"``, ``"q4_0"``).
             cache_type_v: KV cache quantization type for values
                           (e.g. ``"q8_0"``, ``"q4_0"``).
+            n_slots: Number of concurrent slots (each with its own KV
+                     cache). Used for multi-agent architectures.
         """
         if self._backend == "ollama":
             return
@@ -110,6 +114,7 @@ class ServerManager:
             and self._current_flags == flags
             and self._current_cache_type_k == cache_type_k
             and self._current_cache_type_v == cache_type_v
+            and self._current_n_slots == n_slots
         ):
             return
 
@@ -148,6 +153,8 @@ class ServerManager:
             cmd.extend(["--cache-type-k", cache_type_k])
         if cache_type_v is not None:
             cmd.extend(["--cache-type-v", cache_type_v])
+        if n_slots is not None:
+            cmd.extend(["--parallel", str(n_slots)])
 
         self._proc = subprocess.Popen(
             cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
@@ -160,6 +167,7 @@ class ServerManager:
         self._current_flags = flags
         self._current_cache_type_k = cache_type_k
         self._current_cache_type_v = cache_type_v
+        self._current_n_slots = n_slots
 
     async def stop(self) -> None:
         """Stop the current server / unload the Ollama model."""
@@ -183,6 +191,7 @@ class ServerManager:
             self._current_flags = ()
             self._current_cache_type_k = None
             self._current_cache_type_v = None
+            self._current_n_slots = None
             await asyncio.sleep(3)  # let VRAM clear
 
     # ── /props + context ────────────────────────────────────────
@@ -270,6 +279,7 @@ class ServerManager:
         extra_flags: list[str] | None = None,
         cache_type_k: str | None = None,
         cache_type_v: str | None = None,
+        n_slots: int | None = None,
     ) -> int:
         """Start server with the specified budget mode and return the resolved budget.
 
@@ -293,6 +303,7 @@ class ServerManager:
                           (e.g. ``"q8_0"``, ``"q4_0"``).
             cache_type_v: KV cache quantization type for values
                           (e.g. ``"q8_0"``, ``"q4_0"``).
+            n_slots: Number of concurrent slots.
 
         Returns:
             Resolved budget in tokens (ready for ContextManager).
@@ -313,6 +324,7 @@ class ServerManager:
             await self.start(
                 model, gguf_path, mode, extra_flags, ctx_override=None,
                 cache_type_k=cache_type_k, cache_type_v=cache_type_v,
+                n_slots=n_slots,
             )
             full_ctx = await self.get_server_context()
             half_ctx = full_ctx // 2
@@ -321,6 +333,7 @@ class ServerManager:
             await self.start(
                 model, gguf_path, mode, extra_flags, ctx_override=half_ctx,
                 cache_type_k=cache_type_k, cache_type_v=cache_type_v,
+                n_slots=n_slots,
             )
             return await self.resolve_budget(budget_mode)
 
@@ -329,6 +342,7 @@ class ServerManager:
         await self.start(
             model, gguf_path, mode, extra_flags, ctx_override=ctx_override,
             cache_type_k=cache_type_k, cache_type_v=cache_type_v,
+            n_slots=n_slots,
         )
         return await self.resolve_budget(budget_mode, manual_tokens)
 
@@ -396,6 +410,7 @@ async def setup_backend(
     on_compact: Callable[[CompactEvent], None] | None = None,
     cache_type_k: str | None = None,
     cache_type_v: str | None = None,
+    n_slots: int | None = None,
 ) -> tuple[ServerManager, ContextManager]:
     """One-call setup: start backend, resolve budget, create ContextManager.
 
@@ -437,6 +452,7 @@ async def setup_backend(
         extra_flags=extra_flags,
         cache_type_k=cache_type_k,
         cache_type_v=cache_type_v,
+        n_slots=n_slots,
     )
 
     # Ollama: wire num_ctx so every request uses the resolved budget

--- a/tests/unit/test_llamafile_client.py
+++ b/tests/unit/test_llamafile_client.py
@@ -1124,3 +1124,65 @@ class TestThinkFlagStream:
         final = [c for c in chunks if c.type == ChunkType.FINAL][0]
         assert isinstance(final.response, list)
         assert final.response[0].reasoning == "Server reasoning"
+
+
+# ── slot_id ────────────────────────────────────────────────────
+
+
+class TestSlotId:
+    """slot_id injection into request bodies."""
+
+    def test_slot_id_stored(self) -> None:
+        client = LlamafileClient(
+            base_url="http://test:8080/v1", model="test", mode="native", slot_id=1
+        )
+        assert client._slot_id == 1
+
+    def test_slot_id_default_none(self) -> None:
+        client = LlamafileClient(
+            base_url="http://test:8080/v1", model="test", mode="native"
+        )
+        assert client._slot_id is None
+
+    def test_apply_slot_id_injects(self) -> None:
+        client = LlamafileClient(
+            base_url="http://test:8080/v1", model="test", mode="native", slot_id=1
+        )
+        body: dict = {"model": "test"}
+        client._apply_slot_id(body)
+        assert body["slot_id"] == 1
+
+    def test_apply_slot_id_noop_when_none(self) -> None:
+        client = LlamafileClient(
+            base_url="http://test:8080/v1", model="test", mode="native"
+        )
+        body: dict = {"model": "test"}
+        client._apply_slot_id(body)
+        assert "slot_id" not in body
+
+    @pytest.mark.asyncio
+    async def test_native_send_includes_slot_id(self) -> None:
+        client = LlamafileClient(
+            base_url="http://test:8080/v1", model="test", mode="native", slot_id=1
+        )
+        mock_http = AsyncMock()
+        client._http = mock_http
+
+        tool_call_data = {
+            "choices": [{
+                "message": {
+                    "content": "hello",
+                    "tool_calls": None,
+                },
+                "finish_reason": "stop",
+            }],
+        }
+        mock_http.post.return_value = _mock_response(tool_call_data)
+
+        await client.send(
+            [{"role": "user", "content": "test"}], tools=None
+        )
+
+        call_kwargs = mock_http.post.call_args
+        body = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert body["slot_id"] == 1

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -342,6 +342,35 @@ class TestServerManagerStart:
             await sm.start("llama3", "/models/llama3.gguf", cache_type_k="q4_0")
             assert sm._current_cache_type_k == "q4_0"
 
+    @pytest.mark.asyncio
+    async def test_start_with_n_slots(self) -> None:
+        sm = ServerManager(backend="llamaserver", port=8080)
+        mock_proc = MagicMock()
+        with (
+            patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
+        ):
+            await sm.start("llama3", "/models/llama3.gguf", n_slots=2)
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--parallel" in cmd
+        idx = cmd.index("--parallel")
+        assert cmd[idx + 1] == "2"
+        assert sm._current_n_slots == 2
+
+    @pytest.mark.asyncio
+    async def test_start_without_n_slots_omits_flag(self) -> None:
+        sm = ServerManager(backend="llamaserver", port=8080)
+        mock_proc = MagicMock()
+        with (
+            patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
+        ):
+            await sm.start("llama3", "/models/llama3.gguf")
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--parallel" not in cmd
+
 
 # ── ServerManager.stop() ────────────────────────────────────────
 
@@ -413,6 +442,7 @@ class TestServerManagerStop:
         assert sm._current_flags == ()
         assert sm._current_cache_type_k is None
         assert sm._current_cache_type_v is None
+        assert sm._current_n_slots is None
 
 
 # ── ServerManager.get_server_context() ──────────────────────────
@@ -588,7 +618,7 @@ class TestStartWithBudget:
 
         mock_start.assert_called_once_with(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
-            cache_type_k=None, cache_type_v=None,
+            cache_type_k=None, cache_type_v=None, n_slots=None,
         )
         assert result == 13568
 
@@ -607,7 +637,7 @@ class TestStartWithBudget:
 
         mock_start.assert_called_once_with(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=8000,
-            cache_type_k=None, cache_type_v=None,
+            cache_type_k=None, cache_type_v=None, n_slots=None,
         )
         assert result == 8000
 
@@ -634,7 +664,7 @@ class TestStartWithBudget:
 
         mock_start.assert_called_once_with(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
-            cache_type_k=None, cache_type_v=None,
+            cache_type_k=None, cache_type_v=None, n_slots=None,
         )
         assert result == 13568
 
@@ -660,12 +690,12 @@ class TestStartWithBudget:
         # Phase 1: start without -c
         mock_start.assert_any_call(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
-            cache_type_k=None, cache_type_v=None,
+            cache_type_k=None, cache_type_v=None, n_slots=None,
         )
         # Phase 2: restart with half (13568 // 2 = 6784)
         mock_start.assert_any_call(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=6784,
-            cache_type_k=None, cache_type_v=None,
+            cache_type_k=None, cache_type_v=None, n_slots=None,
         )
         assert result == 6784
 


### PR DESCRIPTION
## Summary

- `LlamafileClient`: add `slot_id: int | None` param — injected into all request bodies, routing requests to specific llama-server slots
- `ServerManager`: add `n_slots: int | None` param — passes `--parallel N` to llama-server for multi-slot configurations
- Both params threaded through `start_with_budget()` and `setup_backend()`

Enables multi-agent architectures (e.g. NORA's two-slot setup) where each agent targets a dedicated KV cache slot.

## Smoke tested

Started llama-server with `--parallel 2`, created two `LlamafileClient` instances (`slot_id=0`, `slot_id=1`), sent different messages to each. Both returned correct independent responses. Verified via `/slots` endpoint.

Closes #17 

## Test plan

- [x] 128/128 unit tests passing (121 existing + 7 new)
- [x] `slot_id` stored, injected into body, noop when None
- [x] `slot_id` present in actual `send()` request body
- [x] `--parallel N` flag generated correctly, omitted when None
- [x] Stop clears `n_slots` state
- [x] Live smoke test with 2-slot server
