### PR TITLE
Add multiple terminal tool support

### DIFF
--- a/src/forge/core/runner.py
+++ b/src/forge/core/runner.py
@@ -128,7 +128,7 @@ class WorkflowRunner:
         }
         step_enforcer = StepEnforcer(
             required_steps=workflow.required_steps,
-            terminal_tool=workflow.terminal_tool,
+            terminal_tools=workflow.terminal_tools,
             tool_prerequisites=tool_prerequisites,
         )
         error_tracker = ErrorTracker(
@@ -185,8 +185,12 @@ class WorkflowRunner:
 
             if step_check.needs_nudge:
                 if step_enforcer.premature_exhausted:
+                    attempted = next(
+                        tc.tool for tc in tool_calls
+                        if tc.tool in workflow.terminal_tools
+                    )
                     raise StepEnforcementError(
-                        terminal_tool=workflow.terminal_tool,
+                        terminal_tool=attempted,
                         attempts=step_enforcer.premature_attempts,
                         pending_steps=step_enforcer.pending(),
                     )
@@ -290,7 +294,7 @@ class WorkflowRunner:
                         tool_name=tc.tool,
                         tool_call_id=tc_id,
                     ))
-                    if tc.tool == workflow.terminal_tool:
+                    if tc.tool in workflow.terminal_tools:
                         terminal_result = exc
                     continue
                 except Exception as exc:
@@ -303,7 +307,7 @@ class WorkflowRunner:
                         tool_name=tc.tool,
                         tool_call_id=tc_id,
                     ))
-                    if tc.tool == workflow.terminal_tool:
+                    if tc.tool in workflow.terminal_tools:
                         terminal_result = exc
                     continue
 
@@ -318,7 +322,7 @@ class WorkflowRunner:
                     tool_call_id=tc_id,
                 ))
 
-                if tc.tool == workflow.terminal_tool:
+                if tc.tool in workflow.terminal_tools:
                     terminal_result = result_val
 
             # 3d — Post-batch bookkeeping

--- a/src/forge/core/workflow.py
+++ b/src/forge/core/workflow.py
@@ -198,10 +198,17 @@ class Workflow:
     description: str
     tools: dict[str, ToolDef]
     required_steps: list[str]
-    terminal_tool: str
+    terminal_tool: str | list[str]
     system_prompt_template: str
+    terminal_tools: frozenset[str] = field(default_factory=frozenset, init=False)
 
     def __post_init__(self) -> None:
