### PR TITLE
Fix AnthropicClient token count never synced to context manager

### DIFF
--- a/src/forge/core/inference.py
+++ b/src/forge/core/inference.py
@@ -32,12 +32,18 @@ _NUDGE_KIND_TO_TYPE: dict[str, MessageType] = {
 def _sync_token_count(client: LLMClient, context_manager: ContextManager) -> None:
     """Feed actual token count from the client into the context manager."""
     last_usage = getattr(client, "last_usage", None)
-    if not isinstance(last_usage, dict):
+    if not isinstance(last_usage, dict) or not last_usage:
         return
     slot_id = getattr(client, "_slot_id", None) or 0
     usage: TokenUsage | None = last_usage.get(slot_id)
     if usage is not None:
         context_manager.update_token_count(usage.total_tokens)
+        return
+    # AnthropicClient stores usage as {"input_tokens": int, "output_tokens": int}
+    input_tok = last_usage.get("input_tokens")
+    output_tok = last_usage.get("output_tokens")
+    if isinstance(input_tok, int) and isinstance(output_tok, int):
+        context_manager.update_token_count(input_tok + output_tok)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- `_sync_token_count()` in `inference.py` assumed `last_usage` is always `dict[int, TokenUsage]` (Ollama/Llamafile format)
- `AnthropicClient.last_usage` stores `{"input_tokens": int, "output_tokens": int}` — keyed by strings, not integer slot IDs
- The `.get(slot_id)` call always returned `None` for Anthropic models, so the context manager never learned real token counts

## Impact
- Compaction decisions were based solely on heuristics for Anthropic models
- Could cause context window overflow (API errors) or unnecessary compactions (degraded response quality)

## Fix
- Add a fallback path that detects the Anthropic usage format (`input_tokens`/`output_tokens` keys) and feeds the combined count to the context manager

## Test plan
- [ ] Verify AnthropicClient token counts are correctly passed to context manager
- [ ] Verify Ollama/Llamafile token counts still work as before
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)