### PR TITLE
feat(proxy): implement real token usage reporting

### DIFF
--- a/src/forge/core/inference.py
+++ b/src/forge/core/inference.py
@@ -29,13 +29,18 @@ _NUDGE_KIND_TO_TYPE: dict[str, MessageType] = {
 }
 
 
-def _sync_token_count(client: LLMClient, context_manager: ContextManager) -> None:
-    """Feed actual token count from the client into the context manager."""
+def _get_usage(client: LLMClient) -> TokenUsage | None:
+    """Extract actual token count from the client."""
     last_usage = getattr(client, "last_usage", None)
     if not isinstance(last_usage, dict):
-        return
+        return None
     slot_id = getattr(client, "_slot_id", None) or 0
-    usage: TokenUsage | None = last_usage.get(slot_id)
+    return last_usage.get(slot_id)
+
+
+def _sync_token_count(client: LLMClient, context_manager: ContextManager) -> None:
+    """Feed actual token count from the client into the context manager."""
+    usage = _get_usage(client)
     if usage is not None:
         context_manager.update_token_count(usage.total_tokens)
 
@@ -49,11 +54,13 @@ class InferenceResult:
         new_messages: Messages generated during this call (assistant text from
             failed attempts, nudges, and the final assistant response). The
             caller should append these to their message history.
+        usage: Token usage for the final successful attempt.
         tool_call_counter: Updated counter for generating unique call IDs.
     """
 
     response: list[ToolCall] | TextResponse
     new_messages: list[Message] = field(default_factory=list)
+    usage: TokenUsage | None = None
     tool_call_counter: int = 0
     attempts: int = 1
 
@@ -215,6 +222,7 @@ async def run_inference(
             return InferenceResult(
                 response=validated,
                 new_messages=new_messages,
+                usage=_get_usage(client),
                 tool_call_counter=tool_call_counter,
                 attempts=attempts,
             )

--- a/src/forge/proxy/convert.py
+++ b/src/forge/proxy/convert.py
@@ -95,6 +95,7 @@ def openai_to_messages(openai_messages: list[dict[str, Any]]) -> list[Message]:
 def tool_calls_to_openai(
     tool_calls: list[ToolCall],
     model: str = "forge",
+    usage: Any | None = None,
 ) -> dict[str, Any]:
     """Convert forge ToolCalls to an OpenAI chat completions response object."""
     tc_list = []
@@ -108,7 +109,7 @@ def tool_calls_to_openai(
             },
         })
 
-    return {
+    response = {
         "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
         "object": "chat.completion",
         "model": model,
@@ -124,13 +125,23 @@ def tool_calls_to_openai(
         "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
     }
 
+    if usage:
+        response["usage"] = {
+            "prompt_tokens": getattr(usage, "prompt_tokens", 0),
+            "completion_tokens": getattr(usage, "completion_tokens", 0),
+            "total_tokens": getattr(usage, "total_tokens", 0),
+        }
+
+    return response
+
 
 def text_response_to_openai(
     text: str,
     model: str = "forge",
+    usage: Any | None = None,
 ) -> dict[str, Any]:
     """Convert a text response to an OpenAI chat completions response object."""
-    return {
+    response = {
         "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
         "object": "chat.completion",
         "model": model,
@@ -145,12 +156,22 @@ def text_response_to_openai(
         "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
     }
 
+    if usage:
+        response["usage"] = {
+            "prompt_tokens": getattr(usage, "prompt_tokens", 0),
+            "completion_tokens": getattr(usage, "completion_tokens", 0),
+            "total_tokens": getattr(usage, "total_tokens", 0),
+        }
+
+    return response
+
 
 # ── SSE streaming helpers ────────────────────────────────────────
 
 def tool_calls_to_sse_events(
     tool_calls: list[ToolCall],
     model: str = "forge",
+    usage: Any | None = None,
 ) -> list[dict[str, Any]]:
     """Convert forge ToolCalls to a sequence of SSE chunk objects.
 
@@ -199,7 +220,7 @@ def tool_calls_to_sse_events(
         })
 
     # Final chunk with finish_reason
-    events.append({
+    final_event = {
         "id": cmpl_id,
         "object": "chat.completion.chunk",
         "model": model,
@@ -208,8 +229,16 @@ def tool_calls_to_sse_events(
             "delta": {},
             "finish_reason": "tool_calls",
         }],
-    })
+    }
 
