### PR TITLE
Rescue-parse Qwen Coder XML tool calls (issue #55)

### DIFF
--- a/src/forge/prompts/templates.py
+++ b/src/forge/prompts/templates.py
@@ -118,6 +118,56 @@ _THINK_TAG_RE = re.compile(
     r"\[THINK\].*?\[/THINK\]|<think>.*?</think>", re.DOTALL
 )
 
+# Qwen Coder XML tool call format.
+# <function=name>
+#   <parameter=key>value</parameter>
+#   <parameter=other>value</parameter>
+# </function>
+# Pattern adapted from Qwen's reference parser:
+# https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py
+_QWEN_FUNCTION_RE = re.compile(
+    r"<function=([^>\s]+)>(.*?)</function>", re.DOTALL
+)
+_QWEN_PARAMETER_RE = re.compile(
+    r"<parameter=([^>\s]+)>(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
+    re.DOTALL,
+)
+
+
+def _parse_qwen_xml_tool_calls(text: str, available_tools: list[str]) -> list[ToolCall]:
+    """Parse Qwen Coder XML-format tool calls from model output.
+
+    Handles the format emitted by Qwen3-Coder models (and occasionally other
+    models trained on similar data), with or without the outer <tool_call>
+    wrapper. Whitespace behavior matches Qwen's reference parser: one leading
+    and one trailing newline are stripped from each parameter value.
+
+    Type coercion is deferred to Pydantic — all parameter values are passed
+    as strings, and the tool's parameter model coerces at ToolCall construction.
+    """
+    found: list[ToolCall] = []
+    for fn_match in _QWEN_FUNCTION_RE.finditer(text):
+        tool_name = fn_match.group(1).strip()
+        if tool_name not in available_tools:
+            continue
+
+        body = fn_match.group(2)
+        args: dict[str, str] = {}
+        for param_match in _QWEN_PARAMETER_RE.finditer(body):
+            key = param_match.group(1).strip()
+            value = param_match.group(2)
+            # Strip the first newline after the opening tag and the last
+            # newline before the closing tag — matches Qwen's parser.
+            if value.startswith("\n"):
+                value = value[1:]
+            if value.endswith("\n"):
+                value = value[:-1]
+            args[key] = value
+
+        found.append(ToolCall(tool=tool_name, args=args))
+
+    return found
+
 
 def rescue_tool_call(text: str, available_tools: list[str]) -> list[ToolCall]:
     """Try to parse ToolCalls from a TextResponse that failed native FC.
@@ -129,6 +179,7 @@ def rescue_tool_call(text: str, available_tools: list[str]) -> list[ToolCall]:
     Parsing strategies (in order):
     1. Prompt-injected JSON: {"tool": "name", "args": {...}}
     2. Rehearsal syntax: tool_name[ARGS]{...}
+    3. Qwen Coder XML: <function=name><parameter=key>value</parameter></function>
     """
     # Strip think tags — the tool call may be after or outside thinking blocks
     cleaned = _THINK_TAG_RE.sub("", text).strip()
@@ -150,5 +201,9 @@ def rescue_tool_call(text: str, available_tools: list[str]) -> list[ToolCall]:
                         found.append(ToolCall(tool=tool_name, args=args))
                 except json.JSONDecodeError:
                     pass
+
+    # Strategy 3: Qwen Coder XML — <function=name><parameter=key>value</parameter></function>
+    if not found:
+        found = _parse_qwen_xml_tool_calls(cleaned, available_tools)
 
     return found

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -217,3 +217,85 @@ class TestRescueToolCall:
         assert len(result) >= 1
         assert result[0].tool == "fetch"
         assert result[0].args == {"a": 1}
+
+
+# ── Qwen Coder XML format ───────────────────────────────────────
+
+
+class TestQwenXmlRescue:
+    def test_single_parameter(self) -> None:
+        text = "<function=fetch>\n<parameter=query>hello world</parameter>\n</function>"
+        result = rescue_tool_call(text, ["fetch", "submit"])
+        assert len(result) == 1
+        assert result[0].tool == "fetch"
+        assert result[0].args == {"query": "hello world"}
+
+    def test_multiple_parameters(self) -> None:
+        text = (
+            "<function=fetch>\n"
+            "<parameter=query>hello</parameter>\n"
+            "<parameter=limit>10</parameter>\n"
+            "</function>"
+        )
+        result = rescue_tool_call(text, ["fetch", "submit"])
+        assert len(result) == 1
+        assert result[0].tool == "fetch"
+        assert result[0].args == {"query": "hello", "limit": "10"}
+
+    def test_multiline_parameter_value(self) -> None:
+        """Issue #55 reproducer — bash command spans multiple lines."""
+        text = (
+            "<function=bash>\n"
+            "<parameter=command>\n"
+            'find . -name "*.py" -exec grep -l "percentage" {} \\;\n'
+            "</parameter>\n"
+            "</function>"
+        )
+        result = rescue_tool_call(text, ["bash", "edit"])
+        assert len(result) == 1
+        assert result[0].tool == "bash"
+        # The leading/trailing newlines around the command are stripped
+        assert result[0].args["command"] == 'find . -name "*.py" -exec grep -l "percentage" {} \\;'
+
+    def test_multiple_function_calls(self) -> None:
+        text = (
+            "<function=fetch><parameter=q>one</parameter></function>\n"
+            "<function=submit><parameter=data>two</parameter></function>"
+        )
+        result = rescue_tool_call(text, ["fetch", "submit"])
+        assert len(result) == 2
+        assert result[0].tool == "fetch"
+        assert result[0].args == {"q": "one"}
+        assert result[1].tool == "submit"
+        assert result[1].args == {"data": "two"}
+
+    def test_unknown_tool_ignored(self) -> None:
+        text = "<function=unknown_tool><parameter=x>1</parameter></function>"
+        result = rescue_tool_call(text, ["fetch", "submit"])
+        assert result == []
+
+    def test_mixed_with_thinking(self) -> None:
+        text = (
+            "<think>I should call fetch here</think>\n"
+            "<function=fetch><parameter=query>weather</parameter></function>"
+        )
+        result = rescue_tool_call(text, ["fetch", "submit"])
+        assert len(result) == 1
+        assert result[0].tool == "fetch"
+        assert result[0].args == {"query": "weather"}
+
+    def test_malformed_unclosed_function_falls_through(self) -> None:
+        text = "<function=fetch><parameter=q>never closed"
+        result = rescue_tool_call(text, ["fetch", "submit"])
+        assert result == []
+
+    def test_json_preferred_over_qwen_xml(self) -> None:
+        """JSON extraction runs first; XML is only tried when JSON finds nothing."""
+        text = (
+            '{"tool": "fetch", "args": {"q": "json"}}\n'
+            "<function=submit><parameter=data>xml</parameter></function>"
+        )
+        result = rescue_tool_call(text, ["fetch", "submit"])
+        assert len(result) >= 1
+        assert result[0].tool == "fetch"
+        assert result[0].args == {"q": "json"}


### PR DESCRIPTION
## Summary

Closes #55  — models trained on Qwen Coder data (notably Qwen3-Coder 30B) intermittently emit tool calls in XML format that forge's existing parsers don't recognize, causing `ToolCallError: Retries exhausted` on otherwise-valid calls.

## Format

```xml
<function=bash>
<parameter=command>
grep -r "percentage" . --include="*.py"
</parameter>
</function>
```

## Fix

Adds a third rescue-parsing strategy in `rescue_tool_call`:
1. JSON (forge-style `{"tool": ..., "args": ...}`)
2. Rehearsal syntax (`tool_name[ARGS]{...}`)
3. **Qwen Coder XML** (this PR)

Regex patterns adapted from [Qwen's reference parser](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py). Whitespace handling matches the reference: one leading and one trailing newline stripped per parameter value. Type coercion deferred to Pydantic.

## Impact

In forge-code eval (v3 big run), Qwen3-Coder 30B dropped from ~95% to 85% pipeline pass rate — 15/135 runs failed, all from this XML format. Re-scoring those failed runs with the rescue parser rescues valid tool calls. Target: 85% → 93%+ pipeline.

**Confirmed working on inference rig** against the v3 failed runs.

## Test plan

- [x] 8 new unit tests (single param, multi param, multiline values, multiple calls, unknown tool, thinking-tag interaction, malformed fallthrough, strategy precedence)
- [x] 646 total tests pass
- [x] Manual validation on inference rig against failed Qwen Coder runs from v3 eval

🤖 Generated with [Claude Code](https://claude.com/claude-code)
