### PR TITLE
Document middleware caller responsibilities

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -103,6 +103,8 @@ for tc in result.tool_calls:
     errors.record_result(success=ok)
 ```
 
+**What you own:** The middleware provides validation, rescue parsing, retry nudges, and step enforcement. Your loop is responsible for: iteration caps, cancellation, context management (including compaction and threshold callbacks), and streaming. These are handled automatically by WorkflowRunner but are intentionally left to the caller in middleware mode — the middleware is an advisory layer, not an execution engine.
+
 **Best for:** Framework developers embedding forge's guardrails inside a custom agent, a proprietary pipeline, or another open-source framework. For a complete runnable example showing both APIs, see [`examples/foreign_loop.py`](../examples/foreign_loop.py). For design rationale, see [ADR-011](decisions/011-guardrail-middleware.md).
 
 ### How they relate

--- a/examples/foreign_loop.py
+++ b/examples/foreign_loop.py
@@ -12,6 +12,11 @@ This file has three parts:
   Part 2 -- The granular API (individual middleware components)
   Part 3 -- Using the respond tool for chat in tool-equipped sessions
 
+The middleware covers validation, rescue parsing, retry nudges, and step
+enforcement. Your loop is responsible for: iteration caps, cancellation,
+context management (compaction, threshold callbacks), and streaming. For
+the batteries-included version, see WorkflowRunner.
+
 No LLM backend required -- uses scripted responses to show each guardrail.
 """
 


### PR DESCRIPTION
## Summary

- Add "What you own" section to User Guide middleware docs (Mode 3), clarifying that iteration caps, cancellation, context management, and streaming are the caller's responsibility
- Add the same caller-responsibility note to the `foreign_loop.py` example docstring

Part of the proxy & middleware parity audit. All four middleware gaps (cancel_event, max_iterations, context thresholds, streaming) are by-design — the middleware is an advisory layer, not an execution engine. This change makes that contract explicit in user-facing docs.

## Test plan

- [ ] Docs-only change — no code affected
