### PR TITLE
Add workflow cancellation via cancel_event and update docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -228,9 +228,14 @@ class ToolDef:
     Downstream projects define tools as ToolDefs. The Workflow holds these
     in a dict keyed by name and derives the spec list (for the LLM) and
     callable lookup (for execution) internally.
+
+    Prerequisites express conditional dependencies: "if you call this tool,
+    you must have called tool X first." Enforced via nudge-and-retry at
+    the runner level.
     """
     spec: ToolSpec
     callable: Callable[..., Any]       # sync or async
+    prerequisites: list[str | dict[str, str]]  # name-only or arg-matched
 
     @property
     def name(self) -> str:
@@ -570,19 +575,25 @@ class StepCheck:
 
 
 class StepEnforcer:
-    """Tracks required steps and enforces them with escalating nudges.
+    """Tracks required steps, enforces them with escalating nudges,
+    and enforces tool prerequisites.
 
     Wraps StepTracker internally. Stateful — instantiate per session/task.
 
     Args:
         required_steps: Tool names that must be called before the terminal tool.
-        terminal_tool: The tool that ends the workflow.
+        terminal_tools: The tools that can end the workflow (frozenset).
+        tool_prerequisites: Map of tool name to its ToolDef.prerequisites list.
         max_premature_attempts: How many premature terminal attempts before
             the enforcer signals exhaustion.
+        max_prereq_violations: How many consecutive prerequisite violations
+            before the enforcer signals exhaustion.
     """
 
-    def __init__(self, required_steps: list[str], terminal_tool: str,
-                 max_premature_attempts: int = 3) -> None: ...
+    def __init__(self, required_steps: list[str], terminal_tools: frozenset[str],
+                 tool_prerequisites: dict | None = None,
+                 max_premature_attempts: int = 3,
+                 max_prereq_violations: int = 2) -> None: ...
 
     def check(self, tool_calls: list[ToolCall]) -> StepCheck:
         """Check whether tool calls include a premature terminal call.
@@ -591,16 +602,28 @@ class StepEnforcer:
         """
         ...
 
-    def record(self, tool_name: str) -> None: ...
+    def check_prerequisites(self, tool_calls: list[ToolCall]) -> StepCheck:
+        """Check whether any tool call has unsatisfied prerequisites.
+
+        Evaluates against pre-batch state. Any violation blocks the entire batch.
+        """
+        ...
+
+    def record(self, tool_name: str, args: dict | None = None) -> None: ...
     def is_satisfied(self) -> bool: ...
     def pending(self) -> list[str]: ...
     def reset_premature(self) -> None: ...
+    def reset_prereq_violations(self) -> None: ...
     def summary_hint(self) -> str: ...
 
     @property
     def premature_attempts(self) -> int: ...
     @property
     def premature_exhausted(self) -> bool: ...
+    @property
+    def prereq_violations(self) -> int: ...
+    @property
+    def prereq_exhausted(self) -> bool: ...
     @property
     def completed_steps(self) -> dict[str, None]: ...
 
@@ -643,26 +666,36 @@ class Workflow:
     description: str
     tools: dict[str, ToolDef]            # Keyed by tool name, validated for consistency
     required_steps: list[str]            # Tools that must be called before terminal
-    terminal_tool: str                   # Tool that ends the workflow
+    terminal_tool: str | list[str]       # Tool(s) that can end the workflow
     system_prompt_template: str          # May contain {placeholders}
+    terminal_tools: frozenset[str]       # Normalized from terminal_tool (init=False)
 
     def __post_init__(self) -> None:
-        """Validate tool key/name consistency, required_steps, and terminal_tool."""
+        """Normalize terminal_tool to frozenset. Validate tool key/name
+        consistency, required_steps, terminal_tools, and prerequisites."""
+        # Normalize terminal_tool → terminal_tools (frozenset)
+        if isinstance(self.terminal_tool, str):
+            self.terminal_tools = frozenset([self.terminal_tool])
+        else:
+            self.terminal_tools = frozenset(self.terminal_tool)
+
         for key, tool_def in self.tools.items():
             if key != tool_def.name:
