### PR TITLE
Proxy cleanup and hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ python -m forge.proxy --backend llamaserver --gguf path/to/model.gguf --port 808
 
 Then configure your client to use `http://localhost:8081/v1` as the API base URL.
 
-**Note:** The proxy automatically injects a synthetic `respond` tool when tools are present in the request. The model calls `respond(message="...")` instead of producing bare text, keeping it in tool-calling mode where forge's full guardrail stack applies. The `respond` call is stripped from the outbound response — the client sees a normal text response (`finish_reason: "stop"`) and never knows the tool exists. This eliminates the `trust_text_intent` tradeoff described in [ADR-013](docs/decisions/013-text-response-intent.md) — no retries wasted on conversational turns, no accuracy loss on tool-calling turns.
+**Note:** The proxy automatically injects a synthetic `respond` tool when tools are present in the request. The model calls `respond(message="...")` instead of producing bare text, keeping it in tool-calling mode where forge's full guardrail stack applies. The `respond` call is stripped from the outbound response — the client sees a normal text response (`finish_reason: "stop"`) and never knows the tool exists. This is essential for small local models (~8B), which cannot be trusted to choose correctly between text and tool calls — guiding them to a tool is a must. See [ADR-013](docs/decisions/013-text-response-intent.md) for the full analysis.
 
 ## Backends
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -252,7 +252,6 @@ class ToolCall(BaseModel):
 class TextResponse(BaseModel):
     """Non-tool-call response from the model (reasoning trace, refusal, etc.)."""
     content: str
-    intentional: bool = False  # True = backend signalled finish_reason="stop"
 
 
 # Type alias for what the client returns
@@ -556,12 +555,11 @@ class ResponseValidator:
 
     def __init__(self, tool_names: list[str], rescue_enabled: bool = True) -> None: ...
 
-    def validate(self, response: LLMResponse, trust_text_intent: bool = False) -> ValidationResult:
+    def validate(self, response: LLMResponse) -> ValidationResult:
         """Validate an LLM response.
 
         Returns ValidationResult with tool_calls on success, or a Nudge on failure.
-        TextResponse path: if trust_text_intent and intentional, pass through.
-        Otherwise try rescue_tool_call(), then retry nudge.
+        TextResponse path: try rescue_tool_call(), then retry nudge.
         list[ToolCall] path: check for unknown tool names → unknown_tool_nudge.
         """
         ...
@@ -1655,7 +1653,7 @@ await server.stop()
 
 ## Synthetic Respond Tool
 
-When tools are present but the user sends a conversational message, small models must choose between calling a tool and responding with text. They frequently choose wrong — producing text when they should call tools, or vice versa. The `trust_text_intent` flag (ADR-013) addressed this for the proxy by trusting the model's finish reason, but this dropped 8B models from 100% to as low as 4% on reasoning-heavy workflows.
+When tools are present but the user sends a conversational message, small models must choose between calling a tool and responding with text. They frequently choose wrong — producing text when they should call tools, or vice versa. Small local models (~8B) cannot be trusted to make this choice correctly — eval testing showed that trusting the model's finish reason dropped workflow completion from 100% to as low as 4%. Guiding the model to a tool is a must.
 
 The respond tool eliminates this ambiguity. The model calls `respond(message="...")` instead of producing bare text. From forge's perspective, every response is a valid tool call — no retries wasted on conversational turns, no accuracy loss on tool-calling turns.
 
