### PR TITLE
Document long-running session advisory for filtering transient messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ async def main():
 asyncio.run(main())
 ```
 
-For multi-step workflows, multi-turn conversations, and backend auto-management, see the [User Guide](docs/USER_GUIDE.md).
+For multi-step workflows, multi-turn conversations, and backend auto-management, see the [User Guide](docs/USER_GUIDE.md). If you're building a long-running session (CLI, chat server, voice assistant), see the [long-running session advisory](docs/USER_GUIDE.md#long-running-sessions-filtering-transient-messages) for important guidance on filtering transient messages.
 
 ## Proxy Server
 
@@ -210,7 +210,7 @@ tests/
 
 ## Documentation
 
-- [User Guide](docs/USER_GUIDE.md) — Usage patterns, multi-turn, context management, guardrails
+- [User Guide](docs/USER_GUIDE.md) — Usage patterns, multi-turn, context management, guardrails, long-running session advisory
 - [Model Guide](docs/MODEL_GUIDE.md) — Which model and backend for your hardware
 - [Backend Setup](docs/BACKEND_SETUP.md) — Backend installation and server setup
 - [Eval Guide](docs/EVAL_GUIDE.md) — Eval harness CLI reference, batch eval, BFCL benchmark

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -259,6 +259,37 @@ await server.stop()
 
 The system prompt lives in `conversation` from turn 0 — it is not rebuilt or duplicated on subsequent turns. `StepEnforcer` and `tool_call_counter` reset each `run()` call since they are per-turn state.
 
+### Long-Running Sessions: Filtering Transient Messages
+
+`on_message` emits everything the runner creates during a turn, including transient retry artifacts — failed bare text responses, retry nudges, step nudges, and prerequisite nudges. This is by design: consumers get full visibility for logging and debugging.
+
+For long-running sessions where conversation history persists across turns, these transient messages accumulate. The model sees its own past failures and corrective nudges on every subsequent turn, polluting effective context and degrading coherence — especially on smaller models (8-14B).
+
+**Who's affected:** Any consumer that appends all `on_message` outputs to a persistent message list and reuses it via `initial_messages` on subsequent turns.
+
+**Not affected:** Single-shot workflows, eval scenarios, or consumers that rebuild the message list from scratch each turn.
+
+**Fix:** Filter transient message types before persisting. The metadata already tags these:
+
+```python
+from forge.core.messages import MessageType
+
+TRANSIENT_TYPES = {
+    MessageType.RETRY_NUDGE,
+    MessageType.STEP_NUDGE,
+    MessageType.PREREQUISITE_NUDGE,
+    MessageType.TEXT_RESPONSE,
+}
+
+def on_message(self, msg: Message) -> None:
+    if msg.metadata.type not in TRANSIENT_TYPES:
+        self.messages.append(msg)
+```
+
+`TEXT_RESPONSE` is included because in tool-calling workflows, bare text is always a failed attempt that triggered a retry — the successful response comes as a `TOOL_CALL`. Consumers where intentional text responses are valid (e.g., `trust_text_intent=True`) should keep `TEXT_RESPONSE` in their persist list.
+
+**Why not fix this in forge?** The runner's job is to emit everything — within a turn, retry nudges are useful (the model needs to see the nudge to self-correct). The distinction between "within a turn" and "across turns" is a consumer concern. Compaction handles context overflow but doesn't proactively clean up transient messages — it fires based on token budget pressure, not session hygiene.
+
 ---
 
 ## Choosing a Backend


### PR DESCRIPTION
## Summary

Documents the long-running session advisory — consumers persisting conversation history across turns should filter transient message types (retry nudges, step nudges, prerequisite nudges, text responses) to avoid context pollution on subsequent turns.

## Changes

- **USER_GUIDE.md** — New subsection under Multi-Turn Conversations: "Long-Running Sessions: Filtering Transient Messages." Includes affected/not-affected patterns, code example with `TRANSIENT_TYPES` filter, `TEXT_RESPONSE` caveat for `trust_text_intent=True`, and rationale for why this is a consumer concern.
- **README.md** — Updated User Guide description in docs list, added pointer to the advisory near the multi-turn quick start reference.

## Test plan

- [x] Documentation only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
