### PR TITLE
proxy: discover vLLM served-model-name in external mode instead of sending "default"

### DIFF
--- a/src/forge/clients/vllm.py
+++ b/src/forge/clients/vllm.py
@@ -332,3 +332,25 @@ class VLLMClient:
                 500, f"/v1/models entry missing max_model_len: {models[0]}",
             )
         return int(max_model_len)
+
+    async def get_served_model_name(self) -> str | None:
+        """Query /v1/models for the name vLLM is actually serving.
+
+        vLLM validates the request ``model`` field against its
+        ``--served-model-name`` aliases and returns 404 for an unknown name —
+        unlike llama.cpp, which ignores the field entirely. In external mode
+        the proxy has no model path to send, so it discovers the served
+        identity here (the first ``data[].id``) rather than guessing.
+
+        Returns None if the endpoint reports no models or is unreachable, in
+        which case the caller keeps its placeholder identity.
+        """
+        try:
+            resp = await self._http.get(f"{self.base_url}/models")
+            resp.raise_for_status()
+        except httpx.HTTPError:
+            return None
+        models = resp.json().get("data") or []
+        if not models:
+            return None
+        return models[0].get("id")

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -246,6 +246,22 @@ class ProxyServer:
                 model_path="default",
                 base_url=base,
             )
+            # Unlike llama.cpp, vLLM validates the wire `model` field against
+            # its --served-model-name aliases (404 on mismatch). External mode
+            # has no model path to send, so discover the served identity from
+            # /v1/models instead of shipping the "default" placeholder.
+            served = await client.get_served_model_name()
+            if served:
+                logger.info("Discovered vLLM served model name: %s", served)
+                client.model_path = served
+                client.model = served
+            else:
+                logger.warning(
+                    "Could not discover a served model name from %s/models; "
+                    "sending placeholder 'default' (vLLM will 404 if it "
+                    "validates the model field)",
+                    base,
+                )
         else:
             # Should be unreachable per __init__ validation
             raise ValueError(f"backend={self._backend!r} not valid in external mode")

--- a/tests/unit/test_vllm_client.py
+++ b/tests/unit/test_vllm_client.py
@@ -391,6 +391,31 @@ class TestGetContextLength:
             await client.get_context_length()
 
 
+# ── get_served_model_name ──────────────────────────────────────
+
+
+class TestGetServedModelName:
+    @pytest.mark.asyncio
+    async def test_returns_first_model_id(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "local-primary", "max_model_len": 262144}],
+        })
+        assert await client.get_served_model_name() == "local-primary"
+
+    @pytest.mark.asyncio
+    async def test_empty_data_returns_none(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({"data": []})
+        assert await client.get_served_model_name() is None
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_none(self) -> None:
+        client = _make_client()
+        client._http.get.side_effect = httpx.ConnectError("refused")
+        assert await client.get_served_model_name() is None
+
+
 # ── edge cases ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

In external mode (`forge-proxy --backend vllm --url ...`), the proxy hardcodes the `VLLMClient` with `model_path="default"`, and `send()` puts that value in the request `model` field.

Unlike llama.cpp — which ignores the `model` field — vLLM **validates** it against its `--served-model-name` aliases and returns **404** on a mismatch. So any vLLM server started with a custom `--served-model-name` rejects every proxied request. (This is why the llama.cpp-based path never surfaced it.)

## Fix

- Add `VLLMClient.get_served_model_name()` — queries `/v1/models` and returns the first `data[].id`, or `None` if the endpoint reports no models / is unreachable.
- External-mode setup in `proxy.py` now discovers the served name and adopts it (`client.model_path = client.model = served`). If discovery fails it falls back to the `"default"` placeholder with a warning rather than failing hard.

No new CLI flags. +3 unit tests; full suite passes (974).

## Validation

Tested against a live production vLLM on NVIDIA GB10 (Blackwell), serving a 122B-A10B MoE (NVFP4) under `--served-model-name=local-primary`, `max_model_len 262144`. forge-proxy on `:8001` → `--url http://localhost:8000`.

Startup log: `Discovered vLLM served model name: local-primary` ✅

All three paths returned HTTP 200:
1. **No-tools chat** — normal completion, `finish_reason: stop`. (Would 404 on `model "default"` without this patch.)
2. **Tool request** — clean `get_weather(city="Paris")`, `finish_reason: tool_calls`.
3. **Conversational with tools present** — plain text, synthetic-`respond` inject+strip works (`Stripping respond() call, returning as text`).