-                raise ValueError(
-                    f"Tool key '{key}' does not match ToolDef name '{tool_def.name}'"
-                )
+                raise ValueError(...)
         tool_names = set(self.tools.keys())
         for step in self.required_steps:
             if step not in tool_names:
-                raise ValueError(f"Required step '{step}' not in tools: {tool_names}")
-        if self.terminal_tool not in tool_names:
-            raise ValueError(f"Terminal tool '{self.terminal_tool}' not in tools: {tool_names}")
-        if self.terminal_tool in self.required_steps:
-            raise ValueError(
-                f"Terminal tool '{self.terminal_tool}' cannot also be a required step"
-            )
+                raise ValueError(...)
+        for tt in self.terminal_tools:
+            if tt not in tool_names:
+                raise ValueError(...)
+            if tt in self.required_steps:
+                raise ValueError(...)
+        for key, tool_def in self.tools.items():
+            for prereq in tool_def.prerequisites:
+                prereq_name = prereq if isinstance(prereq, str) else prereq["tool"]
+                if prereq_name not in tool_names:
+                    raise ValueError(...)
 
     def build_system_prompt(self, **kwargs: str) -> str:
         """Render the system prompt with user-provided values."""
@@ -818,6 +851,16 @@ class StepEnforcementError(ForgeError):
     def __init__(self, terminal_tool: str, attempts: int, pending_steps: list[str]):
         ...
 
+class PrerequisiteError(ForgeError):
+    """Model repeatedly called a tool without satisfying its prerequisites."""
+    def __init__(self, tool_name: str, violations: int, missing_prereqs: list[str]):
+        ...
+
+class WorkflowCancelledError(ForgeError):
+    """Workflow was cancelled via cancel_event before completion."""
+    def __init__(self, messages: list, completed_steps: dict[str, None], iteration: int):
+        ...
+
 class ContextBudgetExceeded(ForgeError):
     """Context exceeded budget even after compaction. Unrecoverable."""
     def __init__(self, estimated_tokens: int, budget_tokens: int):
