### PR TITLE
Replace hardcoded MODELS_DIR with FORGE_MODELS_DIR env var

### DIFF
--- a/tests/eval/batch_eval.py
+++ b/tests/eval/batch_eval.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 import time
 from dataclasses import dataclass
@@ -27,7 +28,7 @@ from tests.eval.scenarios import ALL_SCENARIOS, EvalScenario
 
 # ── GGUF paths ──────────────────────────────────────────────────
 
-MODELS_DIR = Path(r"C:\Users\antoi\tools\models")
+MODELS_DIR = Path(os.environ.get("FORGE_MODELS_DIR", "models"))
 
 # Map Ollama model names → GGUF filenames for llama-server / llamafile
 GGUF_MAP: dict[str, str] = {

--- a/tests/eval/bfcl/batch_runner.py
+++ b/tests/eval/bfcl/batch_runner.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -52,7 +53,7 @@ from tests.eval.bfcl.schema_adapter import (
 
 # ── GGUF paths ──────────────────────────────────────────────────
 
-MODELS_DIR = Path(r"C:\Users\antoi\tools\models")
+MODELS_DIR = Path(os.environ.get("FORGE_MODELS_DIR", "models"))
 
 GGUF_MAP: dict[str, str] = {
     "llama3.1:8b-instruct-q4_K_M": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",


### PR DESCRIPTION
## Replace hardcoded MODELS_DIR with FORGE_MODELS_DIR env var

### Summary

- `tests/eval/batch_eval.py` and `tests/eval/bfcl/batch_runner.py` had `MODELS_DIR` hardcoded to `C:\Users\antoi\tools\models`
- Both now read from the `FORGE_MODELS_DIR` environment variable, falling back to a relative `models/` directory

### Test plan

- [x] `python -m tests.eval.batch_eval --config ollama --dry-run` runs clean with no import errors