@@ -1673,7 +1671,7 @@ tools = {
 workflow = Workflow(..., tools=tools, terminal_tool="respond")
 ```
 
-**Proxy:** The respond tool is injected automatically when tools are present in the request. The client never sees it — respond calls are converted to plain text responses (`finish_reason: "stop"`) before returning. This makes `trust_text_intent` irrelevant for the proxy path.
+**Proxy:** The respond tool is injected automatically when tools are present in the request. The client never sees it — respond calls are converted to plain text responses (`finish_reason: "stop"`) before returning.
 
 **Middleware:** Include `"respond"` in `tool_names` when creating a `ResponseValidator` or `Guardrails` instance. The respond call passes validation like any other tool call. See `examples/foreign_loop.py` Part 3 for a complete example.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -10,6 +10,27 @@ For model and backend selection, see [MODEL_GUIDE.md](MODEL_GUIDE.md). For backe
 
 Forge's guardrail stack (retry nudges, step enforcement, error recovery, context compaction, VRAM budgeting) can be consumed in three ways. All three share the same underlying guardrail logic.
 
+### At a glance
+
+Each mode trades control for convenience. WorkflowRunner handles everything; the proxy applies guardrails transparently but drops workflow-level features; the middleware gives you building blocks and nothing else.
+
+| Feature | WorkflowRunner | Proxy | Middleware |
+|---------|:-:|:-:|:-:|
+| Validation + rescue parsing | Yes | Yes | Yes |
+| Retry nudges | Yes | Yes | Yes |
+| Respond tool | Caller adds | Auto-injected | Caller adds |
+| Step enforcement | Yes | No | Yes (caller wires) |
+| Prerequisites | Yes | No | Yes (caller wires) |
+| Max iterations | Yes | Bounded by max_retries | Caller's responsibility |
+| Context compaction | Yes | Yes | Caller wires ContextManager |
+| Context threshold warnings | Yes | No | Caller wires ContextManager |
+| Cancellation | Between iterations | Between retries | Caller's responsibility |
+| Streaming (token-by-token) | Yes | Post-hoc SSE | Caller's responsibility |
+| Tool execution | Yes | No (client executes) | No (caller executes) |
+| Callbacks (on_message, on_compact) | Yes | No | No |
+
+The proxy is intentionally bare-bones — it applies response-quality guardrails (validation, rescue, retry, respond tool) without requiring workflow knowledge. Features like step enforcement and prerequisites require workflow structure that doesn't exist in the OpenAI chat completions API. See [Proxy design boundaries](#proxy-design-boundaries) for details.
+
 ### Mode 1: Standalone Runner (batteries included)
 
 Forge owns the full agentic loop — LLM communication, guardrail policy, tool execution, and orchestration. You provide tools and a task, forge handles everything.
@@ -45,6 +66,20 @@ client = OpenAI(base_url="http://localhost:8081/v1")
 **Best for:** Adding guardrails to existing tools without modifying them. Works with any tool that speaks the OpenAI-compatible API — no per-client wrappers needed.
 
 **Reliability note:** The proxy automatically injects a synthetic `respond` tool when tools are present in the request. The model calls `respond(message="...")` instead of producing bare text, keeping it in tool-calling mode where forge's full guardrail stack applies. The `respond` call is stripped from the outbound response — the client sees a normal text response and never knows the tool exists. This is essential for small local models (~8B), which cannot be trusted to choose correctly between text and tool calls — eval testing showed that trusting the model's text intent dropped workflow completion from 100% to as low as 4%. Guiding the model to a tool is a must. See [ADR-013](decisions/013-text-response-intent.md) for the full analysis.
+
+#### Proxy design boundaries
+
+The proxy is intentionally bare-bones: it applies response-quality guardrails without requiring workflow knowledge. The following features are available in WorkflowRunner but not in the proxy, by design:
+
+- **Step enforcement and prerequisites.** These require workflow structure (required steps, terminal tool, tool dependencies) that doesn't exist in the OpenAI chat completions API. The proxy receives tool definitions per request but has no concept of workflow progression. If you need step enforcement, use WorkflowRunner or the middleware directly.
+
+- **Max iterations.** The proxy calls `run_inference` once per request. Each call is bounded at `max_retries + 1` LLM attempts (default 4). There is no outer loop — a runaway model cannot loop indefinitely. This is sufficient for the proxy's single-request model.
+
+- **Real streaming.** The proxy accepts `stream=true` and returns SSE events, but the full inference completes before SSE conversion. Token-by-token streaming during inference would require validating partial responses, which is incompatible with guardrails that need complete responses (rescue parsing, retry nudges). The guardrail-first design is the proxy's value proposition.
+
+- **Context threshold warnings.** The proxy is stateless — the client sends the full conversation history in every request and decides what to include. Context pressure is the client's concern. Compaction still fires when the budget is exceeded.
+
+- **Cancellation on disconnect.** Client disconnects are detected but do not cancel in-flight inference. This is the same granularity as WorkflowRunner, which checks `cancel_event` between loop iterations but does not interrupt a running LLM call. The worst case is `max_retries + 1` wasted calls (default 4) for a disconnected client.
 
 ### Mode 3: Middleware (composable guardrails)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -44,7 +44,7 @@ client = OpenAI(base_url="http://localhost:8081/v1")
 
 **Best for:** Adding guardrails to existing tools without modifying them. Works with any tool that speaks the OpenAI-compatible API — no per-client wrappers needed.
 
-**Reliability note:** The proxy sets `trust_text_intent=True`, meaning it trusts the backend's finish reason when the model responds with text instead of calling tools. This eliminates retry latency on conversational turns (e.g. the user says "hi" in a tool-equipped session) but means the proxy won't nudge the model if it should have called a tool. In eval testing with an 8B model (Ministral 3 8B Reasoning Q4_K_M), unconditionally trusting intent dropped workflow completion from 100% to as low as 4% on reasoning-heavy scenarios. WorkflowRunner and middleware default to `trust_text_intent=False` and are not affected. See [ADR-013](../decisions/013-text-response-intent.md) for the full analysis.
+**Reliability note:** The proxy automatically injects a synthetic `respond` tool when tools are present in the request. The model calls `respond(message="...")` instead of producing bare text, keeping it in tool-calling mode where forge's full guardrail stack applies. The `respond` call is stripped from the outbound response — the client sees a normal text response and never knows the tool exists. This is essential for small local models (~8B), which cannot be trusted to choose correctly between text and tool calls — eval testing showed that trusting the model's text intent dropped workflow completion from 100% to as low as 4%. Guiding the model to a tool is a must. See [ADR-013](decisions/013-text-response-intent.md) for the full analysis.
 
 ### Mode 3: Middleware (composable guardrails)
 
@@ -288,7 +288,7 @@ def on_message(self, msg: Message) -> None:
         self.messages.append(msg)
 ```
 
-`TEXT_RESPONSE` is included because in tool-calling workflows, bare text is always a failed attempt that triggered a retry — the successful response comes as a `TOOL_CALL`. Consumers where intentional text responses are valid (e.g., `trust_text_intent=True`) should keep `TEXT_RESPONSE` in their persist list.
+`TEXT_RESPONSE` is included because in tool-calling workflows, bare text is always a failed attempt that triggered a retry — the successful response comes as a `TOOL_CALL`. Consumers using the respond tool for conversational replies should keep `TEXT_RESPONSE` in their persist list.
 
 **Why not fix this in forge?** The runner's job is to emit everything — within a turn, retry nudges are useful (the model needs to see the nudge to self-correct). The distinction between "within a turn" and "across turns" is a consumer concern. Compaction handles context overflow but doesn't proactively clean up transient messages — it fires based on token budget pressure, not session hygiene.
 

--- a/docs/decisions/013-text-response-intent.md
+++ b/docs/decisions/013-text-response-intent.md
@@ -1,6 +1,6 @@
 # ADR-013: Text Response Intent -- When the Model Chooses Not to Call Tools
 
-**Status:** Accepted (March 2026) — Approach A implemented
+**Status:** Superseded (April 2026) — `trust_text_intent` and `TextResponse.intentional` removed. The respond tool (Approach B) replaced them.
 
 ## Problem
 
@@ -82,4 +82,8 @@ With `trust_text_intent=True` (unconditional trust): sequential_reasoning droppe
 
 The `intentional` flag is structurally correct — the model can't hallucinate a finish reason. But small models (~8B) frequently *choose wrong*: they produce text with `finish_reason: "stop"` when they should call tools. In WorkflowRunner and middleware, the retry nudge catches this. In proxy mode, the tradeoff is accepted for UX reasons — the client's own agentic loop is responsible for re-prompting.
 
-**Future direction:** A synthetic `respond` tool (Approach B) may be a better long-term solution for proxy/chat modes. Instead of trusting the model's text choice, make "respond with text" an explicit tool call. The model stays in tool-calling mode and forge's full guardrail stack applies. See GitHub issue for design discussion.
+## Superseded
+
+The synthetic `respond` tool (Approach B) was implemented and fully replaces `trust_text_intent`. The `intentional` flag on TextResponse and the `trust_text_intent` parameter have been removed from all interfaces (ResponseValidator, Guardrails, run_inference, and all clients).
+
+**Why:** Small local models (~8B) cannot be trusted to choose correctly between text and tool calls. Eval testing showed that trusting the model's finish reason dropped workflow completion from 100% to as low as 4%. The respond tool eliminates the ambiguity entirely — the model calls `respond(message="...")` instead of producing bare text, staying in tool-calling mode where forge's full guardrail stack applies. Guiding the model to a tool is a must; trusting its text intent is not a viable option for small models.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,14 @@ markers = [
     "integration: marks tests that require a running LLM backend (deselect with '-m \"not integration\"')",
 ]
 asyncio_mode = "auto"
+
+[tool.coverage.run]
+source = ["forge"]
+
+[tool.coverage.report]
+omit = [
+    # Integration-only: lifecycle orchestration requiring real backends/threads.
+    # Covered by eval harness runs, not unit tests.
+    "src/forge/proxy/proxy.py",
+    "src/forge/proxy/__main__.py",
+]

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -203,8 +203,7 @@ class AnthropicClient:
                 )
                 for i, tu in enumerate(tool_uses)
             ]