@@ -863,9 +906,9 @@ class StreamError(ForgeError):
 ```
 Downstream Project
 │
-│  workflow = Workflow(tools=..., required_steps=..., terminal_tool=...)
+│  workflow = Workflow(tools=..., required_steps=..., terminal_tool=...)  # str or list[str]
 │  runner = WorkflowRunner(client=ollama_client, context_manager=ctx_mgr)
-│  result = await runner.run(workflow, "Generate a quote for part X")
+│  result = await runner.run(workflow, "Generate a quote for part X", cancel_event=event)
 │
 ▼
 WorkflowRunner.run()
@@ -876,10 +919,12 @@ WorkflowRunner.run()
 │
 ├─ 2. Initialize guardrail middleware
 │     validator = ResponseValidator(tool_names, rescue_enabled)
-│     step_enforcer = StepEnforcer(required_steps, terminal_tool)
+│     step_enforcer = StepEnforcer(required_steps, terminal_tools, tool_prerequisites)
 │     error_tracker = ErrorTracker(max_retries, max_tool_errors)
 │
 └─ 3. Loop (up to max_iterations):
+      │
+      ├─ 3.0. Cancel check: if cancel_event is set → raise WorkflowCancelledError
       │
       ├─ 3a. ContextManager.maybe_compact(messages)
       │       │
@@ -917,7 +962,14 @@ WorkflowRunner.run()
       │       ├─ Terminal present + steps NOT satisfied → StepCheck(nudge=step_nudge, needs_nudge=True)
       │       │    ├─ step_enforcer.premature_exhausted → raise StepEnforcementError
       │       │    └─ Emit tool call + escalating step nudge (tier 1/2/3), continue
-      │       └─ No premature terminal → StepCheck(needs_nudge=False), continue to 3f
+      │       └─ No premature terminal → StepCheck(needs_nudge=False), continue to 3e.2
+      │
+      ├─ 3e.2. StepEnforcer.check_prerequisites(tool_calls)
+      │       │
+      │       ├─ Any prereq unsatisfied → StepCheck(nudge=prerequisite_nudge, needs_nudge=True)
+      │       │    ├─ step_enforcer.prereq_exhausted → raise PrerequisiteError
+      │       │    └─ Emit tool call + prerequisite nudge, continue
+      │       └─ All prereqs satisfied → continue to 3f
       │
       ├─ 3f. Execute ALL tool calls in the batch sequentially
       │       │
@@ -928,14 +980,15 @@ WorkflowRunner.run()
       │       │    don't record step
       │       ├─ Other exception → feed back as [ToolError], track last_error
       │       │    batch_had_error flag set, continue to next tool in batch
-      │       ├─ Success → step_enforcer.record(), append result as TOOL_RESULT
+      │       ├─ Success → step_enforcer.record(tool, args), append result as TOOL_RESULT
       │       └─ Terminal tool in batch + succeeded → stash result for return
       │
       ├─ 3g. Post-batch bookkeeping:
       │       │
       │       ├─ batch_had_error → error_tracker.record_result(success=False)
       │       │    error_tracker.tool_errors_exhausted → raise ToolExecutionError
-      │       ├─ No errors → error_tracker.reset_errors(), step_enforcer.reset_premature()
+      │       ├─ No errors → error_tracker.reset_errors(), step_enforcer.reset_premature(),
+      │       │    step_enforcer.reset_prereq_violations()
       │       └─ Terminal tool succeeded → return terminal result
       │       │
       │       Messages appended per iteration:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -82,7 +82,7 @@ done = guardrails.record([tc.tool for tc in result.tool_calls])
 from forge.guardrails import ResponseValidator, StepEnforcer, ErrorTracker
 
 validator = ResponseValidator(tool_names=["search", "lookup", "answer"])
-enforcer = StepEnforcer(required_steps=["search", "lookup"], terminal_tool="answer")
+enforcer = StepEnforcer(required_steps=["search", "lookup"], terminal_tools=frozenset(["answer"]))
 errors = ErrorTracker(max_retries=3, max_tool_errors=2)
 
 # Inside your loop:
@@ -130,7 +130,7 @@ The middleware layer is the foundation. Both the proxy server and the standalone
 A forge workflow has four main pieces:
 
 - **Tools** — Python functions the LLM can call, each described by a `ToolSpec` with typed parameters.
-- **Workflow** — A named bundle of tools, with optional `required_steps` (tools the LLM *must* call) and a `terminal_tool` (the tool that ends the workflow).
+- **Workflow** — A named bundle of tools, with optional `required_steps` (tools the LLM *must* call) and a `terminal_tool` (the tool or tools that end the workflow — accepts `str` or `list[str]`).
 - **Client** — An LLM backend adapter (`OllamaClient`, `LlamafileClient`, `AnthropicClient`).
 - **Runner** — `WorkflowRunner` drives the agentic loop: send messages, parse tool calls, execute tools, enforce guardrails, manage compaction.
 
@@ -305,10 +305,76 @@ Forge's guardrail stack runs automatically. Each layer can be independently disa
 | Guardrail | What it does |
 |-----------|-------------|
 | **Step enforcement** | Verifies required tools were called before the terminal tool fires |
+| **Prerequisites** | Enforces conditional tool dependencies (e.g. must read before edit) |
 | **Retry nudges** | Prompts the LLM to try again when a tool call fails validation |
 | **Rescue loops** | Recovers malformed tool calls from the LLM's text output |
 | **Error recovery** | Re-prompts after tool execution errors instead of crashing |
 | **Compaction** | Prevents context overflow in long conversations |
 
 The eval harness measures each guardrail's contribution — see [EVAL_GUIDE.md](EVAL_GUIDE.md) for ablation results.
+
+---
+
+## Tool Prerequisites
+
+Tools can declare conditional dependencies — "if you call this tool, you must have called tool X first." This is enforced at runtime via nudge-and-retry, the same pattern as step enforcement.
+
+```python
+ToolDef(
+    spec=edit_spec,
+    callable=edit_file,
+    # Name-only: any prior call to read_file satisfies it
+    prerequisites=["read_file"],
+)
+
+ToolDef(
+    spec=edit_spec,
+    callable=edit_file,
+    # Arg-matched: must have called read_file with the same path
+    prerequisites=[{"tool": "read_file", "match_arg": "path"}],
+)
+```
+
+If the model calls a tool without satisfying its prerequisites, the runner blocks the batch, emits a `PREREQUISITE_NUDGE`, and the model retries. After `max_prereq_violations` (default 2) consecutive violations, `PrerequisiteError` is raised.
+
+Prerequisites are not included in the tool schema — the model discovers constraints via nudge, same as step enforcement.
+
+---
+
+## Multiple Terminal Tools
+
+Workflows can have multiple valid exit points. Pass a list to `terminal_tool`:
+
+```python
+workflow = Workflow(
+    ...
+    terminal_tool=["set_ac", "no_action"],  # either can end the workflow
+)
+```
+
+Internally normalized to a `frozenset` for O(1) membership checks. A single string is still accepted and works as before.
+
+---
+
+## Cancellation
+
+`WorkflowRunner.run()` accepts an optional `cancel_event` parameter for cooperative cancellation:
+
+```python
+import asyncio
+
+cancel = asyncio.Event()
+
+# In another coroutine or callback:
+cancel.set()
+
+try:
+    result = await runner.run(workflow, "task", cancel_event=cancel)
+except WorkflowCancelledError as e:
+    print(f"Cancelled at iteration {e.iteration}")
+    print(f"Completed steps: {e.completed_steps}")
+    print(f"Messages so far: {len(e.messages)}")
+```
+
+The runner checks the event once per iteration, before the inference call. This is cooperative — if the model is mid-inference, the runner waits for it to finish before checking. The `WorkflowCancelledError` includes the full conversation state for the caller to resume, discard, or log.
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -39,6 +39,8 @@ flowchart TD
 
     subgraph Loop["Main Loop (up to max_iterations)"]
         direction TB
+        CANCEL{"cancel_event<br/>set?"}
+        CANCELLED["Raise WorkflowCancelledError<br/>(messages, completed_steps, iteration)"]
         COMPACT["3a. ContextManager.maybe_compact()"]
         SEND["3b. Fold REASONING into next TOOL_CALL content,<br/>serialize & send to LLM (stream or batch)"]
         CHECK{"list[ToolCall] or<br/>TextResponse?"}
@@ -57,6 +59,9 @@ flowchart TD
             TERMINAL{"StepEnforcer.check():<br/>premature terminal?"}
             STEP_NUDGE["Emit TOOL_CALL + escalating step_nudge<br/>(tier 1/2/3)"]
             STEP_FAIL["Raise StepEnforcementError<br/>(premature_exhausted)"]
+            PREREQ{"StepEnforcer.<br/>check_prerequisites()?"}
+            PREREQ_NUDGE["Emit TOOL_CALL + prerequisite_nudge<br/>→ next iteration"]
+            PREREQ_FAIL["Raise PrerequisiteError<br/>(prereq_exhausted)"]
             EMIT["Emit REASONING (if present)<br/>+ TOOL_CALL message"]
             EXEC_BATCH["Execute ALL tools in batch"]
             TOOL_ERROR{"Exception type?"}
@@ -68,6 +73,8 @@ flowchart TD
             RECORD["StepEnforcer.record() per success<br/>reset_premature(), reset_errors()<br/>→ next iteration"]
         end
 
+        CANCEL -- "yes" --> CANCELLED
+        CANCEL -- "no" --> COMPACT
         COMPACT --> SEND --> CHECK
         CHECK -- "any response" --> VALIDATE
         VALIDATE --> RESCUED
@@ -78,8 +85,11 @@ flowchart TD
         RETRY_COUNT -- "yes" --> FAIL_RETRY
 
         TERMINAL -- "needs_nudge" --> STEP_NUDGE
-        TERMINAL -- "no premature" --> EMIT
+        TERMINAL -- "no premature" --> PREREQ
         STEP_NUDGE -- "premature_exhausted" --> STEP_FAIL
+        PREREQ -- "needs_nudge" --> PREREQ_NUDGE
+        PREREQ -- "satisfied" --> EMIT
+        PREREQ_NUDGE -- "prereq_exhausted" --> PREREQ_FAIL
 
         EMIT --> EXEC_BATCH
         EXEC_BATCH --> TOOL_ERROR
@@ -91,7 +101,7 @@ flowchart TD
         BATCH_DONE -- "no" --> RECORD
     end
 
-    Init --> Loop
+    Init --> CANCEL
 ```
 
 ---