+    if usage:
+        final_event["usage"] = {
+            "prompt_tokens": getattr(usage, "prompt_tokens", 0),
+            "completion_tokens": getattr(usage, "completion_tokens", 0),
+            "total_tokens": getattr(usage, "total_tokens", 0),
+        }
+
+    events.append(final_event)
     return events
 
 
@@ -217,6 +246,7 @@ def text_to_sse_events(
     text: str,
     model: str = "forge",
     chunk_size: int = 0,
+    usage: Any | None = None,
 ) -> list[dict[str, Any]]:
     """Convert a text response to SSE chunk objects.
 
@@ -247,7 +277,7 @@ def text_to_sse_events(
         })
 
     # Final chunk
-    events.append({
+    final_event = {
         "id": cmpl_id,
         "object": "chat.completion.chunk",
         "model": model,
@@ -256,6 +286,14 @@ def text_to_sse_events(
             "delta": {},
             "finish_reason": "stop",
         }],
-    })
+    }
 
+    if usage:
+        final_event["usage"] = {
+            "prompt_tokens": getattr(usage, "prompt_tokens", 0),
+            "completion_tokens": getattr(usage, "completion_tokens", 0),
+            "total_tokens": getattr(usage, "total_tokens", 0),
+        }
+
+    events.append(final_event)
     return events

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -121,10 +121,16 @@ async def handle_chat_completions(
         api_format = getattr(client, "api_format", "ollama")
         api_messages = fold_and_serialize(messages, api_format)
         response = await client.send(api_messages, tools=None, sampling=sampling)
+        
+        # Capture usage for passthrough path
+        last_usage = getattr(client, "last_usage", None)
+        slot_id = getattr(client, "_slot_id", None) or 0
+        usage = last_usage.get(slot_id) if isinstance(last_usage, dict) else None
+
         text = response.content if isinstance(response, TextResponse) else ""
         if is_stream:
-            return text_to_sse_events(text, model=model_name)
-        return text_response_to_openai(text, model=model_name)
+            return text_to_sse_events(text, model=model_name, usage=usage)
+        return text_response_to_openai(text, model=model_name, usage=usage)
 
     # Set up guardrails
     validator = ResponseValidator(tool_names, rescue_enabled=rescue_enabled)
@@ -147,9 +153,15 @@ async def handle_chat_completions(
         # error. The client's own agentic loop can decide what to do.
         raw = exc.raw_response or ""
         logger.warning("Retries exhausted, passing through text: %.120s", raw)
+        
+        # Try to capture usage even on failure if available
+        last_usage = getattr(client, "last_usage", None)
+        slot_id = getattr(client, "_slot_id", None) or 0
+        usage = last_usage.get(slot_id) if isinstance(last_usage, dict) else None
+
         if is_stream:
-            return text_to_sse_events(raw, model=model_name)
-        return text_response_to_openai(raw, model=model_name)
+            return text_to_sse_events(raw, model=model_name, usage=usage)
+        return text_response_to_openai(raw, model=model_name, usage=usage)
 
     # run_inference returns None when max_attempts exhausted
     if result is None:
@@ -158,6 +170,7 @@ async def handle_chat_completions(
         return text_response_to_openai("", model=model_name)
 
     tool_calls = result.response
+    usage = result.usage
 
     # Strip respond() calls — convert to plain text for the client.
     # If the model called respond(message="..."), the client sees a
@@ -170,17 +183,17 @@ async def handle_chat_completions(
         text = respond_calls[0].args.get("message", "")
         logger.info("Stripping respond() call, returning as text")
         if is_stream:
-            return text_to_sse_events(text, model=model_name)
-        return text_response_to_openai(text, model=model_name)
+            return text_to_sse_events(text, model=model_name, usage=usage)
+        return text_response_to_openai(text, model=model_name, usage=usage)
 
     if other_calls:
         # Real tool calls (possibly mixed with respond) — return the
         # real tool calls only, drop respond.
         if is_stream:
-            return tool_calls_to_sse_events(other_calls, model=model_name)
-        return tool_calls_to_openai(other_calls, model=model_name)
+            return tool_calls_to_sse_events(other_calls, model=model_name, usage=usage)
+        return tool_calls_to_openai(other_calls, model=model_name, usage=usage)
 
     # Shouldn't happen, but handle empty tool_calls gracefully
     if is_stream:
-        return text_to_sse_events("", model=model_name)
-    return text_response_to_openai("", model=model_name)
+        return text_to_sse_events("", model=model_name, usage=usage)
+    return text_response_to_openai("", model=model_name, usage=usage)

--- a/tests/unit/test_proxy_handler.py
+++ b/tests/unit/test_proxy_handler.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 from forge.context.manager import ContextManager
 from forge.context.strategies import NoCompact
 from forge.core.workflow import TextResponse, ToolCall
+from forge.clients.base import TokenUsage
 from forge.proxy.handler import handle_chat_completions, _extract_tool_specs
 
 
@@ -17,6 +18,8 @@ def _mock_client(response):
     client = AsyncMock()
     client.api_format = "ollama"
     client.send = AsyncMock(return_value=response)
+    client.last_usage = {}
+    client._slot_id = 0
     return client
 
 
@@ -118,6 +121,8 @@ class TestWithTools:
     async def test_tool_call_returned(self):
         """Valid tool call is returned in OpenAI format."""
         client = _mock_client([ToolCall(tool="search", args={"q": "test"})])
+        client.last_usage = {0: TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)}
+        
         result = await handle_chat_completions(
             _body(tools=[_tool_def("search")]), client, _context_manager(),
         )
@@ -125,22 +130,28 @@ class TestWithTools:
         assert len(tc) == 1
         assert tc[0]["function"]["name"] == "search"
         assert result["choices"][0]["finish_reason"] == "tool_calls"
+        assert result["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
 
     @pytest.mark.asyncio
     async def test_tool_call_stream(self):
         """Valid tool call returns SSE events."""
         client = _mock_client([ToolCall(tool="search", args={})])
+        client.last_usage = {0: TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)}
+        
         result = await handle_chat_completions(
             _body(tools=[_tool_def("search")], stream=True),
             client, _context_manager(),
         )
         assert isinstance(result, list)
         assert result[-1]["choices"][0]["finish_reason"] == "tool_calls"
+        assert result[-1]["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
 
     @pytest.mark.asyncio
     async def test_respond_tool_auto_injected(self):
         """Respond tool is injected — model calling respond returns text."""
         client = _mock_client([ToolCall(tool="respond", args={"message": "Hi!"})])
+        client.last_usage = {0: TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)}
+        
         result = await handle_chat_completions(
             _body(tools=[_tool_def("search")]), client, _context_manager(),
         )
@@ -148,17 +159,21 @@ class TestWithTools:
         assert result["choices"][0]["message"]["content"] == "Hi!"
         assert result["choices"][0]["finish_reason"] == "stop"
         assert "tool_calls" not in result["choices"][0]["message"]
+        assert result["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
 
     @pytest.mark.asyncio
     async def test_respond_stripped_in_stream(self):
         """Respond call in stream mode returns text SSE events."""
         client = _mock_client([ToolCall(tool="respond", args={"message": "Hi!"})])
+        client.last_usage = {0: TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)}
+        
         result = await handle_chat_completions(
             _body(tools=[_tool_def("search")], stream=True),
             client, _context_manager(),
         )
         assert isinstance(result, list)
         assert result[-1]["choices"][0]["finish_reason"] == "stop"
+        assert result[-1]["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
 
     @pytest.mark.asyncio
     async def test_mixed_respond_and_tool_calls(self):
@@ -167,23 +182,29 @@ class TestWithTools:
             ToolCall(tool="search", args={"q": "test"}),
             ToolCall(tool="respond", args={"message": "also this"}),
         ])
+        client.last_usage = {0: TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)}
+        
         result = await handle_chat_completions(
             _body(tools=[_tool_def("search")]), client, _context_manager(),
         )
         tc = result["choices"][0]["message"]["tool_calls"]
         assert len(tc) == 1
         assert tc[0]["function"]["name"] == "search"
+        assert result["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
 
     @pytest.mark.asyncio
     async def test_respond_not_double_injected(self):
         """If client already provides respond tool, don't inject again."""
         client = _mock_client([ToolCall(tool="respond", args={"message": "Hi!"})])
