### PR TITLE
Add custom retry nudge support to WorkflowRunner and Guardrails

### DIFF
--- a/src/forge/core/runner.py
+++ b/src/forge/core/runner.py
@@ -41,6 +41,7 @@ class WorkflowRunner:
         on_chunk: Callable[[StreamChunk], Awaitable[None]] | None = None,
         on_message: Callable[[Message], None] | None = None,
         rescue_enabled: bool = True,
+        retry_nudge: Callable[[str], str] | str | None = None,
     ):
         """
         Args:
@@ -61,6 +62,9 @@ class WorkflowRunner:
                 Does not affect runner behavior.
             rescue_enabled: If False, skip rescue_tool_call() — TextResponse
                 goes straight to retry nudge (or failure if retries=0).
+            retry_nudge: Custom nudge for bare text responses. Pass a string
+                for a static message, or a callable ``(raw_response) -> str``
+                for dynamic nudges. If None, uses the default.
         """
         self.client = client
         self.context_manager = context_manager
@@ -71,6 +75,10 @@ class WorkflowRunner:
         self.on_chunk = on_chunk
         self.on_message = on_message
         self.rescue_enabled = rescue_enabled
+        if isinstance(retry_nudge, str):
+            self._retry_nudge_fn: Callable[[str], str] | None = lambda _raw, _msg=retry_nudge: _msg
+        else:
+            self._retry_nudge_fn = retry_nudge
 
     async def run(
         self,
@@ -125,7 +133,10 @@ class WorkflowRunner:
 
         # Step 2 — Initialize guardrail middleware
         tool_names = list(workflow.tools.keys())
-        validator = ResponseValidator(tool_names, rescue_enabled=self.rescue_enabled)
+        validator = ResponseValidator(
+            tool_names, rescue_enabled=self.rescue_enabled,
+            retry_nudge_fn=self._retry_nudge_fn,
+        )
         tool_prerequisites = {
             name: td.prerequisites
             for name, td in workflow.tools.items()

--- a/src/forge/guardrails/guardrails.py
+++ b/src/forge/guardrails/guardrails.py
@@ -10,6 +10,7 @@ For granular control, use the individual components directly.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -66,6 +67,9 @@ class Guardrails:
             responses. Default True.
         max_premature_attempts: Premature terminal attempts before
             ``check()`` returns ``"fatal"``. Default 3.
+        retry_nudge: Custom nudge for bare text responses. Pass a callable
+            ``(raw_response) -> str`` for dynamic nudges. If None, uses
+            the default.
     """
 
     def __init__(
@@ -77,10 +81,12 @@ class Guardrails:
         max_tool_errors: int = 2,
         rescue_enabled: bool = True,
         max_premature_attempts: int = 3,
+        retry_nudge: Callable[[str], str] | None = None,
     ) -> None:
         self._validator = ResponseValidator(
             tool_names=tool_names,
             rescue_enabled=rescue_enabled,
+            retry_nudge_fn=retry_nudge,
         )
         if isinstance(terminal_tool, str):
             terminal_tools = frozenset([terminal_tool])

--- a/src/forge/guardrails/response_validator.py
+++ b/src/forge/guardrails/response_validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall
@@ -35,11 +36,20 @@ class ResponseValidator:
         tool_names: Valid tool names for this workflow.
         rescue_enabled: If True, attempt to parse tool calls from TextResponse
             before generating a retry nudge.
+        retry_nudge_fn: Custom nudge function for bare text responses. Takes
+            the raw response text and returns the nudge message. If None,
+            uses the default retry nudge from ``forge.prompts.nudges``.
     """
 
-    def __init__(self, tool_names: list[str], rescue_enabled: bool = True) -> None:
+    def __init__(
+        self,
+        tool_names: list[str],
+        rescue_enabled: bool = True,
+        retry_nudge_fn: Callable[[str], str] | None = None,
+    ) -> None:
         self.tool_names = tool_names
         self.rescue_enabled = rescue_enabled
+        self._retry_nudge_fn = retry_nudge_fn or retry_nudge
 
     def validate(
         self, response: LLMResponse, trust_text_intent: bool = False,
@@ -72,7 +82,7 @@ class ResponseValidator:
                 tool_calls=None,
                 nudge=Nudge(
                     role="user",
-                    content=retry_nudge(response.content),
+                    content=self._retry_nudge_fn(response.content),
                     kind="retry",
                 ),
                 needs_retry=True,

--- a/tests/unit/test_guardrails.py
+++ b/tests/unit/test_guardrails.py
@@ -182,3 +182,30 @@ class TestImports:
         from forge import CheckResult, Guardrails
         assert CheckResult is not None
         assert Guardrails is not None
+
+
+# ── Custom retry nudge ───────────────────────────────────────
+
+
+class TestCustomRetryNudge:
+    def test_default_nudge_used_when_none(self):
+        g = make_guardrails()
+        result = g.check(TextResponse(content="bare text"))
+        assert result.action == "retry"
+        assert "tool call" in result.nudge.content.lower()
+
+    def test_custom_nudge_callable(self):
+        custom = lambda raw: f"Wrap this in respond: {raw}"
+        g = make_guardrails(retry_nudge=custom, rescue_enabled=False)
+        result = g.check(TextResponse(content="hello world"))
+        assert result.action == "retry"
+        assert "Wrap this in respond: hello world" == result.nudge.content
+
+    def test_custom_nudge_receives_raw_response(self):
+        captured = []
+        def nudge_fn(raw):
+            captured.append(raw)
+            return "try again"
+        g = make_guardrails(retry_nudge=nudge_fn, rescue_enabled=False)
+        g.check(TextResponse(content="my bare text"))
+        assert captured == ["my bare text"]

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -2057,3 +2057,81 @@ class TestCancellation:
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "dev"}, cancel_event=cancel)
         assert result == "submit_result"
+
+
+# ── Custom retry nudge ───────────────────────────────────────────
+
+
+class TestCustomRetryNudge:
+    """WorkflowRunner custom retry nudge support."""
+
+    @pytest.mark.asyncio
+    async def test_custom_nudge_string(self):
+        """String retry_nudge is used as static message."""
+        collected = []
+        client = MockClient([
+            TextResponse(content="bare text"),
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        wf = _make_workflow()
+        runner = _make_runner(client)
+        runner.on_message = collected.append
+        runner._retry_nudge_fn = lambda _raw: "Wrap in respond tool."
+        result = await runner.run(wf, "go", prompt_vars={"role": "dev"})
+
+        nudges = [m for m in collected if m.metadata.type == MessageType.RETRY_NUDGE]
+        assert len(nudges) == 1
+        assert nudges[0].content == "Wrap in respond tool."
+
+    @pytest.mark.asyncio
+    async def test_custom_nudge_callable(self):
+        """Callable retry_nudge receives raw response."""
+        collected = []
+        client = MockClient([
+            TextResponse(content="my response"),
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        wf = _make_workflow()
+        ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
+        runner = WorkflowRunner(
+            client=client, context_manager=ctx,
+            retry_nudge=lambda raw: f"Please use a tool. You said: {raw[:10]}",
+        )
+        runner.on_message = collected.append
+        result = await runner.run(wf, "go", prompt_vars={"role": "dev"})
+
+        nudges = [m for m in collected if m.metadata.type == MessageType.RETRY_NUDGE]
+        assert len(nudges) == 1
+        assert "Please use a tool. You said: my respons" in nudges[0].content
+
+    @pytest.mark.asyncio
+    async def test_string_retry_nudge_constructor(self):
+        """String passed to constructor is wrapped into callable."""
+        ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
+        runner = WorkflowRunner(
+            client=MockClient([]),
+            context_manager=ctx,
+            retry_nudge="Use the respond tool.",
+        )
+        assert runner._retry_nudge_fn is not None
+        assert runner._retry_nudge_fn("anything") == "Use the respond tool."
+
+    @pytest.mark.asyncio
+    async def test_none_retry_nudge_uses_default(self):
+        """None retry_nudge falls back to default."""
+        collected = []
+        client = MockClient([
+            TextResponse(content="bare text"),
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        wf = _make_workflow()
+        runner = _make_runner(client)
+        runner.on_message = collected.append
+        await runner.run(wf, "go", prompt_vars={"role": "dev"})
+
+        nudges = [m for m in collected if m.metadata.type == MessageType.RETRY_NUDGE]
+        assert len(nudges) == 1
+        assert "tool call" in nudges[0].content.lower()


### PR DESCRIPTION
## Summary

Adds custom retry nudge support to `WorkflowRunner` and `Guardrails`. Consumers can override the nudge wording for bare text responses without affecting the default behavior.

## Problem

The default retry nudge ("Your previous response was not a valid tool call...") implies the model's content was wrong, not just the format. For conversational workflows where `respond` is the terminal tool, the model often generates a good response as bare text, gets nudged, and interprets it as a behavioral correction — pivoting from casual conversation to rigid tool-focused behavior. Especially visible with 8B models.

## Changes

- **`ResponseValidator`** — accepts `retry_nudge_fn: Callable[[str], str] | None`. When set, uses it instead of the default. Single point of change.
- **`WorkflowRunner`** — accepts `retry_nudge: Callable[[str], str] | str | None`. String is wrapped into a callable for convenience. Passes through to `ResponseValidator`.
- **`Guardrails`** — accepts `retry_nudge: Callable[[str], str] | None`. Passes through to its internal `ResponseValidator`.
- Proxy left unchanged (default nudge is appropriate for transparent proxy use).

## Usage

```python
# Static string
runner = WorkflowRunner(
    client=client, context_manager=ctx,
    retry_nudge="Wrap your response in the respond tool.",
)

# Dynamic callable
runner = WorkflowRunner(
    client=client, context_manager=ctx,
    retry_nudge=lambda raw: f"Call respond(message='{raw[:50]}...')",
)
```

Closes #42 .

## Test plan

- [x] 735 unit tests passing (7 new, 0 regressions)
- [x] Tests cover: string constructor wrapping, callable receives raw response, None falls back to default, Guardrails facade passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)