-        intentional = getattr(response, "stop_reason", None) == "end_turn"
-        return TextResponse(content="\n".join(text_parts), intentional=intentional)
+        return TextResponse(content="\n".join(text_parts))
 
     # ── API methods ──────────────────────────────────────────────
 
@@ -260,8 +259,6 @@ class AnthropicClient:
         # Track multiple tool_use blocks by index.
         tool_blocks: list[dict[str, str]] = []  # [{name, args}, ...]
         _current_tool_idx: int = -1
-        stream_stop_reason: str | None = None
-
         try:
             async with self._client.messages.stream(**kwargs) as stream:
                 async for event in stream:
@@ -288,8 +285,6 @@ class AnthropicClient:
                     elif event.type == "content_block_stop":
                         # Reset current tool index when a block finishes
                         _current_tool_idx = -1
-                    elif event.type == "message_delta":
-                        stream_stop_reason = getattr(event.delta, "stop_reason", None)
                     elif event.type == "message_stop":
                         if tool_blocks:
                             reasoning = accumulated_text or None
@@ -302,10 +297,7 @@ class AnthropicClient:
                                 for i, tb in enumerate(tool_blocks)
                             ]
                         else:
-                            final = TextResponse(
-                                content=accumulated_text,
-                                intentional=stream_stop_reason == "end_turn",
-                            )
+                            final = TextResponse(content=accumulated_text)
                         yield StreamChunk(
                             type=ChunkType.FINAL, response=final
                         )

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -246,7 +246,6 @@ class LlamafileClient:
 
         accumulated_content = ""
         accumulated_reasoning = ""
-        stream_intentional = False
         # Track multiple tool calls by index — OpenAI streaming sends
         # tool_calls[N] deltas with an index field.
         tool_call_parts: dict[int, dict[str, str]] = {}  # idx -> {name, args}
@@ -304,10 +303,6 @@ class LlamafileClient:
                         type=ChunkType.TEXT_DELTA, content=content
                     )
 
-                finish_reason = choice.get("finish_reason")
-                if finish_reason is not None:
-                    stream_intentional = finish_reason == "stop"
-
             # Stream ended — build and yield FINAL response.
             if tool_call_parts:
                 reasoning = self._resolve_reasoning(
@@ -345,9 +340,9 @@ class LlamafileClient:
                     )
                     final = extracted
                 else:
-                    final = TextResponse(content=cleaned, intentional=stream_intentional)
+                    final = TextResponse(content=cleaned)
             else:
-                final = TextResponse(content=accumulated_content, intentional=stream_intentional)
+                final = TextResponse(content=accumulated_content)
             yield StreamChunk(type=ChunkType.FINAL, response=final)
 
     async def get_context_length(self) -> int | None:
@@ -425,7 +420,6 @@ class LlamafileClient:
 
         top_choice = data["choices"][0]
         choice = top_choice["message"]
