### PR TITLE
Fix FORGE_FAST double-divide with multi-slot and add kv_unified support

### DIFF
--- a/src/forge/server.py
+++ b/src/forge/server.py
@@ -65,6 +65,7 @@ class ServerManager:
         self._current_cache_type_k: str | None = None
         self._current_cache_type_v: str | None = None
         self._current_n_slots: int | None = None
+        self._current_kv_unified: bool = False
 
     # ── start / stop ────────────────────────────────────────────
 
@@ -78,11 +79,12 @@ class ServerManager:
         cache_type_k: str | None = None,
         cache_type_v: str | None = None,
         n_slots: int | None = None,
+        kv_unified: bool = False,
     ) -> None:
         """Start a llama-server/llamafile process.
 
         No-op if the same model + mode + ctx + extra_flags + cache types
-        + slots is already running.
+        + slots + kv_unified is already running.
         For ``backend="ollama"`` this is always a no-op.
 
         For ``backend="llamafile"``, the llamafile runtime binary is
@@ -101,6 +103,10 @@ class ServerManager:
                           (e.g. ``"q8_0"``, ``"q4_0"``).
             n_slots: Number of concurrent slots (each with its own KV
                      cache). Used for multi-agent architectures.
+            kv_unified: If True, use a single unified KV cache shared
+                        across all slots. Each slot can use up to the
+                        full context. Without this, context is hard-
+                        partitioned per slot.
         """
         if self._backend == "ollama":
             return
@@ -115,6 +121,7 @@ class ServerManager:
             and self._current_cache_type_k == cache_type_k
             and self._current_cache_type_v == cache_type_v
             and self._current_n_slots == n_slots
+            and self._current_kv_unified == kv_unified
         ):
             return
 
@@ -155,6 +162,8 @@ class ServerManager:
             cmd.extend(["--cache-type-v", cache_type_v])
         if n_slots is not None:
             cmd.extend(["--parallel", str(n_slots)])