@@ -148,6 +158,7 @@ Messages are tagged with `MessageType` metadata that determines their compaction
 | `reasoning` | assistant | Thinking models | Preserved through P2, dropped P3 |
 | `text_response` | assistant | Failed tool call attempt | Preserved through P2, dropped P3 |
 | `step_nudge` | user | Runner step enforcement | Dropped P1 |
+| `prerequisite_nudge` | user | Runner prereq enforcement | Dropped P1 |
 | `retry_nudge` | user | Runner retry logic | Dropped P1 |
 | `summary` | system | Compaction output | Never cut |
 
@@ -162,20 +173,20 @@ flowchart TD
     TRIGGER["Token estimate > budget × 0.75"]
 
     subgraph P1["Phase 1: Light"]
-        P1A["Drop all step_nudge, retry_nudge"]
+        P1A["Drop all step_nudge, prerequisite_nudge, retry_nudge"]
         P1B["Truncate old tool_results<br/>to ~200 chars"]
         P1A --> P1B
     end
 
     subgraph P2["Phase 2: Moderate"]
-        P2A["Drop step_nudge, retry_nudge"]
+        P2A["Drop step_nudge, prerequisite_nudge, retry_nudge"]
         P2B["Drop old tool_results entirely"]
         P2C["Reasoning + text_response PRESERVED"]
         P2A --> P2B --> P2C
     end
 
     subgraph P3["Phase 3: Emergency"]
