### PR TITLE
Fix IndexError on empty tool_calls list in proxy convert

### DIFF
--- a/src/forge/proxy/convert.py
+++ b/src/forge/proxy/convert.py
@@ -97,6 +97,8 @@ def tool_calls_to_openai(
     model: str = "forge",
 ) -> dict[str, Any]:
     """Convert forge ToolCalls to an OpenAI chat completions response object."""
+    if not tool_calls:
+        return text_response_to_openai("", model=model)
     tc_list = []
     for i, tc in enumerate(tool_calls):
         tc_list.append({
@@ -157,6 +159,8 @@ def tool_calls_to_sse_events(
     Returns the complete list of chunk dicts ready to be formatted as
     SSE data lines. The caller handles the actual SSE wire format.
     """
+    if not tool_calls:
+        return text_to_sse_events("", model=model)
     cmpl_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
     events: list[dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary
- `tool_calls_to_openai()` and `tool_calls_to_sse_events()` both access `tool_calls[0]` without checking if the list is empty
- If an upstream filtering step ever removes all tool calls, this raises an unhandled `IndexError`
- Add early-return guards that fall back to the corresponding text response helpers when the list is empty

## Impact
- Without this fix, an empty `tool_calls` list would crash the proxy's response serialization with a 500 error instead of gracefully returning an empty response

## Test plan
- [ ] Call `tool_calls_to_openai([])` and verify it returns a valid response without IndexError
- [ ] Call `tool_calls_to_sse_events([])` and verify it returns valid SSE events without IndexError
- [ ] Verify normal tool call conversion still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)