### PR TITLE
Fix unhandled JSONDecodeError in AnthropicClient tool call parsing

### DIFF
--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -110,7 +110,10 @@ class AnthropicClient:
                         func = tc["function"]
                         args = func.get("arguments", "{}")
                         if isinstance(args, str):
-                            args = json.loads(args)
+                            try:
+                                args = json.loads(args)
+                            except json.JSONDecodeError:
+                                args = {}
                         tc_id = tc.get("id", f"toolu_{len(converted)}")
                         blocks.append({
                             "type": "tool_use",


### PR DESCRIPTION
## Summary
- `json.loads(args)` in `_convert_messages` was called without a try/except when parsing tool call arguments
- Malformed JSON in arguments would raise an unhandled `json.JSONDecodeError`, crashing the inference loop with an unhelpful traceback
- Wrap in try/except and fall back to empty dict on parse failure, consistent with LlamafileClient's handling

## Impact
- Without this fix, malformed tool call arguments from upstream systems would crash the entire inference loop instead of producing a recoverable error

## Test plan
- [ ] Verify malformed JSON in tool call arguments doesn't crash the client
- [ ] Verify valid JSON arguments still parse correctly
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)