### PR TITLE
Emit CONTEXT_WARNING via on_message and fix Jinja template crash

### DIFF
--- a/src/forge/core/inference.py
+++ b/src/forge/core/inference.py
@@ -174,9 +174,18 @@ async def run_inference(
         # Fold and serialize
         api_messages = fold_and_serialize(messages, api_format)
 
-        # Inject context warning as transient system message (not persisted)
+        # Inject context warning as transient user message (not persisted
+        # in conversation history). Uses "user" role because mid-conversation
+        # "system" messages break Jinja chat templates on llama-server.
+        # Also emit as a CONTEXT_WARNING message so on_message consumers
+        # (TUI, CLI) can display it to the user.
         if context_warning:
-            api_messages.append({"role": "system", "content": context_warning})
+            api_messages.append({"role": "user", "content": context_warning})
+            new_messages.append(Message(
+                MessageRole.USER,
+                context_warning,
+                MessageMeta(MessageType.CONTEXT_WARNING, step_index=step_index),
+            ))
 
         # Send
         if stream:

--- a/src/forge/core/messages.py
+++ b/src/forge/core/messages.py
@@ -28,6 +28,7 @@ class MessageType(str, Enum):
     TEXT_RESPONSE = "text_response"
     STEP_NUDGE = "step_nudge"
     RETRY_NUDGE = "retry_nudge"
+    CONTEXT_WARNING = "context_warning"
     SUMMARY = "summary"
 
 

--- a/tests/unit/test_context_thresholds.py
+++ b/tests/unit/test_context_thresholds.py
@@ -226,10 +226,11 @@ class TestInferenceInjection:
             trust_text_intent=True,
         )
 
-        # The injected system message should be the last in api_messages
-        system_msgs = [m for m in captured_messages if m["role"] == "system"]
-        assert any("Context usage" in m["content"] for m in system_msgs), \
+        # The injected warning should be the last message (user role)
+        warning_msgs = [m for m in captured_messages if "Context usage" in m.get("content", "")]
+        assert len(warning_msgs) > 0, \
             f"Expected context warning in api_messages, got: {[m['content'][:50] for m in captured_messages]}"
+        assert warning_msgs[0]["role"] == "user"
 
     @pytest.mark.asyncio
     async def test_no_injection_without_threshold_config(self) -> None:

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -30,6 +30,7 @@ class TestMessageType:
             "text_response",
             "step_nudge",
             "retry_nudge",
+            "context_warning",
             "summary",
         }
         actual = {mt.value for mt in MessageType}


### PR DESCRIPTION
## Summary

- Add `CONTEXT_WARNING` to `MessageType` enum
- Emit context warnings as `Message` in `InferenceResult.new_messages` so the runner's `on_message` pipeline delivers them to frontends (TUI, CLI, VS Code)
- Fix Jinja template crash: inject warning as `user` role instead of `system` — mid-conversation system messages break llama-server chat templates

## Test plan

- [x] 677/677 unit tests passing
- [x] Live tested via forge-code TUI: warning appears at 51% context, model switches to targeted reads