-        P3A["Drop step_nudge, retry_nudge"]
+        P3A["Drop step_nudge, prerequisite_nudge, retry_nudge"]
         P3B["Drop old tool_results"]
         P3C["Drop reasoning"]
         P3D["Drop text_response"]
@@ -417,12 +428,14 @@ Workflow
 ├── description: str
 ├── tools: dict[str, ToolDef]          # keyed by tool name
 ├── required_steps: list[str]          # must be called before terminal
-├── terminal_tool: str                 # ends the workflow
+├── terminal_tool: str | list[str]     # tool(s) that end the workflow
+├── terminal_tools: frozenset[str]     # normalized (init=False)
 └── system_prompt_template: str        # may contain {placeholders}
 
 ToolDef
 ├── spec: ToolSpec
-└── callable: Callable[..., Any]
+├── callable: Callable[..., Any]
+└── prerequisites: list[str | dict]   # conditional dependencies (default [])
 
 ToolSpec
 ├── name: str

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -53,6 +53,7 @@ from forge.errors import (
     ToolCallError,
     ToolExecutionError,
     ToolResolutionError,
+    WorkflowCancelledError,
 )
 
 __all__ = [
@@ -132,4 +133,5 @@ __all__ = [
     "ToolCallError",
     "ToolExecutionError",
     "ToolResolutionError",
+    "WorkflowCancelledError",
 ]

--- a/src/forge/core/runner.py
+++ b/src/forge/core/runner.py
@@ -12,7 +12,7 @@ from forge.context.manager import ContextManager
 from forge.core.inference import _NUDGE_KIND_TO_TYPE, _build_tool_call_infos, run_inference
 from forge.core.messages import Message, MessageMeta, MessageRole, MessageType, ToolCallInfo
 from forge.core.workflow import ToolCall, TextResponse, Workflow, ToolSpec
-from forge.errors import MaxIterationsError, PrerequisiteError, StepEnforcementError, ToolCallError, ToolExecutionError, ToolResolutionError
+from forge.errors import MaxIterationsError, PrerequisiteError, StepEnforcementError, ToolCallError, ToolExecutionError, ToolResolutionError, WorkflowCancelledError
 from forge.guardrails import ErrorTracker, ResponseValidator, StepEnforcer
 
 
@@ -78,6 +78,7 @@ class WorkflowRunner:
         user_message: str,
         prompt_vars: dict[str, str] | None = None,
         initial_messages: list[Message] | None = None,
+        cancel_event: asyncio.Event | None = None,
     ) -> Any:
         """Execute the workflow and return the terminal tool's result.
 
@@ -91,12 +92,16 @@ class WorkflowRunner:
                 created during this run, not the replayed history. The caller
                 must include the system prompt and new user message in the
                 seed.
+            cancel_event: If provided and set, the runner will raise
+                WorkflowCancelledError at the start of the next iteration.
+                Checked once per loop, before the inference call.
 
         Raises:
             MaxIterationsError: If max_iterations exceeded without terminal tool.
             ToolCallError: If max_retries_per_step exhausted on a single step.
             ToolExecutionError: If a tool callable raised and the model failed
                 to self-correct after max_tool_errors consecutive attempts.
+            WorkflowCancelledError: If cancel_event was set during execution.
         """
         # Step 1 — Build initial messages
         if initial_messages is not None:
