### PR TITLE
Replace assert with proper error handling in tool execution loop

### DIFF
--- a/src/forge/core/runner.py
+++ b/src/forge/core/runner.py
@@ -353,7 +353,11 @@ class WorkflowRunner:
             if batch_had_error:
                 error_tracker.record_result(success=False)
                 if error_tracker.tool_errors_exhausted:
-                    assert last_error is not None
+                    if last_error is None:
+                        raise ToolExecutionError(
+                            "unknown",
+                            cause=RuntimeError("batch_had_error but last_error is None"),
+                        )
                     raise ToolExecutionError(
                         last_error[0],
                         cause=last_error[1],


### PR DESCRIPTION
## Summary
- `assert last_error is not None` was used as a runtime guard in the tool execution error path
- Python strips `assert` statements when run with `-O` (optimized mode), which some deployments use
- If the invariant were violated under `-O`, `last_error[0]` would raise an opaque `TypeError` instead of a meaningful error

Replace with an explicit if-check that raises `ToolExecutionError` with a clear diagnostic message.

## Test plan
- [ ] Verify tool execution errors still propagate correctly
- [ ] Verify behavior under `python -O` is correct
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)