-        finish_reason = top_choice.get("finish_reason")
         raw_tool_calls = choice.get("tool_calls")
         if raw_tool_calls:
             reasoning = self._resolve_reasoning(
@@ -453,7 +447,7 @@ class LlamafileClient:
         # useful on ToolCall, TextResponse just gets clean content
         if content:
             _, content = _extract_think_tags(content)
-        return TextResponse(content=content, intentional=finish_reason == "stop")
+        return TextResponse(content=content)
 
     async def _send_prompt(
         self,
@@ -487,7 +481,6 @@ class LlamafileClient:
         top_choice = data["choices"][0]
         content = top_choice["message"].get("content", "")
         reasoning_content = top_choice["message"].get("reasoning_content", "")
-        finish_reason = top_choice.get("finish_reason")
         if tools:
             think_text, cleaned = _extract_think_tags(content)
             tool_names = [t.name for t in tools]
@@ -501,4 +494,4 @@ class LlamafileClient:
         # Strip think tags from TextResponse — clean content only
         if content:
             _, content = _extract_think_tags(content)
-        return TextResponse(content=content, intentional=finish_reason == "stop")
+        return TextResponse(content=content)

--- a/src/forge/clients/ollama.py
+++ b/src/forge/clients/ollama.py
@@ -153,9 +153,7 @@ class OllamaClient:
                 for i, tc in enumerate(tool_calls)
             ]
 
-        # No tool_calls and done=true → model intentionally chose text
-        done = data.get("done", False)
-        return TextResponse(content=msg.get("content", ""), intentional=done)
+        return TextResponse(content=msg.get("content", ""))
 
     async def send_stream(
         self,
@@ -254,7 +252,7 @@ class OllamaClient:
                         content = msg.get("content", "")
                         if content:
                             accumulated_content += content
-                        final = TextResponse(content=accumulated_content, intentional=True)
+                        final = TextResponse(content=accumulated_content)
                     yield StreamChunk(type=ChunkType.FINAL, response=final)
                 else:
                     tool_calls = msg.get("tool_calls")

--- a/src/forge/core/inference.py
+++ b/src/forge/core/inference.py
@@ -115,7 +115,6 @@ async def run_inference(
     step_index: int = 0,
     step_hint: str = "",
     max_attempts: int | None = None,
-    trust_text_intent: bool = False,
     stream: bool = False,
     on_chunk: Callable[[StreamChunk], Awaitable[None]] | None = None,
 ) -> InferenceResult | None:
@@ -144,9 +143,6 @@ async def run_inference(
             retries). When None, bounded only by max_retries. The runner
             passes remaining iteration budget here so retries don't exceed
             max_iterations.
-        trust_text_intent: If True, trust the backend's intentional flag
-            on TextResponse and skip retry. Proxy sets this to True;
-            WorkflowRunner leaves it False (default).
         stream: If True, use send_stream() instead of send().
         on_chunk: Async callback for streaming chunks.
 
@@ -209,12 +205,12 @@ async def run_inference(
         _sync_token_count(client, context_manager)
 
         # Validate
-        validation = validator.validate(response, trust_text_intent=trust_text_intent)
+        validation = validator.validate(response)
 
         if not validation.needs_retry:
             error_tracker.reset_retries()
             # Intentional text response or validated tool calls
-            validated = validation.text_response or validation.tool_calls
+            validated = validation.tool_calls
             return InferenceResult(
                 response=validated,
                 new_messages=new_messages,

--- a/src/forge/core/workflow.py
+++ b/src/forge/core/workflow.py
@@ -171,15 +171,9 @@ class ToolCall(BaseModel):
 
 
 class TextResponse(BaseModel):
-    """Non-tool-call response from the model (reasoning trace, refusal, etc.).
-
-    When ``intentional`` is True, the backend signalled that the model chose
-    to produce text (finish_reason="stop") rather than failing to produce a
-    tool call.  ResponseValidator trusts this signal and skips retry.
-    """
+    """Non-tool-call response from the model (reasoning trace, refusal, etc.)."""
 
     content: str
-    intentional: bool = False
 
 
 type LLMResponse = list[ToolCall] | TextResponse

--- a/src/forge/guardrails/guardrails.py
+++ b/src/forge/guardrails/guardrails.py
@@ -28,20 +28,17 @@ class CheckResult:
     Attributes:
         action: What the caller should do next.
             "execute"      -- tool_calls are safe to run.
-            "text"         -- model intentionally responded with text; no tools.
             "retry"        -- model produced an unusable response; inject nudge.
             "step_blocked" -- model tried to skip required steps; inject nudge.
             "fatal"        -- error budget exhausted; stop the workflow.
         tool_calls: Validated tool calls (only set when action == "execute").
-        text: Intentional text content (only set when action == "text").
         nudge: Corrective message to inject (set when action is "retry"
             or "step_blocked").
         reason: Human-readable explanation (only set when action == "fatal").
     """
 
-    action: Literal["execute", "text", "retry", "step_blocked", "fatal"]
+    action: Literal["execute", "retry", "step_blocked", "fatal"]
     tool_calls: list[ToolCall] | None = None
-    text: str | None = None
     nudge: Nudge | None = None
     reason: str | None = None
 
@@ -103,7 +100,7 @@ class Guardrails:
         )
 
     def check(
-        self, response: LLMResponse, trust_text_intent: bool = False,
+        self, response: LLMResponse,
     ) -> CheckResult:
         """Check an LLM response against all guardrails.
 
@@ -112,16 +109,12 @@ class Guardrails:
         Args:
             response: The LLM response -- either a TextResponse or a
                 list of ToolCall objects.
-            trust_text_intent: If True, trust the backend's intentional
-                flag on TextResponse. Default False.
 
         Returns:
             CheckResult indicating what the caller should do next.
         """
         # Checkpoint 1: Is this response usable?
-        validation = self._validator.validate(
-            response, trust_text_intent=trust_text_intent,
-        )
+        validation = self._validator.validate(response)
 
         if validation.needs_retry:
             self._errors.record_retry()
@@ -133,10 +126,6 @@ class Guardrails:
             return CheckResult(action="retry", nudge=validation.nudge)
 
         self._errors.reset_retries()
-
-        # Intentional text — model chose text over tools
-        if validation.text_response is not None:
-            return CheckResult(action="text", text=validation.text_response.content)
 
         # Checkpoint 2: Is the model skipping required steps?
         step_check = self._enforcer.check(validation.tool_calls)

--- a/src/forge/guardrails/response_validator.py
+++ b/src/forge/guardrails/response_validator.py
@@ -15,16 +15,14 @@ from forge.prompts.templates import rescue_tool_call
 class ValidationResult:
     """Result of validating an LLM response.
 
-    Exactly one of ``tool_calls``, ``text_response``, or ``nudge`` is set:
-    - If ``needs_retry`` is False and ``tool_calls`` is set: validated tool calls.
-    - If ``needs_retry`` is False and ``text_response`` is set: intentional text.
+    Exactly one of ``tool_calls`` or ``nudge`` is set:
+    - If ``needs_retry`` is False: ``tool_calls`` contains validated tool calls.
     - If ``needs_retry`` is True: ``nudge`` contains the message to inject.
     """
 
     tool_calls: list[ToolCall] | None
     nudge: Nudge | None
     needs_retry: bool
-    text_response: TextResponse | None = None
 
 
 class ResponseValidator:
@@ -52,26 +50,18 @@ class ResponseValidator:
         self._retry_nudge_fn = retry_nudge_fn or retry_nudge
 
     def validate(
-        self, response: LLMResponse, trust_text_intent: bool = False,
+        self, response: LLMResponse,
     ) -> ValidationResult:
         """Validate an LLM response.
 
         Args:
             response: Either a TextResponse or a list of ToolCall objects.
-            trust_text_intent: If True, trust the backend's ``intentional``
-                flag on TextResponse and skip retry. If False (default),
-                ignore the flag and retry as usual.
 
         Returns:
             ValidationResult with tool_calls on success, or a Nudge on failure.
         """
-        # TextResponse: intentional pass-through (if trusted), then rescue, then retry nudge
+        # TextResponse: rescue, then retry nudge
         if isinstance(response, TextResponse):
-            if trust_text_intent and response.intentional:
-                return ValidationResult(
-                    tool_calls=None, nudge=None, needs_retry=False,
-                    text_response=response,
-                )
             if self.rescue_enabled:
                 rescued = rescue_tool_call(response.content, self.tool_names)
                 if rescued:

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -115,7 +115,6 @@ async def handle_chat_completions(
             validator=validator,
             error_tracker=error_tracker,
             tool_specs=tool_specs,
-            trust_text_intent=True,
         )
     except ToolCallError as exc:
         # Retries exhausted — the model kept returning text instead of tool
@@ -132,13 +131,6 @@ async def handle_chat_completions(
         if is_stream:
             return text_to_sse_events("", model=model_name)
         return text_response_to_openai("", model=model_name)
-
-    # Intentional text response — pass through to client
-    if isinstance(result.response, TextResponse):
-        logger.info("Intentional text response, passing through")
-        if is_stream:
-            return text_to_sse_events(result.response.content, model=model_name)
-        return text_response_to_openai(result.response.content, model=model_name)
 
     tool_calls = result.response
 

--- a/src/forge/tools/respond.py
+++ b/src/forge/tools/respond.py
@@ -2,7 +2,8 @@
 
 The model calls respond(message="...") instead of producing bare text.
 This keeps the model in tool-calling mode where forge's full guardrail
-stack applies, eliminating the trust_text_intent tradeoff.
+stack applies. Small local models (~8B) cannot be trusted to choose
+correctly between text and tool calls — guiding them to a tool is a must.
 
 Usage:
 

--- a/tests/unit/test_context_thresholds.py
+++ b/tests/unit/test_context_thresholds.py
@@ -185,7 +185,7 @@ class TestInferenceInjection:
     async def test_warning_injected_into_api_messages(self) -> None:
         from unittest.mock import AsyncMock
         from forge.core.inference import run_inference
-        from forge.core.workflow import ToolCall, ToolSpec, TextResponse
+        from forge.core.workflow import ToolCall
         from forge.guardrails import ErrorTracker, ResponseValidator
 
         # Tiny budget, threshold at 30% so our messages will cross it
@@ -207,13 +207,13 @@ class TestInferenceInjection:
 
         async def mock_send(api_messages, tools=None):
             captured_messages.extend(api_messages)
-            return TextResponse(content="ok", intentional=True)
+            return [ToolCall(tool="done", args={})]
 
         mock_client = AsyncMock()
         mock_client.send = mock_send
         mock_client.api_format = "ollama"
 
-        validator = ResponseValidator(tool_names=[], rescue_enabled=False)
+        validator = ResponseValidator(tool_names=["done"], rescue_enabled=False)
         error_tracker = ErrorTracker(max_retries=1)
 
         result = await run_inference(
@@ -223,7 +223,6 @@ class TestInferenceInjection:
             validator=validator,
             error_tracker=error_tracker,
             tool_specs=[],
-            trust_text_intent=True,
         )
 
         # The injected warning should be the last message (user role)
@@ -236,7 +235,7 @@ class TestInferenceInjection:
     async def test_no_injection_without_threshold_config(self) -> None:
         from unittest.mock import AsyncMock
         from forge.core.inference import run_inference
-        from forge.core.workflow import TextResponse
+        from forge.core.workflow import ToolCall
         from forge.guardrails import ErrorTracker, ResponseValidator
 
         # No thresholds configured
@@ -251,13 +250,13 @@ class TestInferenceInjection:
 
         async def mock_send(api_messages, tools=None):
             captured_messages.extend(api_messages)
-            return TextResponse(content="ok", intentional=True)
+            return [ToolCall(tool="done", args={})]
 
         mock_client = AsyncMock()
         mock_client.send = mock_send
         mock_client.api_format = "ollama"
 
-        validator = ResponseValidator(tool_names=[], rescue_enabled=False)
+        validator = ResponseValidator(tool_names=["done"], rescue_enabled=False)
         error_tracker = ErrorTracker(max_retries=1)
 
         await run_inference(
@@ -267,7 +266,6 @@ class TestInferenceInjection:
             validator=validator,
             error_tracker=error_tracker,
             tool_specs=[],
-            trust_text_intent=True,
         )
 
         # No context warning should be injected

--- a/tests/unit/test_proxy_convert.py
+++ b/tests/unit/test_proxy_convert.py
@@ -1,0 +1,256 @@
+"""Tests for proxy message conversion (OpenAI ↔ forge)."""
+
+import json
+
+from forge.core.messages import MessageRole, MessageType
+from forge.core.workflow import ToolCall
+from forge.proxy.convert import (
+    openai_to_messages,
+    tool_calls_to_openai,
+    text_response_to_openai,
+    tool_calls_to_sse_events,
+    text_to_sse_events,
+)
+
+
+# ── Inbound: OpenAI → forge ────────────────────────────────
+
+
+class TestOpenaiToMessages:
+    def test_system_message(self):
+        msgs = openai_to_messages([{"role": "system", "content": "You are helpful."}])
+        assert len(msgs) == 1
+        assert msgs[0].role == MessageRole.SYSTEM
+        assert msgs[0].content == "You are helpful."
+        assert msgs[0].metadata.type == MessageType.SYSTEM_PROMPT
+
+    def test_user_message(self):
+        msgs = openai_to_messages([{"role": "user", "content": "Hello"}])
+        assert len(msgs) == 1
+        assert msgs[0].role == MessageRole.USER
+        assert msgs[0].content == "Hello"
+        assert msgs[0].metadata.type == MessageType.USER_INPUT
+
+    def test_assistant_text(self):
+        msgs = openai_to_messages([{"role": "assistant", "content": "Hi there"}])
+        assert len(msgs) == 1
+        assert msgs[0].role == MessageRole.ASSISTANT
+        assert msgs[0].content == "Hi there"
+        assert msgs[0].metadata.type == MessageType.TEXT_RESPONSE
+
+    def test_assistant_tool_calls(self):
+        msgs = openai_to_messages([{
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_abc",
+                "function": {"name": "search", "arguments": '{"q": "test"}'},
+            }],
+        }])
+        assert len(msgs) == 1
+        assert msgs[0].role == MessageRole.ASSISTANT
+        assert msgs[0].metadata.type == MessageType.TOOL_CALL
+        assert msgs[0].tool_calls is not None
+        assert len(msgs[0].tool_calls) == 1
+        assert msgs[0].tool_calls[0].name == "search"
+        assert msgs[0].tool_calls[0].args == {"q": "test"}
+        assert msgs[0].tool_calls[0].call_id == "call_abc"
+
+    def test_tool_result(self):
+        msgs = openai_to_messages([{
+            "role": "tool",
+            "content": "result data",
+            "tool_call_id": "call_abc",
+            "name": "search",
+        }])
+        assert len(msgs) == 1
+        assert msgs[0].role == MessageRole.TOOL
+        assert msgs[0].content == "result data"
+        assert msgs[0].metadata.type == MessageType.TOOL_RESULT
+        assert msgs[0].tool_name == "search"
+        assert msgs[0].tool_call_id == "call_abc"
+
+    def test_unknown_role_maps_to_user(self):
+        msgs = openai_to_messages([{"role": "developer", "content": "stuff"}])
+        assert len(msgs) == 1
+        assert msgs[0].role == MessageRole.USER
+
+    def test_list_content_blocks(self):
+        msgs = openai_to_messages([{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": "World"},
+            ],
+        }])
+        assert msgs[0].content == "Hello\nWorld"
+
+    def test_null_content_becomes_empty(self):
+        msgs = openai_to_messages([{"role": "user", "content": None}])
+        assert msgs[0].content == ""
+
+    def test_multi_message_conversation(self):
+        msgs = openai_to_messages([
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "bye"},
+        ])
+        assert len(msgs) == 4
+        assert [m.role for m in msgs] == [
+            MessageRole.SYSTEM, MessageRole.USER,
+            MessageRole.ASSISTANT, MessageRole.USER,
+        ]
+
+    def test_assistant_tool_calls_with_dict_arguments(self):
+        """Arguments as dict (not JSON string) should be handled."""
+        msgs = openai_to_messages([{
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_1",
+                "function": {"name": "fetch", "arguments": {"url": "http://x"}},
+            }],
+        }])
+        assert msgs[0].tool_calls[0].args == {"url": "http://x"}
+
+    def test_empty_tool_calls_treated_as_text(self):
+        """Empty tool_calls list should be treated as text response."""
+        msgs = openai_to_messages([{
+            "role": "assistant",
+            "content": "thinking...",
+            "tool_calls": [],
+        }])
+        assert msgs[0].metadata.type == MessageType.TEXT_RESPONSE
+
+
+# ── Outbound: forge → OpenAI ───────────────────────────────
+
+
+class TestToolCallsToOpenai:
+    def test_single_tool_call(self):
+        result = tool_calls_to_openai([ToolCall(tool="search", args={"q": "test"})])
+        assert result["object"] == "chat.completion"
+        choices = result["choices"]
+        assert len(choices) == 1
+        msg = choices[0]["message"]
+        assert msg["role"] == "assistant"
+        assert len(msg["tool_calls"]) == 1
+        tc = msg["tool_calls"][0]
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "search"
+        assert json.loads(tc["function"]["arguments"]) == {"q": "test"}
+        assert choices[0]["finish_reason"] == "tool_calls"
+
+    def test_multiple_tool_calls(self):
+        result = tool_calls_to_openai([
+            ToolCall(tool="search", args={"q": "a"}),
+            ToolCall(tool="fetch", args={"url": "b"}),
+        ])
+        assert len(result["choices"][0]["message"]["tool_calls"]) == 2
+
+    def test_reasoning_in_content(self):
+        result = tool_calls_to_openai([
+            ToolCall(tool="search", args={}, reasoning="Let me think..."),
+        ])
+        assert result["choices"][0]["message"]["content"] == "Let me think..."
+
+    def test_no_reasoning_content_is_none(self):
+        result = tool_calls_to_openai([ToolCall(tool="search", args={})])
+        assert result["choices"][0]["message"]["content"] is None
+
+    def test_model_name_propagated(self):
+        result = tool_calls_to_openai(
+            [ToolCall(tool="search", args={})], model="my-model",
+        )
+        assert result["model"] == "my-model"
+
+
+class TestTextResponseToOpenai:
+    def test_basic(self):
+        result = text_response_to_openai("Hello!")
+        assert result["object"] == "chat.completion"
+        msg = result["choices"][0]["message"]
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "Hello!"
+        assert result["choices"][0]["finish_reason"] == "stop"
+
+    def test_empty_text(self):
+        result = text_response_to_openai("")
+        assert result["choices"][0]["message"]["content"] == ""
+
+    def test_model_name(self):
+        result = text_response_to_openai("hi", model="test-model")
+        assert result["model"] == "test-model"
+
+
+# ── SSE streaming ──────────────────────────────────────────
+
+
+class TestToolCallsToSseEvents:
+    def test_single_tool_call_structure(self):
+        events = tool_calls_to_sse_events([ToolCall(tool="search", args={"q": "x"})])
+        # Should have: tool call delta + final chunk
+        assert len(events) == 2
+        # First: tool call delta
+        delta = events[0]["choices"][0]["delta"]
+        assert "tool_calls" in delta
+        assert delta["tool_calls"][0]["function"]["name"] == "search"
+        # Last: finish_reason
+        assert events[-1]["choices"][0]["finish_reason"] == "tool_calls"
+        assert events[-1]["choices"][0]["delta"] == {}
+
+    def test_reasoning_prepended(self):
+        events = tool_calls_to_sse_events([
+            ToolCall(tool="search", args={}, reasoning="Thinking..."),
+        ])
+        # reasoning delta + tool call delta + final
+        assert len(events) == 3
+        assert events[0]["choices"][0]["delta"]["content"] == "Thinking..."
+
+    def test_multiple_tool_calls(self):
+        events = tool_calls_to_sse_events([
+            ToolCall(tool="a", args={}),
+            ToolCall(tool="b", args={}),
+        ])
+        # 2 tool call deltas + final
+        assert len(events) == 3
+
+    def test_consistent_completion_id(self):
+        events = tool_calls_to_sse_events([ToolCall(tool="a", args={})])
+        ids = {e["id"] for e in events}
+        assert len(ids) == 1  # all events share the same completion ID
+
+
+class TestTextToSseEvents:
+    def test_single_chunk(self):
+        events = text_to_sse_events("Hello!")
+        # content chunk + final
+        assert len(events) == 2
+        assert events[0]["choices"][0]["delta"]["content"] == "Hello!"
+        assert events[0]["choices"][0]["delta"]["role"] == "assistant"
+        assert events[-1]["choices"][0]["finish_reason"] == "stop"
+
+    def test_chunked_text(self):
+        events = text_to_sse_events("Hello World!", chunk_size=5)
+        # "Hello", " Worl", "d!" = 3 content chunks + final
+        assert len(events) == 4
+        texts = [e["choices"][0]["delta"]["content"] for e in events[:-1]]
+        assert "".join(texts) == "Hello World!"
+
+    def test_first_chunk_has_role(self):
+        events = text_to_sse_events("Hi", chunk_size=1)
+        assert "role" in events[0]["choices"][0]["delta"]
+        # Second chunk should not have role
+        assert "role" not in events[1]["choices"][0]["delta"]
+
+    def test_empty_text(self):
+        events = text_to_sse_events("")
+        # Even empty: content chunk + final
+        assert len(events) == 2
+        assert events[0]["choices"][0]["delta"]["content"] == ""
+
+    def test_consistent_completion_id(self):
+        events = text_to_sse_events("test", chunk_size=1)
+        ids = {e["id"] for e in events}
+        assert len(ids) == 1

--- a/tests/unit/test_proxy_handler.py
+++ b/tests/unit/test_proxy_handler.py
@@ -1,0 +1,224 @@
+"""Tests for proxy request handler."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from forge.context.manager import ContextManager
+from forge.context.strategies import NoCompact
+from forge.core.workflow import TextResponse, ToolCall
+from forge.proxy.handler import handle_chat_completions, _extract_tool_specs
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+def _mock_client(response):
+    """Create a mock LLMClient that returns the given response."""
+    client = AsyncMock()
+    client.api_format = "ollama"
+    client.send = AsyncMock(return_value=response)
+    return client
+
+
+def _context_manager():
+    return ContextManager(strategy=NoCompact(), budget_tokens=8192)
+
+
+def _body(messages=None, tools=None, stream=False, model="test"):
+    """Build a minimal request body."""
+    b = {"messages": messages or [{"role": "user", "content": "hi"}], "model": model}
+    if tools is not None:
+        b["tools"] = tools
+    if stream:
+        b["stream"] = True
+    return b
+
+
+def _tool_def(name="search", description="Search", parameters=None):
+    """Build an OpenAI-format tool definition."""
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": parameters or {"type": "object", "properties": {}},
+        },
+    }
+
+
+# ── _extract_tool_specs ──────────────────────────────────────
+
+
+class TestExtractToolSpecs:
+    def test_none_returns_empty(self):
+        assert _extract_tool_specs(None) == []
+
+    def test_empty_list_returns_empty(self):
+        assert _extract_tool_specs([]) == []
+
+    def test_extracts_function_tools(self):
+        specs = _extract_tool_specs([_tool_def("search"), _tool_def("fetch")])
+        assert len(specs) == 2
+        assert specs[0].name == "search"
+        assert specs[1].name == "fetch"
+
+    def test_skips_non_function_types(self):
+        tools = [{"type": "retrieval"}, _tool_def("search")]
+        specs = _extract_tool_specs(tools)
+        assert len(specs) == 1
+        assert specs[0].name == "search"
+
+    def test_extracts_parameters(self):
+        params = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        }
+        specs = _extract_tool_specs([_tool_def("search", parameters=params)])
+        assert specs[0].name == "search"
+
+
+# ── No tools → passthrough ──────────────────────────────────
+
+
+class TestNoToolsPassthrough:
+    @pytest.mark.asyncio
+    async def test_text_response_passthrough(self):
+        client = _mock_client(TextResponse(content="Hello!"))
+        result = await handle_chat_completions(
+            _body(), client, _context_manager(),
+        )
+        assert result["choices"][0]["message"]["content"] == "Hello!"
+        assert result["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_text_response_passthrough_stream(self):
+        client = _mock_client(TextResponse(content="Hello!"))
+        result = await handle_chat_completions(
+            _body(stream=True), client, _context_manager(),
+        )
+        # SSE events list
+        assert isinstance(result, list)
+        assert result[-1]["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_model_name_propagated(self):
+        client = _mock_client(TextResponse(content="hi"))
+        result = await handle_chat_completions(
+            _body(model="my-model"), client, _context_manager(),
+        )
+        assert result["model"] == "my-model"
+
+
+# ── With tools → guardrails ─────────────────────────────────
+
+
+class TestWithTools:
+    @pytest.mark.asyncio
+    async def test_tool_call_returned(self):
+        """Valid tool call is returned in OpenAI format."""
+        client = _mock_client([ToolCall(tool="search", args={"q": "test"})])
+        result = await handle_chat_completions(
+            _body(tools=[_tool_def("search")]), client, _context_manager(),
+        )
+        tc = result["choices"][0]["message"]["tool_calls"]
+        assert len(tc) == 1
+        assert tc[0]["function"]["name"] == "search"
+        assert result["choices"][0]["finish_reason"] == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_stream(self):
+        """Valid tool call returns SSE events."""
+        client = _mock_client([ToolCall(tool="search", args={})])
+        result = await handle_chat_completions(
+            _body(tools=[_tool_def("search")], stream=True),
+            client, _context_manager(),
+        )
+        assert isinstance(result, list)
+        assert result[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_respond_tool_auto_injected(self):
+        """Respond tool is injected — model calling respond returns text."""
+        client = _mock_client([ToolCall(tool="respond", args={"message": "Hi!"})])
+        result = await handle_chat_completions(
+            _body(tools=[_tool_def("search")]), client, _context_manager(),
+        )
+        # respond is stripped — client sees text, not a tool call
+        assert result["choices"][0]["message"]["content"] == "Hi!"
+        assert result["choices"][0]["finish_reason"] == "stop"
+        assert "tool_calls" not in result["choices"][0]["message"]
+
+    @pytest.mark.asyncio
+    async def test_respond_stripped_in_stream(self):
+        """Respond call in stream mode returns text SSE events."""
+        client = _mock_client([ToolCall(tool="respond", args={"message": "Hi!"})])
+        result = await handle_chat_completions(
+            _body(tools=[_tool_def("search")], stream=True),
+            client, _context_manager(),
+        )
+        assert isinstance(result, list)
+        assert result[-1]["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_mixed_respond_and_tool_calls(self):
+        """If respond is mixed with real tool calls, respond is dropped."""
+        client = _mock_client([
+            ToolCall(tool="search", args={"q": "test"}),
+            ToolCall(tool="respond", args={"message": "also this"}),
+        ])
+        result = await handle_chat_completions(
+            _body(tools=[_tool_def("search")]), client, _context_manager(),
+        )
+        tc = result["choices"][0]["message"]["tool_calls"]
+        assert len(tc) == 1
+        assert tc[0]["function"]["name"] == "search"
+
+    @pytest.mark.asyncio
+    async def test_respond_not_double_injected(self):
+        """If client already provides respond tool, don't inject again."""
+        client = _mock_client([ToolCall(tool="respond", args={"message": "Hi!"})])
+        tools = [_tool_def("search"), _tool_def("respond")]
+        result = await handle_chat_completions(
+            _body(tools=tools), client, _context_manager(),
+        )
+        # Should still work — respond stripped to text
+        assert result["choices"][0]["message"]["content"] == "Hi!"
+
+
+# ── Error paths ─────────────────────────────────────────────
+
+
+class TestErrorPaths:
+    @pytest.mark.asyncio
+    async def test_retries_exhausted_returns_text(self):
+        """When retries are exhausted, last text is returned to client."""
+        # Model always returns text — will exhaust retries
+        client = AsyncMock()
+        client.api_format = "ollama"
+        client.send = AsyncMock(return_value=TextResponse(content="I can't do that"))
+        result = await handle_chat_completions(
+            _body(tools=[_tool_def("search")]),
+            client, _context_manager(), max_retries=1,
+        )
+        # Should return the text rather than an error
+        assert result["choices"][0]["message"]["content"] == "I can't do that"
+        assert result["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_retries_exhausted_stream(self):
+        """Retries exhausted in stream mode returns text SSE events."""
+        client = AsyncMock()
+        client.api_format = "ollama"
+        client.send = AsyncMock(return_value=TextResponse(content="nope"))
+        result = await handle_chat_completions(
+            _body(tools=[_tool_def("search")], stream=True),
+            client, _context_manager(), max_retries=1,
+        )
+        assert isinstance(result, list)
+        # Should contain the text in SSE events
+        content_events = [
+            e for e in result
+            if e["choices"][0].get("delta", {}).get("content")
+        ]
+        assert len(content_events) > 0

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -1,0 +1,284 @@
+"""Tests for proxy HTTP server."""
+
+import asyncio
+import json
+
+import pytest
+from unittest.mock import AsyncMock
+
+from forge.context.manager import ContextManager
+from forge.context.strategies import NoCompact
+from forge.core.workflow import TextResponse, ToolCall
+from forge.proxy.server import HTTPServer
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+def _mock_client(response):
+    """Create a mock LLMClient that returns the given response."""
+    client = AsyncMock()
+    client.api_format = "ollama"
+    client.send = AsyncMock(return_value=response)
+    return client
+
+
+@pytest.fixture
+async def server_factory():
+    """Factory fixture that creates an HTTPServer on a random port."""
+    servers = []
+
+    async def _make(response, serialize=False):
+        client = _mock_client(response)
+        ctx = ContextManager(strategy=NoCompact(), budget_tokens=8192)
+        srv = HTTPServer(
+            client=client,
+            context_manager=ctx,
+            host="127.0.0.1",
+            port=0,  # OS picks a free port
+            serialize_requests=serialize,
+        )
+        await srv.start()
+        # Get the actual port from the server
+        sock = srv._server.sockets[0]
+        port = sock.getsockname()[1]
+        servers.append(srv)
+        return srv, port
+
+    yield _make
+
+    for srv in servers:
+        await srv.stop()
+
+
+async def _http_request(port, method, path, body=None):
+    """Send an HTTP request and return (status, headers_dict, body_str)."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        if body is not None:
+            body_bytes = json.dumps(body).encode()
+            request = (
+                f"{method} {path} HTTP/1.1\r\n"
+                f"Host: 127.0.0.1:{port}\r\n"
+                f"Content-Type: application/json\r\n"
+                f"Content-Length: {len(body_bytes)}\r\n"
+                f"\r\n"
+            ).encode() + body_bytes
+        else:
+            request = (
+                f"{method} {path} HTTP/1.1\r\n"
+                f"Host: 127.0.0.1:{port}\r\n"
+                f"\r\n"
+            ).encode()
+
+        writer.write(request)
+        await writer.drain()
+
+        # Read response
+        response_data = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+        response_str = response_data.decode("utf-8", errors="replace")
+
+        # Parse status line
+        lines = response_str.split("\r\n")
+        status = int(lines[0].split(" ", 2)[1])
+
+        # Find body (after blank line)
+        body_start = response_str.find("\r\n\r\n")
+        response_body = response_str[body_start + 4:] if body_start >= 0 else ""
+
+        return status, response_body
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+async def _sse_request(port, body):
+    """Send a streaming request and return list of SSE data lines."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        body_bytes = json.dumps(body).encode()
+        request = (
+            f"POST /v1/chat/completions HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{port}\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Content-Length: {len(body_bytes)}\r\n"
+            f"\r\n"
+        ).encode() + body_bytes
+
+        writer.write(request)
+        await writer.drain()
+
+        response_data = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+        response_str = response_data.decode("utf-8", errors="replace")
+
+        # Extract SSE data lines from chunked transfer encoding
+        data_lines = []
+        for line in response_str.split("\n"):
+            line = line.strip()
+            if line.startswith("data: "):
+                data_lines.append(line[6:])
+
+        return data_lines
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+# ── Health & Models ──────────────────────────────────────────
+
+
+class TestHealthAndModels:
+    @pytest.mark.asyncio
+    async def test_health_endpoint(self, server_factory):
+        srv, port = await server_factory(TextResponse(content=""))
+        status, body = await _http_request(port, "GET", "/health")
+        assert status == 200
+        data = json.loads(body)
+        assert data["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_models_endpoint(self, server_factory):
+        srv, port = await server_factory(TextResponse(content=""))
+        status, body = await _http_request(port, "GET", "/v1/models")
+        assert status == 200
+        data = json.loads(body)
+        assert data["object"] == "list"
+        assert len(data["data"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, server_factory):
+        srv, port = await server_factory(TextResponse(content=""))
+        status, body = await _http_request(port, "GET", "/nonexistent")
+        assert status == 404
+
+    @pytest.mark.asyncio
+    async def test_cors_preflight(self, server_factory):
+        srv, port = await server_factory(TextResponse(content=""))
+        status, _ = await _http_request(port, "OPTIONS", "/v1/chat/completions")
+        assert status == 204
+
+
+# ── Chat Completions ────────────────────────────────────────
+
+
+class TestChatCompletions:
+    @pytest.mark.asyncio
+    async def test_no_tools_text_response(self, server_factory):
+        srv, port = await server_factory(TextResponse(content="Hello!"))
+        body = {"messages": [{"role": "user", "content": "hi"}]}
+        status, response_body = await _http_request(
+            port, "POST", "/v1/chat/completions", body,
+        )
+        assert status == 200
+        data = json.loads(response_body)
+        assert data["choices"][0]["message"]["content"] == "Hello!"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_response(self, server_factory):
+        srv, port = await server_factory(
+            [ToolCall(tool="search", args={"q": "test"})],
+        )
+        body = {
+            "messages": [{"role": "user", "content": "search for test"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }],
+        }
+        status, response_body = await _http_request(
+            port, "POST", "/v1/chat/completions", body,
+        )
+        assert status == 200
+        data = json.loads(response_body)
+        tc = data["choices"][0]["message"]["tool_calls"]
+        assert len(tc) == 1
+        assert tc[0]["function"]["name"] == "search"
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_400(self, server_factory):
+        srv, port = await server_factory(TextResponse(content=""))
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            bad_body = b"not json"
+            request = (
+                f"POST /v1/chat/completions HTTP/1.1\r\n"
+                f"Host: 127.0.0.1:{port}\r\n"
+                f"Content-Type: application/json\r\n"
+                f"Content-Length: {len(bad_body)}\r\n"
+                f"\r\n"
+            ).encode() + bad_body
+            writer.write(request)
+            await writer.drain()
+            response_data = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+            assert b"400" in response_data
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+
+# ── SSE Streaming ───────────────────────────────────────────
+
+
+class TestSSEStreaming:
+    @pytest.mark.asyncio
+    async def test_streaming_text_response(self, server_factory):
+        srv, port = await server_factory(TextResponse(content="Hello!"))
+        body = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        }
+        data_lines = await _sse_request(port, body)
+        # Should have content events and [DONE]
+        assert "[DONE]" in data_lines
+        json_events = [json.loads(d) for d in data_lines if d != "[DONE]"]
+        assert len(json_events) > 0
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_call(self, server_factory):
+        srv, port = await server_factory(
+            [ToolCall(tool="search", args={"q": "x"})],
+        )
+        body = {
+            "messages": [{"role": "user", "content": "go"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }],
+            "stream": True,
+        }
+        data_lines = await _sse_request(port, body)
+        assert "[DONE]" in data_lines
+        json_events = [json.loads(d) for d in data_lines if d != "[DONE]"]
+        # Should have tool call deltas
+        has_tool_call = any(
+            "tool_calls" in e["choices"][0].get("delta", {})
+            for e in json_events
+        )
+        assert has_tool_call
+
+
+# ── Serialization ───────────────────────────────────────────
+
+
+class TestSerialization:
+    @pytest.mark.asyncio
+    async def test_serialized_requests_processed(self, server_factory):
+        """Serialized mode processes requests through the queue."""
+        srv, port = await server_factory(
+            TextResponse(content="ok"), serialize=True,
+        )
+        body = {"messages": [{"role": "user", "content": "hi"}]}
+        status, response_body = await _http_request(
+            port, "POST", "/v1/chat/completions", body,
+        )
+        assert status == 200
+        data = json.loads(response_body)
+        assert data["choices"][0]["message"]["content"] == "ok"


### PR DESCRIPTION
## Summary

- Remove `trust_text_intent` param and `TextResponse.intentional` field — the respond tool supersedes both. Small local models (~8B) cannot be trusted to choose between text and tool calls; guiding them to a tool is a must
- Add exec summary table to User Guide showing feature tradeoffs across WorkflowRunner, proxy, and middleware
- Add "Proxy design boundaries" section documenting why prerequisites, step enforcement, real streaming, context thresholds, and cancellation are intentionally out of scope
- Mark ADR-013 as superseded
- Add 54 proxy unit tests covering convert.py (97%), handler.py (92%), server.py (80%)
- Add coverage config excluding integration-only files (proxy.py, __main__.py)

Overall unit coverage: 77% → 91%. Eval confirmed green (18 scenarios, N=1).

Addresses all items from the proxy & middleware parity audit.

## Test plan

- [x] 800 unit tests passing
- [x] Eval run: 18 core scenarios, N=1, all green
- [x] Coverage report clean at 91%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