@@ -142,6 +147,14 @@ class WorkflowRunner:
         iteration = 0
 
         while iteration < self.max_iterations:
+            # 3.0 — Check for cancellation
+            if cancel_event is not None and cancel_event.is_set():
+                raise WorkflowCancelledError(
+                    messages=messages,
+                    completed_steps=step_enforcer.completed_steps,
+                    iteration=iteration,
+                )
+
             # 3a — Inference: compact, fold, serialize, send, validate, retry
             result = await run_inference(
                 messages=messages,

--- a/src/forge/errors.py
+++ b/src/forge/errors.py
@@ -52,6 +52,24 @@ class ToolResolutionError(Exception):
         self.tool_name = tool_name
 
 
+class WorkflowCancelledError(ForgeError):
+    """Workflow was cancelled via cancel_event before completion."""
+
+    def __init__(
+        self,
+        messages: list,
+        completed_steps: dict[str, None],
+        iteration: int,
+    ):
+        super().__init__(
+            f"Workflow cancelled at iteration {iteration}. "
+            f"Completed steps: {completed_steps}"
+        )
+        self.messages = messages
+        self.completed_steps = completed_steps
+        self.iteration = iteration
+
+
 class MaxIterationsError(ForgeError):
     """Workflow exceeded max_iterations without calling the terminal tool."""
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from unittest.mock import MagicMock
 
@@ -21,7 +22,7 @@ from forge.core.workflow import (
     ToolSpec,
     Workflow,
 )
-from forge.errors import MaxIterationsError, PrerequisiteError, StepEnforcementError, StreamError, ToolCallError, ToolExecutionError, ToolResolutionError
+from forge.errors import MaxIterationsError, PrerequisiteError, StepEnforcementError, StreamError, ToolCallError, ToolExecutionError, ToolResolutionError, WorkflowCancelledError
 
 
 class EmptyParams(BaseModel):
@@ -1949,3 +1950,110 @@ class TestMultipleTerminalTools:
 
         step_nudges = [m for m in collected if m.metadata.type == MessageType.STEP_NUDGE]
         assert len(step_nudges) == 2  # both premature attempts nudged
+
+
+# ── Cancellation ─────────────────────────────────────────────────
+
+
+class TestCancellation:
+    """WorkflowRunner cancellation via cancel_event."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_before_start(self):
+        """Cancel event set before run() starts raises immediately."""
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        wf = _make_workflow()
+        runner = _make_runner(client)
+        cancel = asyncio.Event()
+        cancel.set()
+
+        with pytest.raises(WorkflowCancelledError) as exc_info:
+            await runner.run(wf, "go", prompt_vars={"role": "dev"}, cancel_event=cancel)
+
+        assert exc_info.value.iteration == 0
+        assert exc_info.value.completed_steps == {}
+
+    @pytest.mark.asyncio
+    async def test_cancel_mid_workflow(self):
+        """Cancel event set after first tool fires on next iteration."""
+        cancel = asyncio.Event()
+
+        def cancel_after_fetch(**kwargs):
+            cancel.set()
+            return "fetch_result"
+
+        tools = {
+            "fetch": _make_tool("fetch", fn=cancel_after_fetch),
+            "submit": _make_tool("submit"),
+        }
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        wf = _make_workflow(tools=tools, required_steps=["fetch"])
+        runner = _make_runner(client)
+
+        with pytest.raises(WorkflowCancelledError) as exc_info:
+            await runner.run(wf, "go", prompt_vars={"role": "dev"}, cancel_event=cancel)
+
+        assert "fetch" in exc_info.value.completed_steps
+        assert exc_info.value.iteration == 1
+
+    @pytest.mark.asyncio
+    async def test_cancel_preserves_messages(self):
+        """Cancelled error includes conversation history."""
+        cancel = asyncio.Event()
+
+        def cancel_after_fetch(**kwargs):
+            cancel.set()
+            return "fetch_result"
+
+        tools = {
+            "fetch": _make_tool("fetch", fn=cancel_after_fetch),
+            "submit": _make_tool("submit"),
+        }
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        wf = _make_workflow(tools=tools, required_steps=["fetch"])
+        runner = _make_runner(client)
+
+        with pytest.raises(WorkflowCancelledError) as exc_info:
+            await runner.run(wf, "go", prompt_vars={"role": "dev"}, cancel_event=cancel)
+
+        messages = exc_info.value.messages
+        assert len(messages) > 0
+        # Should have system prompt, user input, tool call, tool result
+        types = [m.metadata.type for m in messages]
+        assert MessageType.SYSTEM_PROMPT in types
+        assert MessageType.USER_INPUT in types
+        assert MessageType.TOOL_RESULT in types
+
+    @pytest.mark.asyncio
+    async def test_no_cancel_event_runs_normally(self):
+        """None cancel_event has no effect."""
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        wf = _make_workflow()
+        runner = _make_runner(client)
+        result = await runner.run(wf, "go", prompt_vars={"role": "dev"}, cancel_event=None)
+        assert result == "submit_result"
+
+    @pytest.mark.asyncio
+    async def test_unset_cancel_event_runs_normally(self):
+        """Cancel event that is never set doesn't interfere."""
+        cancel = asyncio.Event()  # never set
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        wf = _make_workflow()
+        runner = _make_runner(client)
+        result = await runner.run(wf, "go", prompt_vars={"role": "dev"}, cancel_event=cancel)
+        assert result == "submit_result"


### PR DESCRIPTION
## Summary

Adds cooperative workflow cancellation via `asyncio.Event` and updates all three doc files (ARCHITECTURE, WORKFLOW, USER_GUIDE) to reflect prerequisites, multiple terminal tools, and cancellation.

## Changes

**Cancellation:**
- `WorkflowRunner.run()` accepts optional `cancel_event: asyncio.Event`
- Checked once per iteration at top of loop, before inference call
- Raises `WorkflowCancelledError` with `messages`, `completed_steps`, `iteration`
- 5 new tests: cancel before start, cancel mid-workflow, preserves messages, None event, unset event

**Documentation (catches up #35 and #36 too):**
- `ARCHITECTURE.md` — ToolDef prerequisites, StepEnforcer prereqs + terminal_tools, Workflow terminal_tool type + validation, PrerequisiteError + WorkflowCancelledError, data flow pseudocode (cancel check, prereq check, args on record, prereq reset)
- `WORKFLOW.md` — Data types (ToolDef.prerequisites, Workflow.terminal_tools), message types table (prerequisite_nudge), flowchart (cancel + prereq nodes), compaction phases (prerequisite_nudge in all three)
- `USER_GUIDE.md` — Concepts (terminal_tool accepts list), middleware example (terminal_tools frozenset), guardrails table (prerequisites), new sections for tool prerequisites, multiple terminal tools, and cancellation

Closes #37 .

## Test plan

- [x] 720 unit tests passing (5 new, 0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
