### PR TITLE
Update PyPI package name to forge-guardrails, disable codecov PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Supports Ollama, llama-server (llama.cpp), Llamafile, and Anthropic as backends.
 ## Install
 
 ```bash
-pip install forge-llm                # core only
-pip install "forge-llm[anthropic]"   # + Anthropic client
+pip install forge-guardrails                # core only
+pip install "forge-guardrails[anthropic]"   # + Anthropic client
 ```
 
 For development:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "forge-llm"
+name = "forge-guardrails"
 version = "0.4.0"
 description = "A reliability layer for self-hosted LLM tool-calling. Guardrails, context management, and backend adapters for multi-step agentic workflows."
 requires-python = ">=3.12"


### PR DESCRIPTION
forge-llm and forgeai both collided with existing PyPI projects. forge-guardrails is live at https://pypi.org/project/forge-guardrails/