+        if kv_unified:
+            cmd.append("--kv-unified")
 
         self._proc = subprocess.Popen(
             cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
@@ -168,6 +177,7 @@ class ServerManager:
         self._current_cache_type_k = cache_type_k
         self._current_cache_type_v = cache_type_v
         self._current_n_slots = n_slots
+        self._current_kv_unified = kv_unified
 
     async def stop(self) -> None:
         """Stop the current server / unload the Ollama model."""
@@ -192,6 +202,7 @@ class ServerManager:
             self._current_cache_type_k = None
             self._current_cache_type_v = None
             self._current_n_slots = None
+            self._current_kv_unified = False
             await asyncio.sleep(3)  # let VRAM clear
 
     # ── /props + context ────────────────────────────────────────
@@ -215,8 +226,13 @@ class ServerManager:
     async def get_server_context(self) -> int:
         """Read the actual n_ctx from the running server.
 
+        Note: Without ``--kv-unified``, llama-server's ``/props`` endpoint
+        reports **per-slot** context (``total_ctx / n_parallel``). With
+        ``--kv-unified``, it reports the full available context (each slot
+        can use the whole pool).
+
         Returns:
-            The context length.
+            The context length as reported by ``/props``.
 
         Raises:
             BudgetResolutionError: Server unreachable, returned an error,
@@ -266,7 +282,10 @@ class ServerManager:
                 return full // 2
             return full
 
-        # llamaserver / llamafile — all non-manual modes read /props
+        # llamaserver / llamafile — all non-manual modes read /props.
+        # With kv_unified, /props already reports the full available context
+        # (each slot can use the whole pool). Without it, /props reports the
+        # per-slot partition — which is the correct budget for compaction.
         return await self.get_server_context()
 
     async def start_with_budget(
@@ -280,6 +299,7 @@ class ServerManager:
         cache_type_k: str | None = None,
         cache_type_v: str | None = None,
         n_slots: int | None = None,
+        kv_unified: bool = False,
     ) -> int:
         """Start server with the specified budget mode and return the resolved budget.
 
@@ -291,6 +311,12 @@ class ServerManager:
 
         For Ollama: ignores gguf_path, doesn't start a process.
         Returns VRAM tier budget.
+
+        The returned budget accounts for slot configuration:
+        - Non-unified (default): per-slot context (what ContextManager
+          should use for compaction — the slot can only use this much).
+        - Unified (``kv_unified=True``): total context across all slots
+          (each slot can use up to the full amount).
 
         Args:
             model: Model name (Ollama-style canonical name).
@@ -304,6 +330,8 @@ class ServerManager:
             cache_type_v: KV cache quantization type for values
                           (e.g. ``"q8_0"``, ``"q4_0"``).
             n_slots: Number of concurrent slots.
+            kv_unified: If True, use a single unified KV cache shared
+                        across all slots.
 
         Returns:
             Resolved budget in tokens (ready for ContextManager).
@@ -324,16 +352,22 @@ class ServerManager:
             await self.start(
                 model, gguf_path, mode, extra_flags, ctx_override=None,
                 cache_type_k=cache_type_k, cache_type_v=cache_type_v,
-                n_slots=n_slots,
+                n_slots=n_slots, kv_unified=kv_unified,
             )
-            full_ctx = await self.get_server_context()
-            half_ctx = full_ctx // 2
+            # /props reports per-slot context (non-unified) or full context
+            # (unified). Either way, recover the total for -c math.
+            reported_ctx = await self.get_server_context()
+            if kv_unified or not n_slots or n_slots <= 1:
+                total_ctx = reported_ctx
+            else:
+                total_ctx = reported_ctx * n_slots
+            half_total = total_ctx // 2
 
-            # Phase 2: restart with half context
+            # Phase 2: restart with half total context
             await self.start(
-                model, gguf_path, mode, extra_flags, ctx_override=half_ctx,
+                model, gguf_path, mode, extra_flags, ctx_override=half_total,
                 cache_type_k=cache_type_k, cache_type_v=cache_type_v,
-                n_slots=n_slots,
+                n_slots=n_slots, kv_unified=kv_unified,
             )
             return await self.resolve_budget(budget_mode)
 
@@ -342,7 +376,7 @@ class ServerManager:
         await self.start(
             model, gguf_path, mode, extra_flags, ctx_override=ctx_override,
             cache_type_k=cache_type_k, cache_type_v=cache_type_v,
-            n_slots=n_slots,
+            n_slots=n_slots, kv_unified=kv_unified,
         )
         return await self.resolve_budget(budget_mode, manual_tokens)
 
@@ -412,6 +446,7 @@ async def setup_backend(
     cache_type_k: str | None = None,
     cache_type_v: str | None = None,
     n_slots: int | None = None,
+    kv_unified: bool = False,
     context_thresholds: list[float] | None = None,
     on_context_threshold: Callable[[int, int, float], str | None] | None = None,
 ) -> tuple[ServerManager, ContextManager]:
@@ -427,6 +462,11 @@ async def setup_backend(
     VRAM usage per token, effectively increasing usable context for the
     same GPU memory.  Common values: ``"q8_0"`` (~50% savings vs F16),
     ``"q4_0"`` (~75% savings).  Only applies to llama-server / llamafile.
+
+    When ``kv_unified=True``, all slots share a single KV cache pool.
+    Each slot can use up to the full context. The returned budget reflects
+    the total available context (not per-slot). Without it, context is
+    hard-partitioned per slot and the budget reflects the per-slot amount.
 
     Example usage::
 
@@ -456,6 +496,7 @@ async def setup_backend(
         cache_type_k=cache_type_k,
         cache_type_v=cache_type_v,
         n_slots=n_slots,
+        kv_unified=kv_unified,
     )
 
     # Ollama: wire num_ctx so every request uses the resolved budget

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -618,7 +618,7 @@ class TestStartWithBudget:
 
         mock_start.assert_called_once_with(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
-            cache_type_k=None, cache_type_v=None, n_slots=None,
+            cache_type_k=None, cache_type_v=None, n_slots=None, kv_unified=False,
         )
         assert result == 13568
 
@@ -637,7 +637,7 @@ class TestStartWithBudget:
 
         mock_start.assert_called_once_with(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=8000,
-            cache_type_k=None, cache_type_v=None, n_slots=None,
+            cache_type_k=None, cache_type_v=None, n_slots=None, kv_unified=False,
         )
         assert result == 8000
 
@@ -664,7 +664,7 @@ class TestStartWithBudget:
 
         mock_start.assert_called_once_with(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
-            cache_type_k=None, cache_type_v=None, n_slots=None,
+            cache_type_k=None, cache_type_v=None, n_slots=None, kv_unified=False,
         )
         assert result == 13568
 
@@ -690,12 +690,12 @@ class TestStartWithBudget:
         # Phase 1: start without -c
         mock_start.assert_any_call(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
-            cache_type_k=None, cache_type_v=None, n_slots=None,
+            cache_type_k=None, cache_type_v=None, n_slots=None, kv_unified=False,
         )
         # Phase 2: restart with half (13568 // 2 = 6784)
         mock_start.assert_any_call(
             "llama3", "/models/llama3.gguf", "native", None, ctx_override=6784,
-            cache_type_k=None, cache_type_v=None, n_slots=None,
+            cache_type_k=None, cache_type_v=None, n_slots=None, kv_unified=False,
         )
         assert result == 6784
 
@@ -735,6 +735,185 @@ class TestStartWithBudget:
                 budget_mode=BudgetMode.FORGE_FAST,
             )
         assert result == 2048  # half of 4096 tier for <24 GB
+
+    @pytest.mark.asyncio
+    async def test_forge_fast_multi_slot_no_double_divide(self) -> None:
+        """FORGE_FAST with 2 slots: recovers total before halving."""
+        sm = ServerManager(backend="llamaserver")
+        # /props reports 35K per-slot (from 70K total / 2 slots)
+        # After restart with -c 35K (half of 70K), /props reports 17.5K per-slot
+        with (
+            patch.object(sm, "start", new_callable=AsyncMock) as mock_start,
+            patch.object(
+                sm, "get_server_context", new_callable=AsyncMock,
+                side_effect=[35000, 17500],
+            ),
+        ):
+            result = await sm.start_with_budget(
+                "llama3", "/models/llama3.gguf",
+                budget_mode=BudgetMode.FORGE_FAST,
+                n_slots=2,
+            )
+
+        assert mock_start.call_count == 2
+        # Phase 2: -c should be 35000 (half of 70K total), NOT 17500 (half of per-slot)
+        mock_start.assert_any_call(
+            "llama3", "/models/llama3.gguf", "native", None, ctx_override=35000,
+            cache_type_k=None, cache_type_v=None, n_slots=2, kv_unified=False,
+        )
+        # Budget returned is per-slot (non-unified): 17500
+        assert result == 17500
+
+    @pytest.mark.asyncio
+    async def test_forge_fast_single_slot_unchanged(self) -> None:
+        """FORGE_FAST with 1 slot: same behavior as before."""
+        sm = ServerManager(backend="llamaserver")
+        with (
+            patch.object(sm, "start", new_callable=AsyncMock) as mock_start,
+            patch.object(
+                sm, "get_server_context", new_callable=AsyncMock,
+                side_effect=[13568, 6784],
+            ),
+        ):
+            result = await sm.start_with_budget(
+                "llama3", "/models/llama3.gguf",
+                budget_mode=BudgetMode.FORGE_FAST,
+                n_slots=1,
+            )
+
+        mock_start.assert_any_call(
+            "llama3", "/models/llama3.gguf", "native", None, ctx_override=6784,
+            cache_type_k=None, cache_type_v=None, n_slots=1, kv_unified=False,
+        )
+        assert result == 6784
+
+    @pytest.mark.asyncio
+    async def test_kv_unified_returns_full_budget(self) -> None:
+        """kv_unified=True with 2 slots: /props reports full context, budget matches."""
+        sm = ServerManager(backend="llamaserver")
+
+        async def fake_start(*args, **kwargs):
+            sm._current_kv_unified = kwargs.get("kv_unified", False)
+            sm._current_n_slots = kwargs.get("n_slots")
+
+        # With kv_unified, /props reports full context (not divided by slots)
+        with (
+            patch.object(sm, "start", side_effect=fake_start),
+            patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=70000),
+        ):
+            result = await sm.start_with_budget(
+                "llama3", "/models/llama3.gguf",
+                budget_mode=BudgetMode.FORGE_FULL,
+                n_slots=2,
+                kv_unified=True,
+            )
+
+        # Budget is what /props reports — no multiplication needed
+        assert result == 70000
+
+    @pytest.mark.asyncio
+    async def test_kv_unified_single_slot_no_change(self) -> None:
+        """kv_unified with 1 slot: same as without — /props reports full context."""
+        sm = ServerManager(backend="llamaserver")
+
+        with (
+            patch.object(sm, "start", new_callable=AsyncMock),
+            patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=70000),
+        ):
+            result = await sm.start_with_budget(
+                "llama3", "/models/llama3.gguf",
+                budget_mode=BudgetMode.FORGE_FULL,
+                n_slots=1,
+                kv_unified=True,
+            )
+
+        assert result == 70000
+
+    @pytest.mark.asyncio
+    async def test_non_unified_returns_per_slot_budget(self) -> None:
+        """Without kv_unified, 2 slots: budget is per-slot context."""
+        sm = ServerManager(backend="llamaserver")
+        with (
+            patch.object(sm, "start", new_callable=AsyncMock),
+            patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=35000),
+        ):
+            result = await sm.start_with_budget(
+                "llama3", "/models/llama3.gguf",
+                budget_mode=BudgetMode.FORGE_FULL,
+                n_slots=2,
+                kv_unified=False,
+            )
+
+        # Non-unified: per-slot is the correct budget
+        assert result == 35000
+
+    @pytest.mark.asyncio
+    async def test_kv_unified_injects_flag(self) -> None:
+        """kv_unified=True passes --kv-unified to start()."""
+        sm = ServerManager(backend="llamaserver")
+        with (
+            patch.object(sm, "start", new_callable=AsyncMock) as mock_start,
+            patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=35000),
+        ):
+            await sm.start_with_budget(
+                "llama3", "/models/llama3.gguf",
+                budget_mode=BudgetMode.FORGE_FULL,
+                n_slots=2,
+                kv_unified=True,
+            )
+
+        mock_start.assert_called_once_with(
+            "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
+            cache_type_k=None, cache_type_v=None, n_slots=2, kv_unified=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_forge_fast_kv_unified_multi_slot(self) -> None:
+        """FORGE_FAST + kv_unified + 2 slots: /props reports full context."""
+        sm = ServerManager(backend="llamaserver")
+
+        # With unified, /props reports full context (not per-slot).
+        # Phase 1: /props reports 70K (full). FORGE_FAST halves: -c 35K.
+        # Phase 2: /props reports 35K (full at new size). Budget = 35K.
+        with (
+            patch.object(sm, "start", new_callable=AsyncMock),
+            patch.object(
+                sm, "get_server_context", new_callable=AsyncMock,
+                side_effect=[70000, 35000],
+            ),
+        ):
+            result = await sm.start_with_budget(
+                "llama3", "/models/llama3.gguf",
+                budget_mode=BudgetMode.FORGE_FAST,
+                n_slots=2,
+                kv_unified=True,
+            )
+
+        assert result == 35000
+
+    @pytest.mark.asyncio
+    async def test_forge_fast_kv_unified_single_slot(self) -> None:
+        """FORGE_FAST + kv_unified + 1 slot: straightforward halving."""
+        sm = ServerManager(backend="llamaserver")
+        with (
+            patch.object(sm, "start", new_callable=AsyncMock) as mock_start,
+            patch.object(
+                sm, "get_server_context", new_callable=AsyncMock,
+                side_effect=[70000, 35000],
+            ),
+        ):
+            result = await sm.start_with_budget(
+                "llama3", "/models/llama3.gguf",
+                budget_mode=BudgetMode.FORGE_FAST,
+                n_slots=1,
+                kv_unified=True,
+            )
+
+        mock_start.assert_any_call(
+            "llama3", "/models/llama3.gguf", "native", None, ctx_override=35000,
+            cache_type_k=None, cache_type_v=None, n_slots=1, kv_unified=True,
+        )
+        assert result == 35000
 
 
 # ── setup_backend() ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes FORGE_FAST double-dividing context when `n_slots > 1` and adds `kv_unified` as a first-class parameter for unified KV cache support.

## Problem

FORGE_FAST reads per-slot context from `/props`, halves it, and passes it as `-c` (total context). But `-c` is total, and llama-server divides it by `n_parallel` again. With 2 slots and ~70K total: expected ~17K per slot, got ~9K.

Additionally, llama-server's `--kv-unified` flag (shared KV cache pool across slots) changes what `/props` reports — full context instead of per-slot — and forge had no way to account for this.

## Changes

**FORGE_FAST fix (`server.py`):**
- Recovers total context from per-slot (`reported * n_slots`) before halving
- With `kv_unified`, `/props` already reports full context, so no multiplication needed
- Single-slot behavior unchanged

**`kv_unified` as first-class param:**
- Same pattern as `cache_type_k`, `cache_type_v`, `n_slots` — first-class on `start()`, `start_with_budget()`, `setup_backend()`
- `start()` injects `--kv-unified` into the server command when True
- Stored as `self._current_kv_unified`, included in reuse check, reset in `stop()`
- `resolve_budget()` returns what `/props` reports — correct for both unified and non-unified because `/props` semantics change with the flag

**`get_server_context()` docstring** updated to document `/props` behavior with and without `--kv-unified`.

Closes #40 .

## Test plan

- [x] 728 unit tests passing (8 new, 0 regressions)
- [x] Live smoke test against Ministral 8B with Q8_0 KV cache:

```
  1. Single slot, FORGE_FULL:          68,608
  2. Two slots, FORGE_FULL:            35,072
  3. Two slots, FORGE_FAST:            17,664  (half of 2)
  4. Single slot, FORGE_FAST:          34,304  (half of 1)
  5. Two slots, FORGE_FULL, unified:   68,608  (same as 1)
```

All five configs return correct budgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
