### PR TITLE
Fix server readiness: poll /props instead of /health (v0.4.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forge-guardrails"
-version = "0.4.0"
+version = "0.4.1"
 description = "A reliability layer for self-hosted LLM tool-calling. Guardrails, context management, and backend adapters for multi-step agentic workflows."
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/forge/server.py
+++ b/src/forge/server.py
@@ -407,12 +407,17 @@ class ServerManager:
     # ── health polling ──────────────────────────────────────────
 
     async def _wait_healthy(self, timeout: float = 120.0) -> None:
-        """Poll ``/health`` until the server is ready.
+        """Poll ``/props`` until the server is fully ready.
+
+        Uses ``/props`` rather than ``/health`` because llama-server's
+        middleware gates both endpoints behind ``is_ready``, but polling
+        ``/props`` directly confirms the model is loaded and serving —
+        eliminating any gap between health-ok and props-available.
 
         Raises:
-            RuntimeError: If the server doesn't become healthy within *timeout*.
+            RuntimeError: If the server doesn't become ready within *timeout*.
         """
-        url = f"http://localhost:{self._port}/health"
+        url = f"http://localhost:{self._port}/props"
         deadline = time.monotonic() + timeout
         async with httpx.AsyncClient(timeout=5.0) as client:
             while time.monotonic() < deadline:
@@ -420,13 +425,13 @@ class ServerManager:
                     resp = await client.get(url)
                     if resp.status_code == 200:
                         data = resp.json()
-                        if data.get("status") == "ok":
+                        if "default_generation_settings" in data:
                             return
                 except (httpx.ConnectError, httpx.ReadError, httpx.TimeoutException):
                     pass
                 await asyncio.sleep(2)
         raise RuntimeError(
-            f"Server did not become healthy within {timeout}s"
+            f"Server did not become ready within {timeout}s"
         )
 
 


### PR DESCRIPTION
## Summary

Fix a race condition where `_wait_healthy()` passes but `query_props()` returns 503 ("Loading model"). Observed on 2-slot kv-unified llama-server startup.

**Root cause:** `_wait_healthy()` polled `/health`, which returns `{"status": "ok"}` as soon as llama-server's `is_ready` flag is set. `query_props()` then hits `/props` immediately after — but in rare timing conditions, `/props` could still return 503.

**Fix:** `_wait_healthy()` now polls `/props` directly instead of `/health`. When `/props` returns 200 with `default_generation_settings`, the server is guaranteed ready for all subsequent calls. Same retry logic (2s interval, 120s timeout). One fix covers all budget modes (BACKEND, FORGE_FULL, FORGE_FAST, MANUAL).

**Version bump:** 0.4.0 → 0.4.1

## Test plan

- [x] 638 unit tests pass
- [x] Managed start with kv-unified + 2 slots: `_wait_healthy()` → `query_props()` returns n_ctx: 68608
- [x] forge-code TUI starts cleanly through `setup_backend()` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