+        # Normalize terminal_tool to frozenset for O(1) membership checks.
+        if isinstance(self.terminal_tool, str):
+            self.terminal_tools = frozenset([self.terminal_tool])
+        else:
+            self.terminal_tools = frozenset(self.terminal_tool)
+
         for key, tool_def in self.tools.items():
             if key != tool_def.name:
                 raise ValueError(
@@ -213,14 +220,15 @@ class Workflow:
                 raise ValueError(
                     f"Required step '{step}' not in tools: {tool_names}"
                 )
-        if self.terminal_tool not in tool_names:
-            raise ValueError(
-                f"Terminal tool '{self.terminal_tool}' not in tools: {tool_names}"
-            )
-        if self.terminal_tool in self.required_steps:
-            raise ValueError(
-                f"Terminal tool '{self.terminal_tool}' cannot also be a required step"
-            )
+        for tt in self.terminal_tools:
+            if tt not in tool_names:
+                raise ValueError(
+                    f"Terminal tool '{tt}' not in tools: {tool_names}"
+                )
+            if tt in self.required_steps:
+                raise ValueError(
+                    f"Terminal tool '{tt}' cannot also be a required step"
+                )
         for key, tool_def in self.tools.items():
             for prereq in tool_def.prerequisites:
                 prereq_name = prereq if isinstance(prereq, str) else prereq["tool"]

--- a/src/forge/guardrails/guardrails.py
+++ b/src/forge/guardrails/guardrails.py
@@ -56,7 +56,8 @@ class Guardrails:
         tool_names: Valid tool names for this workflow.
         required_steps: Tools that must be called before the terminal tool.
             Defaults to no required steps.
-        terminal_tool: The tool that ends the workflow.
+        terminal_tool: The tool(s) that can end the workflow. Accepts a
+            single name or a frozenset of names.
         max_retries: Consecutive bad responses before ``check()`` returns
             ``"fatal"``. Default 3.
         max_tool_errors: Consecutive tool execution failures before
@@ -70,7 +71,7 @@ class Guardrails:
     def __init__(
         self,
         tool_names: list[str],
-        terminal_tool: str,
+        terminal_tool: str | frozenset[str],
         required_steps: list[str] | None = None,
         max_retries: int = 3,
         max_tool_errors: int = 2,
@@ -81,9 +82,13 @@ class Guardrails:
             tool_names=tool_names,
             rescue_enabled=rescue_enabled,
         )
+        if isinstance(terminal_tool, str):
+            terminal_tools = frozenset([terminal_tool])
+        else:
+            terminal_tools = terminal_tool
         self._enforcer = StepEnforcer(
             required_steps=required_steps or [],
-            terminal_tool=terminal_tool,
+            terminal_tools=terminal_tools,
             max_premature_attempts=max_premature_attempts,
         )
         self._errors = ErrorTracker(
@@ -157,5 +162,5 @@ class Guardrails:
         self._errors.reset_errors()
         self._enforcer.reset_premature()
         return self._enforcer.is_satisfied() and any(
-            name == self._enforcer.terminal_tool for name in executed
+            name in self._enforcer.terminal_tools for name in executed
         )

--- a/src/forge/guardrails/step_enforcer.py
+++ b/src/forge/guardrails/step_enforcer.py
@@ -32,7 +32,7 @@ class StepEnforcer:
 
     Args:
         required_steps: Tool names that must be called before the terminal tool.
-        terminal_tool: The tool that ends the workflow.
+        terminal_tools: The tools that can end the workflow.
         tool_prerequisites: Map of tool name to its ToolDef.prerequisites list.
         max_premature_attempts: How many premature terminal attempts before
             the enforcer signals exhaustion (via StepCheck or raising).
@@ -43,13 +43,13 @@ class StepEnforcer:
     def __init__(
         self,
         required_steps: list[str],
-        terminal_tool: str,
+        terminal_tools: frozenset[str],
         tool_prerequisites: dict[str, list[str | dict[str, str]]] | None = None,
         max_premature_attempts: int = 3,
         max_prereq_violations: int = 2,
     ) -> None:
         self._tracker = StepTracker(required_steps=required_steps)
-        self.terminal_tool = terminal_tool
+        self.terminal_tools = terminal_tools
         self._tool_prerequisites = tool_prerequisites or {}
         self.max_premature_attempts = max_premature_attempts
         self.max_prereq_violations = max_prereq_violations
@@ -59,7 +59,7 @@ class StepEnforcer:
     def check(self, tool_calls: list[ToolCall]) -> StepCheck:
         """Check whether tool calls include a premature terminal call.
 
-        If the terminal tool is in the batch and required steps aren't
+        If a terminal tool is in the batch and required steps aren't
         satisfied, returns a StepCheck with an escalating nudge. The
         escalation tier increments on each premature attempt (1=polite,
         2=direct, 3=aggressive).
@@ -70,16 +70,20 @@ class StepEnforcer:
         Returns:
             StepCheck with nudge if premature, or no nudge if clear to proceed.
         """
-        has_terminal = any(tc.tool == self.terminal_tool for tc in tool_calls)
+        has_terminal = any(tc.tool in self.terminal_tools for tc in tool_calls)
 
         if has_terminal and not self._tracker.is_satisfied():
             self._premature_attempts += 1
             tier = min(self._premature_attempts, 3)
+            # Find which terminal tool was attempted for the nudge message
+            attempted = next(
+                tc.tool for tc in tool_calls if tc.tool in self.terminal_tools
+            )
             return StepCheck(
                 nudge=Nudge(
                     role="user",
                     content=step_nudge(
-                        self.terminal_tool,
+                        attempted,
                         self._tracker.pending(),
                         tier=tier,
                     ),
@@ -136,8 +140,8 @@ class StepEnforcer:
         return self._tracker.pending()
 
     def terminal_reached(self, tool_calls: list[ToolCall]) -> bool:
-        """True if the terminal tool is in the batch and steps are satisfied."""
-        has_terminal = any(tc.tool == self.terminal_tool for tc in tool_calls)
+        """True if a terminal tool is in the batch and steps are satisfied."""
+        has_terminal = any(tc.tool in self.terminal_tools for tc in tool_calls)
         return has_terminal and self._tracker.is_satisfied()
 
     @property

--- a/tests/eval/eval_runner.py
+++ b/tests/eval/eval_runner.py
@@ -147,18 +147,19 @@ def _build_workflow_with_capture(
         base_workflow = scenario.workflow
         validate_state_fn = scenario.validate_state
 
-    original_fn = base_workflow.get_callable(base_workflow.terminal_tool)
-    terminal_spec = base_workflow.tools[base_workflow.terminal_tool].spec
-
-    def capturing_terminal(**kwargs: Any) -> Any:
-        capture["args"] = kwargs
-        return original_fn(**kwargs)
-
     tools = dict(base_workflow.tools)
-    tools[base_workflow.terminal_tool] = ToolDef(
-        spec=terminal_spec,
-        callable=capturing_terminal,
-    )
+    for tt_name in base_workflow.terminal_tools:
+        original_fn = base_workflow.get_callable(tt_name)
+        terminal_spec = base_workflow.tools[tt_name].spec
+
+        def capturing_terminal(_fn=original_fn, **kwargs: Any) -> Any:
+            capture["args"] = kwargs
+            return _fn(**kwargs)
+
+        tools[tt_name] = ToolDef(
+            spec=terminal_spec,
+            callable=capturing_terminal,
+        )
 
     # Ablation: disable step enforcement by clearing required_steps
     required_steps = base_workflow.required_steps

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1876,3 +1876,76 @@ class TestPrerequisiteEnforcement:
 
         prereq_nudges = [m for m in collected if m.metadata.type == MessageType.PREREQUISITE_NUDGE]
         assert len(prereq_nudges) == 1  # only the b.py mismatch
+
+
+# ── Multiple terminal tools ──────────────────────────────────────
+
+
+class TestMultipleTerminalTools:
+    """Runner-level multiple terminal tool support."""
+
+    @pytest.mark.asyncio
+    async def test_first_terminal_exits(self):
+        """Workflow exits on the first terminal tool called."""
+        tools = {
+            "gather": _make_tool("gather"),
+            "set_ac": _make_tool("set_ac", fn=lambda **kw: "ac_on"),
+            "no_action": _make_tool("no_action", fn=lambda **kw: "skipped"),
+        }
+        client = MockClient([
+            ToolCall(tool="gather", args={}),
+            ToolCall(tool="set_ac", args={}),
+        ])
+        wf = _make_workflow(
+            tools=tools, required_steps=["gather"],
+            terminal_tool=["set_ac", "no_action"],
+        )
+        runner = _make_runner(client)
+        result = await runner.run(wf, "manage ac", prompt_vars={"role": "agent"})
+        assert result == "ac_on"
+
+    @pytest.mark.asyncio
+    async def test_second_terminal_exits(self):
+        """Workflow also exits on the other terminal tool."""
+        tools = {
+            "gather": _make_tool("gather"),
+            "set_ac": _make_tool("set_ac", fn=lambda **kw: "ac_on"),
+            "no_action": _make_tool("no_action", fn=lambda **kw: "skipped"),
+        }
+        client = MockClient([
+            ToolCall(tool="gather", args={}),
+            ToolCall(tool="no_action", args={}),
+        ])
+        wf = _make_workflow(
+            tools=tools, required_steps=["gather"],
+            terminal_tool=["set_ac", "no_action"],
+        )
+        runner = _make_runner(client)
+        result = await runner.run(wf, "manage ac", prompt_vars={"role": "agent"})
+        assert result == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_premature_terminal_blocked_for_all(self):
+        """Both terminal tools are blocked before required steps."""
+        collected = []
+        tools = {
+            "gather": _make_tool("gather"),
+            "set_ac": _make_tool("set_ac"),
+            "no_action": _make_tool("no_action"),
+        }
+        client = MockClient([
+            ToolCall(tool="set_ac", args={}),       # premature
+            ToolCall(tool="no_action", args={}),     # also premature
+            ToolCall(tool="gather", args={}),         # required step
+            ToolCall(tool="set_ac", args={}),         # now allowed
+        ])
+        wf = _make_workflow(
+            tools=tools, required_steps=["gather"],
+            terminal_tool=["set_ac", "no_action"],
+        )
+        runner = _make_runner(client)
+        runner.on_message = collected.append
+        await runner.run(wf, "go", prompt_vars={"role": "agent"})
+
+        step_nudges = [m for m in collected if m.metadata.type == MessageType.STEP_NUDGE]
+        assert len(step_nudges) == 2  # both premature attempts nudged

--- a/tests/unit/test_step_enforcer.py
+++ b/tests/unit/test_step_enforcer.py
@@ -12,7 +12,7 @@ class TestStepEnforcerCheck:
     def setup_method(self):
         self.enforcer = StepEnforcer(
             required_steps=["search", "lookup"],
-            terminal_tool="answer",
+            terminal_tools=frozenset(["answer"]),
         )
 
     def test_no_terminal_no_nudge(self):
@@ -78,7 +78,7 @@ class TestStepEnforcerRecord:
     def setup_method(self):
         self.enforcer = StepEnforcer(
             required_steps=["search", "lookup"],
-            terminal_tool="answer",
+            terminal_tools=frozenset(["answer"]),
         )
 
     def test_initially_not_satisfied(self):
@@ -111,7 +111,7 @@ class TestStepEnforcerTerminalReached:
     def setup_method(self):
         self.enforcer = StepEnforcer(
             required_steps=["search"],
-            terminal_tool="answer",
+            terminal_tools=frozenset(["answer"]),
         )
 
     def test_terminal_reached_when_satisfied(self):
@@ -135,7 +135,7 @@ class TestStepEnforcerExhaustion:
     def test_premature_exhausted(self):
         enforcer = StepEnforcer(
             required_steps=["search"],
-            terminal_tool="answer",
+            terminal_tools=frozenset(["answer"]),
             max_premature_attempts=2,
         )
         calls = [ToolCall(tool="answer", args={})]
@@ -148,7 +148,7 @@ class TestStepEnforcerExhaustion:
     def test_premature_attempts_count(self):
         enforcer = StepEnforcer(
             required_steps=["search"],
-            terminal_tool="answer",
+            terminal_tools=frozenset(["answer"]),
         )
         assert enforcer.premature_attempts == 0
         enforcer.check([ToolCall(tool="answer", args={})])
@@ -161,7 +161,7 @@ class TestStepEnforcerResetPremature:
     def test_reset_clears_counter(self):
         enforcer = StepEnforcer(
             required_steps=["search"],
-            terminal_tool="answer",
+            terminal_tools=frozenset(["answer"]),
             max_premature_attempts=2,
         )
         calls = [ToolCall(tool="answer", args={})]
@@ -175,7 +175,7 @@ class TestStepEnforcerResetPremature:
     def test_reset_allows_fresh_attempts(self):
         enforcer = StepEnforcer(
             required_steps=["search"],
-            terminal_tool="answer",
+            terminal_tools=frozenset(["answer"]),
             max_premature_attempts=2,
         )
         calls = [ToolCall(tool="answer", args={})]
@@ -192,13 +192,13 @@ class TestStepEnforcerCompletedSteps:
 
     def test_initially_empty(self):
         enforcer = StepEnforcer(
-            required_steps=["search"], terminal_tool="answer"
+            required_steps=["search"], terminal_tools=frozenset(["answer"])
         )
         assert enforcer.completed_steps == {}
 
     def test_reflects_recordings(self):
         enforcer = StepEnforcer(
-            required_steps=["search", "lookup"], terminal_tool="answer"
+            required_steps=["search", "lookup"], terminal_tools=frozenset(["answer"])
         )
         enforcer.record("search")
         assert "search" in enforcer.completed_steps
@@ -210,13 +210,13 @@ class TestStepEnforcerNoRequiredSteps:
 
     def test_always_satisfied(self):
         enforcer = StepEnforcer(
-            required_steps=[], terminal_tool="answer"
+            required_steps=[], terminal_tools=frozenset(["answer"])
         )
         assert enforcer.is_satisfied() is True
 
     def test_terminal_never_premature(self):
         enforcer = StepEnforcer(
-            required_steps=[], terminal_tool="answer"
+            required_steps=[], terminal_tools=frozenset(["answer"])
         )
         calls = [ToolCall(tool="answer", args={})]
         result = enforcer.check(calls)
@@ -229,7 +229,7 @@ class TestPrerequisiteCheckNameOnly:
     def setup_method(self):
         self.enforcer = StepEnforcer(
             required_steps=[],
-            terminal_tool="respond",
+            terminal_tools=frozenset(["respond"]),
             tool_prerequisites={"edit_file": ["read_file"]},
         )
 
@@ -258,7 +258,7 @@ class TestPrerequisiteCheckArgMatched:
     def setup_method(self):
         self.enforcer = StepEnforcer(
             required_steps=[],
-            terminal_tool="respond",
+            terminal_tools=frozenset(["respond"]),
             tool_prerequisites={
                 "edit_file": [{"tool": "read_file", "match_arg": "path"}],
             },
@@ -301,7 +301,7 @@ class TestPrerequisiteCheckMixed:
     def test_both_must_be_satisfied(self):
         enforcer = StepEnforcer(
             required_steps=[],
-            terminal_tool="respond",
+            terminal_tools=frozenset(["respond"]),
             tool_prerequisites={
                 "edit_file": [
                     "authenticate",
@@ -333,7 +333,7 @@ class TestPrerequisiteBatchBlocking:
     def test_any_violation_blocks_entire_batch(self):
         enforcer = StepEnforcer(
             required_steps=[],
-            terminal_tool="respond",
+            terminal_tools=frozenset(["respond"]),
             tool_prerequisites={"edit_file": ["read_file"]},
         )
         calls = [
@@ -351,7 +351,7 @@ class TestPrerequisiteExhaustion:
     def test_exhausted_after_max_violations(self):
         enforcer = StepEnforcer(
             required_steps=[],
-            terminal_tool="respond",
+            terminal_tools=frozenset(["respond"]),
             tool_prerequisites={"edit_file": ["read_file"]},
             max_prereq_violations=2,
         )
@@ -365,7 +365,7 @@ class TestPrerequisiteExhaustion:
     def test_violation_count_tracks(self):
         enforcer = StepEnforcer(
             required_steps=[],
-            terminal_tool="respond",
+            terminal_tools=frozenset(["respond"]),
             tool_prerequisites={"edit_file": ["read_file"]},
         )
         assert enforcer.prereq_violations == 0
@@ -375,7 +375,7 @@ class TestPrerequisiteExhaustion:
     def test_reset_clears_violations(self):
         enforcer = StepEnforcer(
             required_steps=[],
-            terminal_tool="respond",
+            terminal_tools=frozenset(["respond"]),
             tool_prerequisites={"edit_file": ["read_file"]},
             max_prereq_violations=1,
         )
@@ -393,8 +393,47 @@ class TestPrerequisiteNoPrereqs:
     def test_always_passes(self):
         enforcer = StepEnforcer(
             required_steps=[],
-            terminal_tool="respond",
+            terminal_tools=frozenset(["respond"]),
         )
         calls = [ToolCall(tool="edit_file", args={"path": "foo.py"})]
         result = enforcer.check_prerequisites(calls)
         assert result.needs_nudge is False
+
+
+class TestMultipleTerminalTools:
+    """Multiple terminal tools support."""
+
+    def setup_method(self):
+        self.enforcer = StepEnforcer(
+            required_steps=["gather_data"],
+            terminal_tools=frozenset(["set_ac", "no_action"]),
+        )
+
+    def test_either_terminal_triggers_premature_check(self):
+        calls_a = [ToolCall(tool="set_ac", args={})]
+        result = self.enforcer.check(calls_a)
+        assert result.needs_nudge is True
+        assert "set_ac" in result.nudge.content
+
+    def test_second_terminal_also_triggers(self):
+        calls_b = [ToolCall(tool="no_action", args={})]
+        result = self.enforcer.check(calls_b)
+        assert result.needs_nudge is True
+        assert "no_action" in result.nudge.content
+
+    def test_either_terminal_succeeds_after_steps(self):
+        self.enforcer.record("gather_data")
+        calls_a = [ToolCall(tool="set_ac", args={})]
+        assert self.enforcer.terminal_reached(calls_a) is True
+        calls_b = [ToolCall(tool="no_action", args={})]
+        assert self.enforcer.terminal_reached(calls_b) is True
+
+    def test_non_terminal_does_not_trigger(self):
+        calls = [ToolCall(tool="gather_data", args={})]
+        result = self.enforcer.check(calls)
+        assert result.needs_nudge is False
+
+    def test_non_terminal_does_not_reach(self):
+        self.enforcer.record("gather_data")
+        calls = [ToolCall(tool="gather_data", args={})]
+        assert self.enforcer.terminal_reached(calls) is False

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -79,6 +79,35 @@ class TestWorkflowValidation:
         assert wf.name == "test_workflow"
         assert len(wf.tools) == 2
 
+    def test_multiple_terminal_tools_accepted(self):
+        tools = _make_tools("fetch_data", "approve", "reject")
+        wf = _make_workflow(
+            tools=tools,
+            required_steps=["fetch_data"],
+            terminal_tool=["approve", "reject"],
+        )
+        assert wf.terminal_tools == frozenset(["approve", "reject"])
+
+    def test_single_terminal_tool_normalized_to_frozenset(self):
+        wf = _make_workflow()
+        assert isinstance(wf.terminal_tools, frozenset)
+        assert wf.terminal_tools == frozenset(["submit_result"])
+
+    def test_raises_on_unknown_terminal_tool_in_list(self):
+        with pytest.raises(ValueError, match="Terminal tool 'nonexistent'"):
+            _make_workflow(
+                tools=_make_tools("fetch_data", "submit_result"),
+                terminal_tool=["submit_result", "nonexistent"],
+            )
+
+    def test_raises_when_any_terminal_tool_in_required_steps(self):
+        with pytest.raises(ValueError, match="cannot also be a required step"):
+            _make_workflow(
+                tools=_make_tools("fetch_data", "approve", "reject"),
+                required_steps=["fetch_data", "approve"],
+                terminal_tool=["approve", "reject"],
+            )
+
     def test_raises_on_unknown_prerequisite_name_only(self):
         tools = _make_tools("fetch_data", "submit_result")
         tools["submit_result"].prerequisites = ["nonexistent"]


### PR DESCRIPTION
## Summary

Generalizes `Workflow.terminal_tool` to accept `str | list[str]`. A single string remains valid (no breaking change). When multiple tools are provided, any of them can terminate the workflow. Internally normalized to a `frozenset` for O(1) membership checks.

## Changes

- `Workflow.terminal_tool: str | list[str]` — accepts single or multiple terminal tools
- `Workflow.terminal_tools: frozenset[str]` — normalized internal representation, used by all consumers
- `Workflow.__post_init__` — validates each terminal tool exists and is not a required step
- `StepEnforcer` — accepts `terminal_tools: frozenset[str]`, all checks use `in` membership
- `runner.py` — all `== workflow.terminal_tool` replaced with `in workflow.terminal_tools`
- `guardrails.py` — facade accepts `str | frozenset[str]`, normalizes and passes through
- `eval_runner.py` — capturing wrapper iterates `terminal_tools` to wrap all terminals
- 12 new tests covering multi-terminal enforcement, workflow validation, and runner exit behavior
- All existing tests updated from `terminal_tool=` to `terminal_tools=frozenset(...)` in StepEnforcer construction

Closes #34 .

## Test plan

- [x] 715 unit tests passing (12 new, 0 regressions)
- [x] Live smoke test against Ministral 8B: workflow with `respond` and `take_action` as terminals — model correctly exits via either depending on user intent
- [ ] Eval batch run to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
