### PR TITLE
feat: Add Dockerfile for containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM python:3.13-alpine3.23 AS builder
+
+RUN pip install --root-user-action=ignore --no-cache-dir --upgrade pip \
+    && pip install --root-user-action=ignore --no-cache-dir uv
+
+ENV UV_LINK_MODE=copy
+
+WORKDIR /app
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --extra anthropic --no-install-project --no-dev
+
+COPY pyproject.toml LICENSE README.md ./
+COPY src/ ./src/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --extra anthropic --no-dev
+
+
+FROM python:3.13-alpine3.23
+LABEL org.opencontainers.image.title="Forge Proxy" \
+    org.opencontainers.image.description="A reliability layer for self-hosted LLM tool-calling" \
+    org.opencontainers.image.url="https://github.com/antoinezambelli/forge" \
+    org.opencontainers.image.source="https://github.com/antoinezambelli/forge" \
+    org.opencontainers.image.vendor="Antoine Zambelli" \
+    org.opencontainers.image.licenses="MIT"
+ENV PYTHONUNBUFFERED=1
+
+RUN apk add --no-cache ca-certificates \
+    && addgroup -g 1000 appuser \
+    && adduser -D -u 1000 -G appuser appuser
+
+COPY --from=builder --chown=appuser:appuser /app /app
+
+WORKDIR /app
+
+USER appuser
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+HEALTHCHECK \
+    --interval=15s \
+    --timeout=5s \
+    --start-period=5s \
+    --retries=3 \
+    CMD ["wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8081/health"]
+
+EXPOSE 8081
+
+ENTRYPOINT ["forge-proxy", "--host", "0.0.0.0", "--port", "8081"]

--- a/README.md
+++ b/README.md
@@ -174,6 +174,25 @@ For the full guardrail surface, use `WorkflowRunner` directly. The proxy trades 
 | `--budget-tokens N` | — | Manual token budget (requires `--budget-mode manual`) |
 | `--serialize` / `--no-serialize` | auto | Force request serialization (single-slot backends) |
 
+### Docker
+
+You can run the forge proxy as a Docker container.
+
+**Build the image:**
+
+```bash
+docker build -t forge-proxy .
+```
+
+**Run the container:**
+
+```bash
+# Connect to an external backend (e.g. vLLM hosted on the same machine)
+docker run -p 8081:8081 forge-proxy --backend-url http://host.docker.internal:8000 --budget-mode manual --budget-tokens 8192
+```
+
+Note: If your backend is running on `localhost` of the host machine, use `http://host.docker.internal:PORT` (on macOS/Windows) or the host's IP address to allow the container to reach it.
+
 ## Backends
 
 | Backend | Best for | Native FC? |


### PR DESCRIPTION
Introduces a multi-stage Dockerfile to build and package the Forge Proxy application.

The builder stage utilizes `uv` for efficient dependency management, ensuring consistent and fast package installations. The final runtime image is based on a minimal Python Alpine image, configured with OCI labels for improved metadata.

Enhances security by running the application as a non-root user (`appuser`) and sets up a robust health check to monitor container readiness. Defines the entrypoint for simplified deployment.