+        client.last_usage = {0: TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)}
+        
         tools = [_tool_def("search"), _tool_def("respond")]
         result = await handle_chat_completions(
             _body(tools=tools), client, _context_manager(),
         )
         # Should still work — respond stripped to text
         assert result["choices"][0]["message"]["content"] == "Hi!"
+        assert result["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
 
 
 # ── Error paths ─────────────────────────────────────────────
@@ -194,9 +215,8 @@ class TestErrorPaths:
     async def test_retries_exhausted_returns_text(self):
         """When retries are exhausted, last text is returned to client."""
         # Model always returns text — will exhaust retries
-        client = AsyncMock()
-        client.api_format = "ollama"
-        client.send = AsyncMock(return_value=TextResponse(content="I can't do that"))
+        client = _mock_client(TextResponse(content="I can't do that"))
+        client.last_usage = {0: TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)}
         result = await handle_chat_completions(
             _body(tools=[_tool_def("search")]),
             client, _context_manager(), max_retries=1,
@@ -204,13 +224,13 @@ class TestErrorPaths:
         # Should return the text rather than an error
         assert result["choices"][0]["message"]["content"] == "I can't do that"
         assert result["choices"][0]["finish_reason"] == "stop"
+        assert result["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
 
     @pytest.mark.asyncio
     async def test_retries_exhausted_stream(self):
         """Retries exhausted in stream mode returns text SSE events."""
-        client = AsyncMock()
-        client.api_format = "ollama"
-        client.send = AsyncMock(return_value=TextResponse(content="nope"))
+        client = _mock_client(TextResponse(content="nope"))
+        client.last_usage = {0: TokenUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)}
         result = await handle_chat_completions(
             _body(tools=[_tool_def("search")], stream=True),
             client, _context_manager(), max_retries=1,
@@ -222,6 +242,7 @@ class TestErrorPaths:
             if e["choices"][0].get("delta", {}).get("content")
         ]
         assert len(content_events) > 0
+        assert result[-1]["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
 
 
 class TestSamplingPlumbing:
@@ -231,15 +252,17 @@ class TestSamplingPlumbing:
     async def test_no_tools_path_passes_sampling(self):
         """Inbound body sampling fields reach client.send on the no-tools path."""
         client = _mock_client(TextResponse(content="ok"))
+        client.last_usage = {0: TokenUsage(1, 1, 2)}
         body = _body(messages=[{"role": "user", "content": "hi"}])
         body["temperature"] = 0.5
         body["top_p"] = 0.9
 
-        await handle_chat_completions(body, client, _context_manager(), max_retries=1)
+        result = await handle_chat_completions(body, client, _context_manager(), max_retries=1)
 
         client.send.assert_called_once()
         sampling = client.send.call_args.kwargs["sampling"]
         assert sampling == {"temperature": 0.5, "top_p": 0.9, "model": "test"}
+        assert result["usage"] == {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
 
     @pytest.mark.asyncio
     async def test_no_tools_path_no_sampling_fields(self):
@@ -265,6 +288,7 @@ class TestSamplingPlumbing:
             return InferenceResult(
                 response=[ToolCall(tool="search", args={"q": "x"})],
                 new_messages=[],
+                usage=TokenUsage(10, 5, 15),
                 tool_call_counter=0,
                 attempts=1,
             )
@@ -277,9 +301,10 @@ class TestSamplingPlumbing:
         body["seed"] = 42
         body["temperature"] = 0.3
 
-        await handle_chat_completions(body, client, _context_manager(), max_retries=1)
+        result = await handle_chat_completions(body, client, _context_manager(), max_retries=1)
 
         assert captured["sampling"] == {"temperature": 0.3, "seed": 42, "model": "test"}
+        assert result["usage"] == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
 
     @pytest.mark.asyncio
     async def test_per_call_sampling_does_not_mutate_client(self):


### PR DESCRIPTION
- Extract actual token counts from backend clients using the new _get_usage helper.
- Propagate usage statistics through InferenceResult to the proxy handler.
- Include 'usage' object in OpenAI-compatible responses for both standard and streaming paths.
- Update proxy handler unit tests to verify usage data integrity using TokenUsage objects.