### PR TITLE
Add SlotWorker for priority-queued shared slot access (v0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A reliability layer for self-hosted LLM tool-calling. Forge takes an 8B model fr
 
 Three ways to use it:
 
-- **WorkflowRunner** — Define tools, pick a backend, run structured agent loops. Forge manages the full lifecycle: system prompts, tool execution, context compaction, and guardrails. Best when you're building on forge directly.
+- **WorkflowRunner** — Define tools, pick a backend, run structured agent loops. Forge manages the full lifecycle: system prompts, tool execution, context compaction, and guardrails. **SlotWorker** adds priority-queued access to a shared inference slot with auto-preemption — for multi-agent architectures where specialist workflows share a GPU slot. Best when you're building on forge directly.
 
 - **Guardrails middleware** — Use forge's reliability stack ([composable middleware](examples/foreign_loop.py)) inside your own orchestration loop. You control the loop; forge validates responses, rescues malformed tool calls, and enforces required steps.
 
@@ -170,6 +170,7 @@ src/forge/
     workflow.py        # ToolSpec, ToolDef, ToolCall, TextResponse, Workflow
     inference.py       # run_inference() — shared front half (compact, fold, validate, retry)
     runner.py          # WorkflowRunner — the agentic loop
+    slot_worker.py     # SlotWorker — priority-queued slot access
     steps.py           # StepTracker
   guardrails/
     nudge.py           # Nudge dataclass
@@ -210,7 +211,7 @@ tests/
 
 ## Documentation
 
-- [User Guide](docs/USER_GUIDE.md) — Usage patterns, multi-turn, context management, guardrails, long-running session advisory
+- [User Guide](docs/USER_GUIDE.md) — Usage patterns, multi-turn, context management, guardrails, slot worker, long-running session advisory
 - [Model Guide](docs/MODEL_GUIDE.md) — Which model and backend for your hardware
 - [Backend Setup](docs/BACKEND_SETUP.md) — Backend installation and server setup
 - [Eval Guide](docs/EVAL_GUIDE.md) — Eval harness CLI reference, batch eval, BFCL benchmark

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -409,3 +409,78 @@ except WorkflowCancelledError as e:
 
 The runner checks the event once per iteration, before the inference call. This is cooperative — if the model is mid-inference, the runner waits for it to finish before checking. The `WorkflowCancelledError` includes the full conversation state for the caller to resume, discard, or log.
 
+---
+
+## SlotWorker — Shared Slot Access
+
+`SlotWorker` serializes workflow execution on a single inference slot with priority-based queuing and auto-preemption. Use it when multiple callers need to share a slot — for example, a home assistant's specialist workflows (calendar, AC management, escalation) all sharing slot 1 while the main conversation runs on slot 0.
+
+### Basic usage (FIFO)
+
+```python
+from forge import SlotWorker, WorkflowRunner
+
+# One runner pinned to a slot, one worker wrapping it
+runner = WorkflowRunner(client=client, context_manager=ctx)
+worker = SlotWorker(runner)
+await worker.start()
+
+# From anywhere — multiple concurrent callers are serialized
+result = await worker.submit(workflow, "do the thing")
+```
+
+### Priority
+
+Priority is an `int` — lower values run first. Forge imposes no semantics; the consumer defines what the levels mean:
+
+```python
+# Consumer defines their own levels
+USER = 0
+ESCALATED = 1
+ROUTINE = 2
+
+# User-initiated request — highest priority
+result = await worker.submit(calendar_wf, "what's on my schedule?", priority=USER)
+
+# Background cron — lowest priority, can be preempted
+result = await worker.submit(ac_wf, "check temperature", priority=ROUTINE)
+```
+
+Without an explicit priority, all tasks default to 0 (pure FIFO).
+
+### Auto-preemption
+
+If a higher-priority task is submitted while a lower-priority task is running, the running task is automatically cancelled and the higher-priority task takes over. The cancelled task's `submit()` raises `WorkflowCancelledError`.
+
+```python
+# Routine AC check is running (priority=2)...
+# User asks about calendar (priority=0) — AC check is auto-cancelled
+result = await worker.submit(calendar_wf, "what's next?", priority=0)
+```
+
+You can also cancel manually:
+
+```python
+worker.cancel_current()  # cancels whatever is running
+```
+
+### Multi-slot architecture
+
+For multi-slot setups (e.g., with `--kv-unified`), create one `SlotWorker` per shared slot. The main conversation slot typically doesn't need a worker — it's dedicated to one persistent session.
+
+```python
+# Slot 0: main conversation (no worker needed — dedicated)
+main_client = LlamafileClient(model="...", slot_id=0)
+main_runner = WorkflowRunner(client=main_client, context_manager=ctx)
+
+# Slot 1: shared specialist slot (needs a worker)
+service_client = LlamafileClient(model="...", slot_id=1)
+service_runner = WorkflowRunner(client=service_client, context_manager=ctx)
+service_worker = SlotWorker(service_runner)
+await service_worker.start()
+
+# Tools route through the worker
+async def query_calendar(**kwargs):
+    return await service_worker.submit(calendar_wf, kwargs["query"], priority=0)
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forge"
-version = "0.3.0"
+version = "0.4.0"
 description = "A reusable framework for self-hosted LLM tool-calling and multi-step agentic workflows."
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -12,6 +12,7 @@ from forge.core.workflow import (
 from forge.core.steps import StepTracker
 from forge.core.inference import InferenceResult, fold_and_serialize, run_inference
 from forge.core.runner import WorkflowRunner
+from forge.core.slot_worker import SlotWorker
 from forge.clients.base import ChunkType, LLMClient, StreamChunk, TokenUsage
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
@@ -78,6 +79,8 @@ __all__ = [
     "run_inference",
     # Runner
     "WorkflowRunner",
+    # Slot worker
+    "SlotWorker",
     # Client
     "ChunkType",
     "LLMClient",

--- a/src/forge/core/slot_worker.py
+++ b/src/forge/core/slot_worker.py
@@ -1,0 +1,142 @@
+"""SlotWorker — serialized access to a WorkflowRunner with priority queuing."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from forge.core.workflow import Workflow
+from forge.core.messages import Message
+from forge.core.runner import WorkflowRunner
+
+
+class SlotWorker:
+    """Serializes workflow execution on a single inference slot.
+
+    Wraps a WorkflowRunner with a priority queue. Each ``submit()`` call
+    waits for its turn, runs to completion, and returns the result.
+    Cancel events are wired automatically.
+
+    Priority is an int — lower values run first. The consumer defines
+    what the levels mean (forge imposes no semantics). Default priority
+    is 0 for all tasks (pure FIFO).
+
+    Auto-preemption: if a submitted task has strictly higher priority
+    (lower int) than the currently running task, the running task is
+    cancelled via ``cancel_event`` and the higher-priority task takes over.
+
+    Args:
+        runner: The WorkflowRunner to serialize access to.
+    """
+
+    def __init__(self, runner: WorkflowRunner) -> None:
+        self.runner = runner
+        self._queue: asyncio.PriorityQueue[
+            tuple[int, int, Workflow, str, dict[str, str] | None, asyncio.Future[Any]]
+        ] = asyncio.PriorityQueue()
+        self._counter = 0
+        self._cancel_event: asyncio.Event | None = None
+        self._current_priority: int | None = None
+        self._worker_task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start the worker loop."""
+        if self._worker_task is not None:
+            return
+        self._worker_task = asyncio.create_task(self._worker())
+
+    async def stop(self) -> None:
+        """Stop the worker loop. Pending tasks receive CancelledError."""
+        if self._worker_task is not None:
+            self._worker_task.cancel()
+            try:
+                await self._worker_task
+            except asyncio.CancelledError:
+                pass
+            self._worker_task = None
+
+    async def submit(
+        self,
+        workflow: Workflow,
+        user_message: str,
+        priority: int = 0,
+        prompt_vars: dict[str, str] | None = None,
+    ) -> Any:
+        """Submit a workflow for execution and wait for the result.
+
+        Args:
+            workflow: The workflow to execute.
+            user_message: The user's input message.
+            priority: Execution priority (lower = higher priority).
+                Default 0. Consumer defines the semantics.
+            prompt_vars: Variables for the system prompt template.
+
+        Returns:
+            The terminal tool's result.
+
+        Raises:
+            WorkflowCancelledError: If the task was preempted by a
+                higher-priority submission.
+            Any exception raised by the WorkflowRunner.
+        """
+        future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+        self._counter += 1
+        await self._queue.put(
+            (priority, self._counter, workflow, user_message, prompt_vars, future)
+        )
+
+        # Auto-preempt: if a higher-priority task arrives while a
+        # lower-priority task is running, cancel the running task.
+        if (
+            self._current_priority is not None
+            and priority < self._current_priority
+            and self._cancel_event is not None
+        ):
+            self._cancel_event.set()
+
+        return await future
+
+    def cancel_current(self) -> None:
+        """Cancel the currently running workflow, if any."""
+        if self._cancel_event is not None:
+            self._cancel_event.set()
+
+    @property
+    def running_priority(self) -> int | None:
+        """Priority of the currently running task, or None if idle."""
+        return self._current_priority
+
+    @property
+    def pending(self) -> int:
+        """Number of tasks waiting in the queue."""
+        return self._queue.qsize()
+
+    async def _worker(self) -> None:
+        """Process tasks from the queue sequentially."""
+        while True:
+            priority, _counter, workflow, user_message, prompt_vars, future = (
+                await self._queue.get()
+            )
+
+            # Skip cancelled futures (consumer cancelled before we got to it)
+            if future.cancelled():
+                continue
+
+            self._cancel_event = asyncio.Event()
+            self._current_priority = priority
+
+            try:
+                result = await self.runner.run(
+                    workflow,
+                    user_message,
+                    prompt_vars=prompt_vars,
+                    cancel_event=self._cancel_event,
+                )
+                if not future.done():
+                    future.set_result(result)
+            except Exception as exc:
+                if not future.done():
+                    future.set_exception(exc)
+            finally:
+                self._cancel_event = None
+                self._current_priority = None

--- a/tests/unit/test_slot_worker.py
+++ b/tests/unit/test_slot_worker.py
@@ -1,0 +1,458 @@
+"""Tests for SlotWorker — serialized access to WorkflowRunner with priority queuing."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock
+
+import pytest
+
+from forge.context.manager import ContextManager
+from forge.context.strategies import NoCompact
+from forge.core.messages import MessageType
+from forge.core.runner import WorkflowRunner
+from forge.core.slot_worker import SlotWorker
+from forge.core.workflow import (
+    TextResponse,
+    ToolCall,
+    ToolDef,
+    ToolSpec,
+    Workflow,
+)
+from forge.errors import WorkflowCancelledError
+from pydantic import BaseModel
+
+
+class EmptyParams(BaseModel):
+    pass
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+def _make_tool(name: str, fn=None) -> ToolDef:
+    if fn is None:
+        fn = lambda **kwargs: f"{name}_result"
+    return ToolDef(
+        spec=ToolSpec(name=name, description=f"Tool {name}", parameters=EmptyParams),
+        callable=fn,
+    )
+
+
+def _make_workflow(terminal_tool: str = "submit") -> Workflow:
+    return Workflow(
+        name="test_wf",
+        description="A test workflow",
+        tools={
+            "fetch": _make_tool("fetch"),
+            terminal_tool: _make_tool(terminal_tool),
+        },
+        required_steps=["fetch"],
+        terminal_tool=terminal_tool,
+        system_prompt_template="You are a {role}.",
+    )
+
+
+class MockClient:
+    """Mock LLMClient that returns scripted responses."""
+
+    def __init__(self, responses: list):
+        self.responses = list(responses)
+        self._call_index = 0
+
+    async def send(self, messages, tools=None):
+        resp = self.responses[self._call_index]
+        self._call_index += 1
+        if isinstance(resp, ToolCall):
+            return [resp]
+        return resp
+
+    async def send_stream(self, messages, tools=None):
+        raise NotImplementedError
+
+    async def get_context_length(self):
+        return None
+
+
+def _make_worker(client: MockClient) -> SlotWorker:
+    ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
+    runner = WorkflowRunner(client=client, context_manager=ctx)
+    return SlotWorker(runner)
+
+
+# ── Basic operation ──────────────────────────────────────────
+
+
+class TestBasicOperation:
+
+    @pytest.mark.asyncio
+    async def test_submit_returns_result(self):
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        worker = _make_worker(client)
+        await worker.start()
+        try:
+            result = await worker.submit(
+                _make_workflow(), "go", prompt_vars={"role": "dev"},
+            )
+            assert result == "submit_result"
+        finally:
+            await worker.stop()
+
+    @pytest.mark.asyncio
+    async def test_fifo_ordering(self):
+        """Tasks submitted with equal priority run in FIFO order."""
+        order = []
+
+        def make_client(tag):
+            def fn(**kw):
+                order.append(tag)
+                return f"{tag}_done"
+            client = MockClient([
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ])
+            return client, fn
+
+        # We need a single client that can handle multiple sequential workflows.
+        # Use a client with enough responses for 2 sequential workflows.
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+
+        def track_first(**kw):
+            order.append("first")
+            return "first_result"
+
+        def track_second(**kw):
+            order.append("second")
+            return "second_result"
+
+        wf1 = Workflow(
+            name="wf1", description="first",
+            tools={"fetch": _make_tool("fetch"), "submit": _make_tool("submit", fn=track_first)},
+            required_steps=["fetch"], terminal_tool="submit",
+            system_prompt_template="You are a {role}.",
+        )
+        wf2 = Workflow(
+            name="wf2", description="second",
+            tools={"fetch": _make_tool("fetch"), "submit": _make_tool("submit", fn=track_second)},
+            required_steps=["fetch"], terminal_tool="submit",
+            system_prompt_template="You are a {role}.",
+        )
+
+        worker = _make_worker(client)
+        await worker.start()
+        try:
+            r1 = await worker.submit(wf1, "first", prompt_vars={"role": "dev"})
+            r2 = await worker.submit(wf2, "second", prompt_vars={"role": "dev"})
+            assert r1 == "first_result"
+            assert r2 == "second_result"
+            assert order == ["first", "second"]
+        finally:
+            await worker.stop()
+
+    @pytest.mark.asyncio
+    async def test_idle_properties(self):
+        client = MockClient([])
+        worker = _make_worker(client)
+        assert worker.running_priority is None
+        assert worker.pending == 0
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self):
+        client = MockClient([])
+        worker = _make_worker(client)
+        await worker.start()
+        task1 = worker._worker_task
+        await worker.start()  # should not create a second task
+        assert worker._worker_task is task1
+        await worker.stop()
+
+
+# ── Priority ─────────────────────────────────────────────────
+
+
+class TestPriority:
+
+    @pytest.mark.asyncio
+    async def test_higher_priority_runs_first_when_queued(self):
+        """When multiple tasks are queued, lower int runs first."""
+        order = []
+
+        # We'll submit two tasks while the worker is blocked on a third.
+        # Use an event to control when the first task completes.
+        gate = asyncio.Event()
+
+        def blocking_fetch(**kw):
+            # We need this to be async to block
+            return "fetch_result"
+
+        def track_high(**kw):
+            order.append("high")
+            return "high_result"
+
+        def track_low(**kw):
+            order.append("low")
+            return "low_result"
+
+        # First workflow blocks, then two more queue up
+        client = MockClient([
+            # First workflow (blocker)
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+            # High priority (should run second)
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+            # Low priority (should run third)
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+
+        wf_blocker = _make_workflow()
+        wf_high = Workflow(
+            name="high", description="high",
+            tools={"fetch": _make_tool("fetch"), "submit": _make_tool("submit", fn=track_high)},
+            required_steps=["fetch"], terminal_tool="submit",
+            system_prompt_template="You are a {role}.",
+        )
+        wf_low = Workflow(
+            name="low", description="low",
+            tools={"fetch": _make_tool("fetch"), "submit": _make_tool("submit", fn=track_low)},
+            required_steps=["fetch"], terminal_tool="submit",
+            system_prompt_template="You are a {role}.",
+        )
+
+        worker = _make_worker(client)
+        await worker.start()
+        try:
+            # Run blocker first, then queue low and high
+            r_block = await worker.submit(wf_blocker, "block", prompt_vars={"role": "dev"})
+
+            # Now queue low (priority=10) then high (priority=1)
+            # High should run before low despite being submitted second
+            task_low = asyncio.create_task(
+                worker.submit(wf_low, "low", priority=10, prompt_vars={"role": "dev"})
+            )
+            task_high = asyncio.create_task(
+                worker.submit(wf_high, "high", priority=1, prompt_vars={"role": "dev"})
+            )
+
+            r_high = await task_high
+            r_low = await task_low
+
+            assert r_high == "high_result"
+            assert r_low == "low_result"
+            assert order == ["high", "low"]
+        finally:
+            await worker.stop()
+
+    @pytest.mark.asyncio
+    async def test_default_priority_is_zero(self):
+        """Default priority is 0 (equal for all tasks)."""
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        worker = _make_worker(client)
+        await worker.start()
+        try:
+            # Submit without explicit priority
+            result = await worker.submit(
+                _make_workflow(), "go", prompt_vars={"role": "dev"},
+            )
+            assert result == "submit_result"
+        finally:
+            await worker.stop()
+
+
+# ── Preemption ───────────────────────────────────────────────
+
+
+class TestPreemption:
+
+    @pytest.mark.asyncio
+    async def test_cancel_current(self):
+        """cancel_current() cancels the running workflow."""
+        gate = asyncio.Event()
+
+        async def slow_fetch(**kw):
+            await gate.wait()
+            return "fetch_result"
+
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),
+        ])
+        wf = Workflow(
+            name="slow", description="slow",
+            tools={
+                "fetch": ToolDef(
+                    spec=ToolSpec(name="fetch", description="fetch", parameters=EmptyParams),
+                    callable=slow_fetch,
+                ),
+                "submit": _make_tool("submit"),
+            },
+            required_steps=["fetch"], terminal_tool="submit",
+            system_prompt_template="You are a {role}.",
+        )
+
+        worker = _make_worker(client)
+        await worker.start()
+        try:
+            task = asyncio.create_task(
+                worker.submit(wf, "go", prompt_vars={"role": "dev"})
+            )
+            await asyncio.sleep(0.05)  # let the worker start
+            worker.cancel_current()
+            gate.set()  # unblock the tool so the runner can check cancel
+
+            with pytest.raises(WorkflowCancelledError):
+                await task
+        finally:
+            await worker.stop()
+
+    @pytest.mark.asyncio
+    async def test_auto_preempt_lower_priority(self):
+        """Higher-priority submit auto-cancels lower-priority running task."""
+        gate = asyncio.Event()
+
+        async def slow_fetch(**kw):
+            await gate.wait()
+            return "fetch_result"
+
+        # Slow workflow on slot (priority 10)
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),  # slow task
+            ToolCall(tool="fetch", args={}),  # high-priority task
+            ToolCall(tool="submit", args={}),
+        ])
+        wf_slow = Workflow(
+            name="slow", description="slow",
+            tools={
+                "fetch": ToolDef(
+                    spec=ToolSpec(name="fetch", description="fetch", parameters=EmptyParams),
+                    callable=slow_fetch,
+                ),
+                "submit": _make_tool("submit"),
+            },
+            required_steps=["fetch"], terminal_tool="submit",
+            system_prompt_template="You are a {role}.",
+        )
+        wf_fast = _make_workflow()
+
+        worker = _make_worker(client)
+        await worker.start()
+        try:
+            slow_task = asyncio.create_task(
+                worker.submit(wf_slow, "slow", priority=10, prompt_vars={"role": "dev"})
+            )
+            await asyncio.sleep(0.05)  # let slow task start running
+
+            # Submit higher priority — should auto-cancel the slow task
+            fast_task = asyncio.create_task(
+                worker.submit(wf_fast, "fast", priority=1, prompt_vars={"role": "dev"})
+            )
+            gate.set()  # unblock so cancel can propagate
+
+            result = await fast_task
+            assert result == "submit_result"
+
+            with pytest.raises(WorkflowCancelledError):
+                await slow_task
+        finally:
+            await worker.stop()
+
+    @pytest.mark.asyncio
+    async def test_no_preempt_equal_priority(self):
+        """Equal priority does not trigger preemption."""
+        client = MockClient([
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        worker = _make_worker(client)
+        await worker.start()
+        try:
+            r1 = await worker.submit(
+                _make_workflow(), "first", priority=5, prompt_vars={"role": "dev"},
+            )
+            r2 = await worker.submit(
+                _make_workflow(), "second", priority=5, prompt_vars={"role": "dev"},
+            )
+            assert r1 == "submit_result"
+            assert r2 == "submit_result"
+        finally:
+            await worker.stop()
+
+
+# ── Error handling ───────────────────────────────────────────
+
+
+class TestErrorHandling:
+
+    @pytest.mark.asyncio
+    async def test_exception_propagates_to_caller(self):
+        """Exceptions from the runner propagate to the submit() caller."""
+        from forge.errors import MaxIterationsError
+
+        client = MockClient([
+            TextResponse(content="bare text"),
+            TextResponse(content="bare text again"),
+            TextResponse(content="bare text third"),
+            TextResponse(content="bare text fourth"),
+        ])
+        ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
+        runner = WorkflowRunner(
+            client=client, context_manager=ctx,
+            max_iterations=3, rescue_enabled=False,
+        )
+        worker = SlotWorker(runner)
+        await worker.start()
+        try:
+            with pytest.raises(Exception):
+                await worker.submit(
+                    _make_workflow(), "go", prompt_vars={"role": "dev"},
+                )
+        finally:
+            await worker.stop()
+
+    @pytest.mark.asyncio
+    async def test_worker_continues_after_error(self):
+        """Worker processes next task after a failed one."""
+        client = MockClient([
+            # First workflow: will fail (not enough responses to complete)
+            TextResponse(content="fail"),
+            TextResponse(content="fail"),
+            TextResponse(content="fail"),
+            TextResponse(content="fail"),
+            # Second workflow: succeeds
+            ToolCall(tool="fetch", args={}),
+            ToolCall(tool="submit", args={}),
+        ])
+        ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
+        runner = WorkflowRunner(
+            client=client, context_manager=ctx,
+            max_iterations=3, rescue_enabled=False,
+        )
+        worker = SlotWorker(runner)
+        await worker.start()
+        try:
+            # First task fails
+            with pytest.raises(Exception):
+                await worker.submit(
+                    _make_workflow(), "fail", prompt_vars={"role": "dev"},
+                )
+            # Second task succeeds
+            result = await worker.submit(
+                _make_workflow(), "succeed", prompt_vars={"role": "dev"},
+            )
+            assert result == "submit_result"
+        finally:
+            await worker.stop()


### PR DESCRIPTION
## Summary

Adds `SlotWorker` — a priority-queued wrapper for `WorkflowRunner` that serializes workflow execution on a shared inference slot with auto-preemption. Bumps version to 0.4.0.

This replaces the need for consumers to hand-roll slot management code. Pairs with `kv_unified` for multi-agent architectures where specialist workflows share a GPU slot while a main conversation runs on a dedicated slot.

## Changes

**New: `src/forge/core/slot_worker.py`**
- `SlotWorker(runner)` — wraps a WorkflowRunner with an async priority queue
- `submit(workflow, message, priority=0)` — queues and awaits result. Priority is a bare int (lower = higher priority), consumer defines semantics
- Auto-preemption: if a higher-priority task is submitted while a lower-priority task is running, the running task is cancelled via `cancel_event`
- `cancel_current()` — manual cancellation
- `start()` / `stop()` lifecycle
- Properties: `running_priority`, `pending`

**Updated:**
- `__init__.py` — export `SlotWorker`
- `pyproject.toml` — version 0.3.0 → 0.4.0
- `README.md` — mention SlotWorker in WorkflowRunner description, add to file tree and docs list
- `USER_GUIDE.md` — new "SlotWorker — Shared Slot Access" section with basic usage, priority, auto-preemption, and multi-slot architecture examples

## Design decisions

- **Priority is a bare int, not an enum.** Forge doesn't define what "user" or "routine" means — the consumer does. This avoids coupling forge to any specific scheduling vocabulary.
- **Auto-preemption is built in.** When a higher-priority task arrives, the lower-priority running task is cancelled automatically. This is the killer feature that eliminates consumer boilerplate.
- **One worker per slot.** Multi-slot setups create multiple `SlotWorker` instances. The consumer decides routing.
- **No slot pool / slot allocation.** With `kv_unified`, slot assignment is static (decided at startup). Dynamic allocation adds complexity without clear benefit.

## Test plan

- [x] 746 unit tests passing (11 new, 0 regressions)
- [x] Live smoke test: 2 slots, kv-unified, Ministral 8B — sequential tasks, concurrent tasks on different slots, auto-preemption
- [x] NORA integration confirmed: replaced hand-rolled SlotManager (~60 lines) with forge SlotWorker, all tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
