### PR TITLE
fix(proxy): model name pass-through for external backends

### DIFF
--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -286,8 +286,9 @@ class LlamafileClient:
             await self._resolve_and_send(messages, tools, sampling)
         mode = self.resolved_mode
 
+        model_name = (sampling or {}).get("model") or self.model
         body: dict[str, Any] = {
-            "model": self.model,
+            "model": model_name,
             "stream": True,
             "stream_options": {"include_usage": True},
             "cache_prompt": self._cache_prompt,
@@ -468,8 +469,9 @@ class LlamafileClient:
     ) -> LLMResponse:
         """Send using native function calling (OpenAI tools parameter)."""
         merged = _merge_consecutive(messages)
+        model_name = (sampling or {}).get("model") or self.model
         body: dict[str, Any] = {
-            "model": self.model,
+            "model": model_name,
             "messages": merged,
             "cache_prompt": self._cache_prompt,
         }
@@ -534,8 +536,9 @@ class LlamafileClient:
                 "content": tool_prompt + "\n\n" + prepared[0]["content"],
             }
 
+        model_name = (sampling or {}).get("model") or self.model
         body: dict[str, Any] = {
-            "model": self.model,
+            "model": model_name,
             "messages": prepared,
             "cache_prompt": self._cache_prompt,
         }

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -33,7 +33,7 @@ logger = logging.getLogger("forge.proxy")
 _SAMPLING_FIELDS = (
     "temperature", "top_p", "top_k", "min_p",
     "repeat_penalty", "presence_penalty", "seed",
-    "chat_template_kwargs",
+    "chat_template_kwargs", "model",
 )
 
 

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -167,7 +167,7 @@ class ProxyServer:
             # GGUF path. "default" is a placeholder identity for the wire
             # model field (llama-server ignores it) and JSONL model field.
             client = LlamafileClient(
-                gguf_path="default",
+                gguf_path=self._model or "default",
                 base_url=base,
                 mode="native",
             )

--- a/tests/unit/test_proxy_handler.py
+++ b/tests/unit/test_proxy_handler.py
@@ -239,11 +239,11 @@ class TestSamplingPlumbing:
 
         client.send.assert_called_once()
         sampling = client.send.call_args.kwargs["sampling"]
-        assert sampling == {"temperature": 0.5, "top_p": 0.9}
+        assert sampling == {"temperature": 0.5, "top_p": 0.9, "model": "test"}
 
     @pytest.mark.asyncio
     async def test_no_tools_path_no_sampling_fields(self):
-        """No sampling fields in body → sampling=None."""
+        """No sampling fields in body → sampling contains only model."""
         client = _mock_client(TextResponse(content="ok"))
 
         await handle_chat_completions(
@@ -251,7 +251,7 @@ class TestSamplingPlumbing:
         )
 
         sampling = client.send.call_args.kwargs["sampling"]
-        assert sampling is None
+        assert sampling == {"model": "test"}
 
     @pytest.mark.asyncio
     async def test_tools_path_passes_sampling_to_run_inference(self, monkeypatch):
@@ -279,7 +279,7 @@ class TestSamplingPlumbing:
 
         await handle_chat_completions(body, client, _context_manager(), max_retries=1)
 
-        assert captured["sampling"] == {"temperature": 0.3, "seed": 42}
+        assert captured["sampling"] == {"temperature": 0.3, "seed": 42, "model": "test"}
 
     @pytest.mark.asyncio
     async def test_per_call_sampling_does_not_mutate_client(self):
@@ -291,9 +291,9 @@ class TestSamplingPlumbing:
         body1["temperature"] = 0.99
         await handle_chat_completions(body1, client, _context_manager(), max_retries=1)
         first_sampling = client.send.call_args.kwargs["sampling"]
-        assert first_sampling == {"temperature": 0.99}
+        assert first_sampling == {"temperature": 0.99, "model": "test"}
 
         # Second request: no sampling fields.
         await handle_chat_completions(_body(), client, _context_manager(), max_retries=1)
         second_sampling = client.send.call_args.kwargs["sampling"]
-        assert second_sampling is None
+        assert second_sampling == {"model": "test"}


### PR DESCRIPTION
- Forwards the `model` field from inbound requests to the backend client.
- Enables dynamic model selection, improving compatibility with multi-model backends like vLLM.
- Allows configuration of a default model name for external backends via the CLI flag.
- Addresses routing errors that occurred when a static 'default' model name was previously sent.