### PR TITLE
Fix httpx connection pool leak in OllamaClient and LlamafileClient

### DIFF
--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -167,6 +167,10 @@ class LlamafileClient:
 
         self.last_usage: dict[int, TokenUsage] = {}
 
+    async def aclose(self) -> None:
+        """Close the underlying httpx connection pool."""
+        await self._http.aclose()
+
         if mode in ("native", "prompt"):
             self.resolved_mode: str | None = mode
         else:

--- a/src/forge/clients/ollama.py
+++ b/src/forge/clients/ollama.py
@@ -78,6 +78,10 @@ class OllamaClient:
         self._think_resolved: bool = think is not None
         self.last_usage: dict[int, TokenUsage] = {}
 
+    async def aclose(self) -> None:
+        """Close the underlying httpx connection pool."""
+        await self._http.aclose()
+
     # Sampling fields recognized in per-call overrides. ``seed`` is
     # accepted only as a per-call override (not an instance field).
     _SAMPLING_FIELDS = (


### PR DESCRIPTION
## Summary
- `OllamaClient` and `LlamafileClient` both create `httpx.AsyncClient` in `__init__` but never close it
- `httpx.AsyncClient` holds open connection pools and sockets — without explicit cleanup, connections leak over time
- Add `aclose()` method to both clients so callers can properly clean up the connection pool on shutdown

## Impact
- In long-running processes, leaked connections accumulate, consuming file descriptors
- On graceful shutdown, pending connections may not be properly terminated, leading to `ResourceWarning: unclosed connection` warnings

## Test plan
- [ ] Verify `aclose()` properly closes the httpx client
- [ ] Verify no resource warnings after shutdown
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)