### PR TITLE
feat(proxy): add Anthropic API support as first-class backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.0
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,12 @@ repos:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: pii-check
+        name: PII/sensitive data check
+        entry: python3 scripts/check_pii.py
+        language: system
+        stages: [commit]
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pytest-asyncio",
     "anthropic>=0.40",
     "mpmath",
+    "ruff>=0.8",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -66,3 +67,32 @@ omit = [
     "src/forge/proxy/proxy.py",
     "src/forge/proxy/__main__.py",
 ]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "F",      # pyflakes
+    "I",      # isort
+    "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "SIM",    # flake8-simplify
+    "RUF",    # ruff rules
+]
+ignore = [
+    "E501",   # line too long (ruff handles formatting)
+    "SIM108", # use ternary instead of if-else
+    "SIM105", # suppress is context-dependent (asyncio CancelledError)
+    "UP042",  # StrEnum not available on 3.11
+    "RUF001", # ambiguous chars (EN dash, etc. — intentional)
+    "RUF002", # ambiguous chars (multiplication sign — intentional)
+    "RUF022", # __all__ ordering — manual by category
+    "E731",   # lambda assignment — legacy code
+]
+exclude = ["tests/eval"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["forge"]

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Pre-commit hook: scan staged files for PII and sensitive data.
+
+Exit 0 if clean, exit 1 if suspicious content found.
+"""
+
+import re
+import subprocess
+import sys
+
+# Patterns that should never appear in committed code
+PATTERNS = [
+    ("macOS user path", r"/Users/\w+[^/]*(?:/\.ssh|/\.gnupg|/\.local|/\.zsh|/\.cache|/\.npm|/\.config)"),
+    ("zsh history", r"\.zsh_history"),
+    ("SSH private key", r"ssh-(rsa|ed25519|ecdsa|dsa)\s"),
+    ("PEM private key", r"-----BEGIN.*PRIVATE KEY-----"),
+    ("netrc file", r"machine\s+\S+\s+login"),
+    ("email address (non-noreply)", r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?<!noreply)"),
+    ("phone number", r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b"),
+    ("password/secret assignment", r"(?:password|secret|api_key|token)\s*[:=]\s*['\"]?\w{8,}['\"]?"),
+    ("AWS credentials", r"(?:AKIA|ASIA)[A-Z0-9]{16}"),
+    ("private IP range", r"\b(?:10\.|192\.168\.|172\.(?:1[6-9]|2\d|3[01])\.)\d{1,3}\.\d{1,3}\b"),
+]
+
+
+def main() -> int:
+    # Get list of staged files (added/modified only)
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACDMR"],
+        capture_output=True,
+        text=True,
+    )
+    files = [f for f in result.stdout.strip().split("\n") if f]
+    if not files:
+        return 0
+
+    # Skip ourselves and other PII checkers to avoid false positives
+    skip_files = {"scripts/check_pii.py"}
+    files = [f for f in files if f not in skip_files]
+    if not files:
+        return 0
+
+    # Get the staged content for non-skipped files only
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--diff-filter=ACDM", "-U0", "--", *files],
+        capture_output=True,
+        text=True,
+    )
+    diff = result.stdout
+
+    # Only scan added lines (start with '+'), skip diff headers ('---'/'+++')
+    added_lines = [
+        line[1:]  # strip leading '+'
+        for line in diff.split("\n")
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+    added_text = "\n".join(added_lines)
+
+    found = []
+    for name, pattern in PATTERNS:
+        for match in re.finditer(pattern, added_text, re.IGNORECASE):
+            # Skip lines that are clearly regex definitions (contain r' or r")
+            snippet = match.group()[:60]
+            # Skip if the matched text looks like it's inside a string literal definition
+            found.append((name, snippet))
+
+    if not found:
+        print("PII check: clean")
+        return 0
+
+    print("PII check: FAILED — suspicious content in staged changes:")
+    for name, snippet in found:
+        print(f"  [{name}] {snippet}")
+    print("\nReview and remove sensitive data before committing.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -20,6 +20,7 @@ from forge.core.steps import StepTracker
 from forge.core.inference import InferenceResult, fold_and_serialize, run_inference
 from forge.core.runner import WorkflowRunner
 from forge.core.slot_worker import SlotWorker
+from forge.clients.anthropic import AnthropicClient
 from forge.clients.base import ChunkType, LLMClient, StreamChunk, TokenUsage
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
@@ -91,6 +92,7 @@ __all__ = [
     # Slot worker
     "SlotWorker",
     # Client
+    "AnthropicClient",
     "ChunkType",
     "LLMClient",
     "LlamafileClient",

--- a/src/forge/clients/__init__.py
+++ b/src/forge/clients/__init__.py
@@ -1,5 +1,6 @@
 """Client adapters for LLM backends."""
 
+from forge.clients.anthropic import AnthropicClient
 from forge.clients.base import ChunkType, LLMClient, StreamChunk
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
@@ -10,6 +11,7 @@ from forge.clients.sampling_defaults import (
 )
 
 __all__ = [
+    "AnthropicClient",
     "ChunkType",
     "LLMClient",
     "LlamafileClient",

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -11,6 +11,8 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
+import os
+
 import anthropic
 
 from forge.clients.base import ChunkType, StreamChunk
@@ -39,6 +41,7 @@ class AnthropicClient:
         max_retries: int = 3,
         tool_choice: str | None = None,
         recommended_sampling: bool = False,
+        base_url: str | None = None,
     ) -> None:
         self.model = model
         self.max_tokens = max_tokens
@@ -50,11 +53,24 @@ class AnthropicClient:
             log.debug(
                 "AnthropicClient ignores recommended_sampling=True — no sampling kwargs are exposed."
             )
-        self._client = anthropic.AsyncAnthropic(
-            api_key=api_key,
-            timeout=timeout,
-            max_retries=max_retries,
-        )
+        kwargs: dict[str, Any] = {
+            "api_key": api_key,
+            "timeout": timeout,
+            "max_retries": max_retries,
+        }
+        if base_url is not None:
+            kwargs["base_url"] = base_url
+        else:
+            # The Anthropic SDK reads ANTHROPIC_BASE_URL from env. When
+            # the user does not provide an explicit base_url we must
+            # suppress that env var so the SDK hits the real Anthropic
+            # endpoint (not a local override).
+            _saved = os.environ.pop("ANTHROPIC_BASE_URL", None)
+            self._client = anthropic.AsyncAnthropic(**kwargs)
+            if _saved is not None:
+                os.environ["ANTHROPIC_BASE_URL"] = _saved
+            return
+        self._client = anthropic.AsyncAnthropic(**kwargs)
         # Populated after each send()/send_stream() call.
         self.last_usage: dict[str, int] | None = None
 
@@ -238,7 +254,7 @@ class AnthropicClient:
 
     async def send(
         self,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
     ) -> LLMResponse:
@@ -268,7 +284,7 @@ class AnthropicClient:
 
     async def send_stream(
         self,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -8,10 +8,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from collections.abc import AsyncIterator
 from typing import Any
-
-import os
 
 import anthropic
 
@@ -36,7 +35,7 @@ class AnthropicClient:
         self,
         model: str,
         api_key: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int = 8192,
         timeout: float = 300.0,
         max_retries: int = 3,
         tool_choice: str | None = None,
@@ -50,9 +49,7 @@ class AnthropicClient:
         # AnthropicClient does not expose sampling kwargs through forge today.
         # The Anthropic SDK manages sampling internally.
         if recommended_sampling:
-            log.debug(
-                "AnthropicClient ignores recommended_sampling=True — no sampling kwargs are exposed."
-            )
+            log.debug("AnthropicClient ignores recommended_sampling=True — no sampling kwargs are exposed.")
         kwargs: dict[str, Any] = {
             "api_key": api_key,
             "timeout": timeout,
@@ -128,19 +125,23 @@ class AnthropicClient:
                         if isinstance(args, str):
                             args = json.loads(args)
                         tc_id = tc.get("id", f"toolu_{len(converted)}")
-                        blocks.append({
-                            "type": "tool_use",
-                            "id": tc_id,
-                            "name": func["name"],
-                            "input": args,
-                        })
+                        blocks.append(
+                            {
+                                "type": "tool_use",
+                                "id": tc_id,
+                                "name": func["name"],
+                                "input": args,
+                            }
+                        )
                         pending_tool_use_ids.append(tc_id)
                     converted.append({"role": "assistant", "content": blocks})
                 else:
-                    converted.append({
-                        "role": "assistant",
-                        "content": msg.get("content", ""),
-                    })
+                    converted.append(
+                        {
+                            "role": "assistant",
+                            "content": msg.get("content", ""),
+                        }
+                    )
                 continue
 
             if role == "tool":
@@ -161,22 +162,26 @@ class AnthropicClient:
                 if pending_tool_use_ids:
                     blocks = []
                     for tc_id in pending_tool_use_ids:
-                        blocks.append({
-                            "type": "tool_result",
-                            "tool_use_id": tc_id,
-                            "content": "Not executed.",
-                            "is_error": True,
-                        })
+                        blocks.append(
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": tc_id,
+                                "content": "Not executed.",
+                                "is_error": True,
+                            }
+                        )
                     pending_tool_use_ids.clear()
                     text = msg.get("content", "")
                     if text:
                         blocks.append({"type": "text", "text": text})
                     converted.append({"role": "user", "content": blocks})
                 else:
-                    converted.append({
-                        "role": "user",
-                        "content": msg.get("content", ""),
-                    })
+                    converted.append(
+                        {
+                            "role": "user",
+                            "content": msg.get("content", ""),
+                        }
+                    )
                 continue
 
         # Merge consecutive same-role messages (Anthropic requires strict
@@ -236,13 +241,14 @@ class AnthropicClient:
         self,
         messages: list[dict[str, Any]],
         tools: list[ToolSpec] | None,
+        max_tokens: int | None = None,
     ) -> dict[str, Any]:
         """Build kwargs dict for messages.create / messages.stream."""
         system, converted = self._convert_messages(messages)
         kwargs: dict[str, Any] = {
             "model": self.model,
             "messages": converted,
-            "max_tokens": self.max_tokens,
+            "max_tokens": max_tokens if max_tokens is not None else self.max_tokens,
         }
         if system:
             kwargs["system"] = system
@@ -257,6 +263,7 @@ class AnthropicClient:
         messages: list[dict[str, Any]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        max_tokens: int | None = None,
     ) -> LLMResponse:
         """Send messages via the Anthropic Messages API.
 
@@ -269,13 +276,11 @@ class AnthropicClient:
                 "AnthropicClient ignores per-call sampling overrides: %s",
                 sorted(sampling.keys()),
             )
-        kwargs = self._build_kwargs(messages, tools)
+        kwargs = self._build_kwargs(messages, tools, max_tokens=max_tokens)
         try:
             response = await self._client.messages.create(**kwargs)
         except anthropic.APIError as exc:
-            raise BackendError(
-                getattr(exc, "status_code", 0), str(exc)
-            ) from exc
+            raise BackendError(getattr(exc, "status_code", 0), str(exc)) from exc
         self.last_usage = {
             "input_tokens": response.usage.input_tokens,
             "output_tokens": response.usage.output_tokens,
@@ -287,6 +292,7 @@ class AnthropicClient:
         messages: list[dict[str, Any]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        max_tokens: int | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Stream via the Anthropic Messages API.
 
@@ -297,7 +303,7 @@ class AnthropicClient:
                 "AnthropicClient ignores per-call sampling overrides: %s",
                 sorted(sampling.keys()),
             )
-        kwargs = self._build_kwargs(messages, tools)
+        kwargs = self._build_kwargs(messages, tools, max_tokens=max_tokens)
 
         accumulated_text = ""
         # Track multiple tool_use blocks by index.
@@ -308,10 +314,12 @@ class AnthropicClient:
                 async for event in stream:
                     if event.type == "content_block_start":
                         if event.content_block.type == "tool_use":
-                            tool_blocks.append({
-                                "name": event.content_block.name,
-                                "args": "",
-                            })
+                            tool_blocks.append(
+                                {
+                                    "name": event.content_block.name,
+                                    "args": "",
+                                }
+                            )
                             _current_tool_idx = len(tool_blocks) - 1
                     elif event.type == "content_block_delta":
                         if event.delta.type == "text_delta":
@@ -342,9 +350,7 @@ class AnthropicClient:
                             ]
                         else:
                             final = TextResponse(content=accumulated_text)
-                        yield StreamChunk(
-                            type=ChunkType.FINAL, response=final
-                        )
+                        yield StreamChunk(type=ChunkType.FINAL, response=final)
                 # Grab usage from the final accumulated message.
                 final_message = await stream.get_final_message()
                 self.last_usage = {
@@ -352,9 +358,7 @@ class AnthropicClient:
                     "output_tokens": final_message.usage.output_tokens,
                 }
         except anthropic.APIError as exc:
-            raise BackendError(
-                getattr(exc, "status_code", 0), str(exc)
-            ) from exc
+            raise BackendError(getattr(exc, "status_code", 0), str(exc)) from exc
 
     async def get_context_length(self) -> int | None:
         """Claude models have 200K context."""

--- a/src/forge/core/inference.py
+++ b/src/forge/core/inference.py
@@ -118,6 +118,7 @@ async def run_inference(
     stream: bool = False,
     on_chunk: Callable[[StreamChunk], Awaitable[None]] | None = None,
     sampling: dict[str, Any] | None = None,
+    max_tokens: int | None = None,
 ) -> InferenceResult | None:
     """Send messages to the LLM with compaction, folding, validation, and retry.
 
@@ -163,14 +164,14 @@ async def run_inference(
     attempt_limit = max_retries + 1
     if max_attempts is not None:
         attempt_limit = min(attempt_limit, max_attempts)
-    attempts = 0
-
     for _attempt in range(attempt_limit):
-        attempts += 1
+        attempts = _attempt + 1
 
         # Compact
         compacted = context_manager.maybe_compact(
-            messages, step_index=step_index, step_hint=step_hint,
+            messages,
+            step_index=step_index,
+            step_hint=step_hint,
         )
         # Update the caller's list in-place if compaction changed it
         if compacted is not messages:
@@ -190,17 +191,19 @@ async def run_inference(
         # (TUI, CLI) can display it to the user.
         if context_warning:
             api_messages.append({"role": "user", "content": context_warning})
-            new_messages.append(Message(
-                MessageRole.USER,
-                context_warning,
-                MessageMeta(MessageType.CONTEXT_WARNING, step_index=step_index),
-            ))
+            new_messages.append(
+                Message(
+                    MessageRole.USER,
+                    context_warning,
+                    MessageMeta(MessageType.CONTEXT_WARNING, step_index=step_index),
+                )
+            )
 
         # Send
         if stream:
             response = await _send_streaming(client, api_messages, tool_specs, on_chunk, sampling)
         else:
-            response = await client.send(api_messages, tools=tool_specs, sampling=sampling)
+            response = await client.send(api_messages, tools=tool_specs, sampling=sampling, max_tokens=max_tokens)
 
         # Update context manager with real token count if available.
         _sync_token_count(client, context_manager)
@@ -222,8 +225,8 @@ async def run_inference(
         # Retry path
         error_tracker.record_retry()
         if error_tracker.retries_exhausted:
-            raw = response.content if isinstance(response, TextResponse) else str(
-                [(tc.tool, tc.args) for tc in response]
+            raw = (
+                response.content if isinstance(response, TextResponse) else str([(tc.tool, tc.args) for tc in response])
             )
             raise ToolCallError(
                 f"Retries exhausted after {max_retries} consecutive failed attempts",
@@ -311,7 +314,6 @@ async def _send_streaming(
             response = chunk.response
     if response is None:
         raise StreamError(
-            "Stream ended without FINAL chunk — the client adapter "
-            "may be malformed or the connection was interrupted"
+            "Stream ended without FINAL chunk — the client adapter may be malformed or the connection was interrupted"
         )
     return response

--- a/src/forge/proxy/__main__.py
+++ b/src/forge/proxy/__main__.py
@@ -18,16 +18,17 @@ def main() -> None:
     )
 
     # Mode selection
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument(
+    parser.add_argument(
         "--backend-url",
-        help="URL of externally managed backend (external mode)",
+        help="URL of externally managed backend (external mode), or Anthropic-compatible endpoint with --backend anthropic",
     )
-    group.add_argument(
+    parser.add_argument(
         "--backend",
-        choices=["llamaserver", "llamafile", "ollama"],
+        choices=["llamaserver", "llamafile", "ollama", "anthropic"],
         help="Backend type (managed mode)",
     )
+    if not any(arg in sys.argv for arg in ("--backend-url", "--backend")):
+        parser.error("Provide either --backend-url or --backend")
 
     # Managed mode options
     parser.add_argument("--model", help="Model name (required for ollama)")

--- a/src/forge/proxy/convert.py
+++ b/src/forge/proxy/convert.py
@@ -259,3 +259,499 @@ def text_to_sse_events(
     })
 
     return events
+
+
+# ── Anthropic ↔ OpenAI conversion ──────────────────────────────────
+
+# Mapping Anthropic stop_reason → OpenAI finish_reason
+_STOP_REASON_MAP = {
+    "end_turn": "stop",
+    "max_tokens": "length",
+    "tool_use": "tool_calls",
+    "stop_sequence": "stop",
+}
+
+# Reverse: OpenAI finish_reason → Anthropic stop_reason
+# Note: both end_turn and stop_sequence map to "stop", so we prefer end_turn
+_STOP_REASON_MAP_REV = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+    "content_filter": "stop_sequence",
+}
+
+
+def anthropic_to_openai_messages(body: dict[str, Any]) -> list[dict[str, Any]]:
+    """Convert an Anthropic API request body to OpenAI-format messages list.
+
+    Handles:
+    - Top-level ``system`` string → ``role: "system"`` message
+    - ``messages`` array with Anthropic format (``role``, ``content`` blocks)
+    - ``tool_use`` content blocks → ``assistant`` with ``tool_calls``
+    - ``tool_result`` content blocks → ``tool`` role messages
+    - Plain text content → string content
+    """
+    messages: list[dict[str, Any]] = []
+    system = body.get("system")
+    if system:
+        messages.append({"role": "system", "content": system})
+
+    for msg in body.get("messages", []):
+        role = msg.get("role", "user")
+        content_blocks = msg.get("content", "")
+
+        if role == "assistant":
+            if isinstance(content_blocks, list):
+                tool_calls = []
+                text_parts = []
+                for block in content_blocks:
+                    if isinstance(block, dict):
+                        if block.get("type") == "tool_use":
+                            tool_calls.append({
+                                "id": block.get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                                "type": "function",
+                                "function": {
+                                    "name": block.get("name", ""),
+                                    "arguments": json.dumps(block.get("input", {})),
+                                },
+                            })
+                        elif block.get("type") == "text":
+                            text_parts.append(block.get("text", ""))
+                        elif block.get("type") == "thinking":
+                            text_parts.append(f"<think>{block.get('text', '')}</think>")
+                ai_msg: dict[str, Any] = {"role": "assistant"}
+                if text_parts:
+                    ai_msg["content"] = "\n".join(text_parts)
+                if tool_calls:
+                    ai_msg["tool_calls"] = tool_calls
+                messages.append(ai_msg)
+            else:
+                messages.append({
+                    "role": "assistant",
+                    "content": content_blocks or "",
+                })
+
+        elif role == "user":
+            if isinstance(content_blocks, list):
+                # Check if there are tool_result blocks
+                tool_results = [b for b in content_blocks if isinstance(b, dict) and b.get("type") == "tool_result"]
+                text_blocks = [b for b in content_blocks if isinstance(b, dict) and b.get("type") in ("text", "thinking")]
+
+                for tr in tool_results:
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": tr.get("tool_use_id", ""),
+                        "content": tr.get("content", ""),
+                        "name": tr.get("name", ""),
+                    })
+
+                if text_blocks:
+                    text_content = ""
+                    for tb in text_blocks:
+                        if tb.get("type") == "thinking":
+                            text_content += f"<think>{tb.get('text', '')}</think>"
+                        else:
+                            text_content += tb.get("text", "")
+                    messages.append({
+                        "role": "user",
+                        "content": text_content,
+                    })
+            else:
+                messages.append({
+                    "role": "user",
+                    "content": content_blocks or "",
+                })
+
+    return messages
+
+
+def openai_to_anthropic_messages(messages: list[dict[str, Any]]) -> dict[str, Any]:
+    """Convert OpenAI-format messages list to Anthropic API body fields.
+
+    Extracts system message and converts messages to Anthropic format.
+    Returns a dict with ``system`` and ``messages`` keys suitable for
+    the Anthropic API body (not the full body — caller adds model,
+    max_tokens, tools, etc.).
+    """
+    system: str | None = None
+    anthropic_msgs: list[dict[str, Any]] = []
+
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "") or ""
+
+        if role == "system":
+            system = content
+            continue
+
+        if role == "assistant":
+            tool_calls = msg.get("tool_calls")
+            blocks: list[dict[str, Any]] = []
+            if content:
+                blocks.append({"type": "text", "text": content})
+            if tool_calls:
+                for tc in tool_calls:
+                    func = tc.get("function", {})
+                    args = func.get("arguments", "{}")
+                    if isinstance(args, str):
+                        args = json.loads(args)
+                    blocks.append({
+                        "type": "tool_use",
+                        "id": tc.get("id", f"toolu_{uuid.uuid4().hex[:8]}"),
+                        "name": func.get("name", ""),
+                        "input": args,
+                    })
+            anthropic_msgs.append({"role": "assistant", "content": blocks if blocks else ""})
+
+        elif role == "tool":
+            # Tool results go inside a user message
+            tc_id = msg.get("tool_call_id", "")
+            is_error = msg.get("is_error", False)
+            block: dict[str, Any] = {
+                "type": "tool_result",
+                "tool_use_id": tc_id,
+                "content": content,
+            }
+            if is_error:
+                block["is_error"] = True
+            anthropic_msgs.append({"role": "user", "content": [block]})
+
+        else:
+            # "user" or anything else
+            if isinstance(content, list):
+                # Already in content-block format; normalize
+                blocks = []
+                for b in content:
+                    if isinstance(b, dict):
+                        if b.get("type") == "text":
+                            blocks.append({"type": "text", "text": b.get("text", "")})
+                        elif b.get("type") == "thinking":
+                            blocks.append({"type": "thinking", "text": b.get("text", "")})
+                        else:
+                            blocks.append(b)
+                    else:
+                        blocks.append({"type": "text", "text": str(b)})
+                anthropic_msgs.append({"role": "user", "content": blocks})
+            else:
+                anthropic_msgs.append({"role": "user", "content": content})
+
+    result: dict[str, Any] = {"messages": anthropic_msgs}
+    if system:
+        result["system"] = system
+    return result
+
+
+def openai_to_anthropic_response(openai_resp: dict[str, Any], model: str) -> dict[str, Any]:
+    """Convert an OpenAI chat.completion response to Anthropic format.
+
+    Handles both text and tool-call responses.
+    """
+    choice = openai_resp.get("choices", [{}])[0]
+    message = choice.get("message", {})
+    finish_reason = choice.get("finish_reason", "stop")
+    stop_reason = _STOP_REASON_MAP_REV.get(finish_reason, "end_turn")
+
+    # Build content blocks
+    content_blocks: list[dict[str, Any]] = []
+    reasoning = message.get("content", "") or ""
+
+    tool_calls = message.get("tool_calls", [])
+    if tool_calls:
+        for tc in tool_calls:
+            func = tc.get("function", {})
+            args = func.get("arguments", "{}")
+            if isinstance(args, str):
+                args = json.loads(args)
+            content_blocks.append({
+                "type": "tool_use",
+                "id": tc.get("id", f"toolu_{uuid.uuid4().hex[:8]}"),
+                "name": func.get("name", ""),
+                "input": args,
+            })
+        # Reasoning/thinking goes as text block before tool_use
+        if reasoning:
+            content_blocks.insert(0, {"type": "text", "text": reasoning})
+    else:
+        content_blocks.append({"type": "text", "text": reasoning})
+
+    usage = openai_resp.get("usage", {})
+    anthropic_usage = {
+        "input_tokens": usage.get("prompt_tokens", 0),
+        "output_tokens": usage.get("completion_tokens", 0),
+    }
+
+    return {
+        "id": openai_resp.get("id", f"msg_{uuid.uuid4().hex[:12]}"),
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": content_blocks,
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": anthropic_usage,
+    }
+
+
+def openai_to_anthropic_sse(openai_events: list[dict[str, Any]], model: str) -> list[dict[str, Any]]:
+    """Convert OpenAI SSE chunks to Anthropic SSE events.
+
+    Handles text deltas, tool call deltas, and finish_reason.
+    """
+    events: list[dict[str, Any]] = []
+    # Track tool_use blocks by index for streaming
+    tool_indices: dict[int, dict[str, Any]] = {}
+    cmpl_id = openai_events[0].get("id", f"msg_{uuid.uuid4().hex[:12]}") if openai_events else f"msg_{uuid.uuid4().hex[:12]}"
+    accumulated_text = ""
+
+    for event in openai_events:
+        choices = event.get("choices", [])
+        for choice in choices:
+            delta = choice.get("delta", {})
+            finish_reason = choice.get("finish_reason")
+
+            # Text delta
+            if "content" in delta and delta["content"] is not None:
+                accumulated_text += delta["content"]
+                events.append({
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                })
+                events.append({
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": delta["content"]},
+                })
+                events.append({
+                    "type": "content_block_stop",
+                    "index": 0,
+                })
+
+            # Tool call deltas
+            tool_calls = delta.get("tool_calls", [])
+            for tc in tool_calls:
+                idx = tc.get("index", 0)
+                if "id" in tc and idx not in tool_indices:
+                    tool_indices[idx] = {"name": "", "args": "", "id": tc["id"]}
+                if idx in tool_indices:
+                    if "function" in tc and "name" in tc.get("function", {}):
+                        tool_indices[idx]["name"] = tc["function"]["name"]
+                    if "function" in tc and "arguments" in tc.get("function", {}):
+                        tool_indices[idx]["args"] += tc["function"]["arguments"]
+
+            # Final chunk
+            if finish_reason:
+                # Emit tool_use blocks
+                for tidx, tdata in sorted(tool_indices.items()):
+                    events.append({
+                        "type": "content_block_start",
+                        "index": tidx + 1,
+                        "content_block": {"type": "tool_use", "name": tdata["name"], "id": tdata["id"]},
+                    })
+                    events.append({
+                        "type": "content_block_delta",
+                        "index": tidx + 1,
+                        "delta": {"type": "input_json_delta", "partial_json": tdata["args"]},
+                    })
+                    events.append({
+                        "type": "content_block_stop",
+                        "index": tidx + 1,
+                    })
+
+                events.append({
+                    "type": "message_stop",
+                    "stop_reason": _STOP_REASON_MAP_REV.get(finish_reason, "end_turn"),
+                })
+
+    # Wrap in Anthropic SSE message format
+    wrapped: list[dict[str, Any]] = []
+    for ev in events:
+        wrapped.append({**ev, "id": cmpl_id, "model": model})
+
+    # Add message_start
+    wrapped.insert(0, {
+        "id": cmpl_id,
+        "type": "message_start",
+        "model": model,
+        "message": {
+            "id": cmpl_id,
+            "type": "message",
+            "role": "assistant",
+            "model": model,
+            "content": [],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        },
+    })
+    # Add message_stop at end
+    wrapped.append({
+        "id": cmpl_id,
+        "type": "message_stop",
+    })
+
+    return wrapped
+
+
+def anthropic_to_openai_response(anthropic_resp: dict[str, Any], model: str) -> dict[str, Any]:
+    """Convert an Anthropic API response to OpenAI chat.completion format.
+
+    Handles both text and tool-call responses.
+    """
+    stop_reason = anthropic_resp.get("stop_reason", "end_turn")
+    finish_reason = _STOP_REASON_MAP.get(stop_reason, "stop")
+
+    content_blocks = anthropic_resp.get("content", [])
+    tool_calls = []
+    text_parts = []
+
+    for block in content_blocks:
+        if isinstance(block, dict):
+            if block.get("type") == "tool_use":
+                tool_calls.append({
+                    "id": block.get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name", ""),
+                        "arguments": json.dumps(block.get("input", {})),
+                    },
+                })
+            elif block.get("type") == "text":
+                text_parts.append(block.get("text", ""))
+            elif block.get("type") == "thinking":
+                text_parts.append(f"<think>{block.get('text', '')}</think>")
+
+    usage = anthropic_resp.get("usage", {})
+    openai_usage = {
+        "prompt_tokens": usage.get("input_tokens", 0),
+        "completion_tokens": usage.get("output_tokens", 0),
+        "total_tokens": usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
+    }
+
+    message: dict[str, Any] = {"role": "assistant"}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    if text_parts:
+        message["content"] = "\n".join(text_parts)
+    else:
+        message["content"] = ""
+
+    return {
+        "id": anthropic_resp.get("id", f"chatcmpl-{uuid.uuid4().hex[:12]}"),
+        "object": "chat.completion",
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": message,
+            "finish_reason": finish_reason,
+        }],
+        "usage": openai_usage,
+    }
+
+
+def anthropic_to_openai_sse(anthropic_events: list[dict[str, Any]], model: str) -> list[dict[str, Any]]:
+    """Convert Anthropic SSE events to OpenAI SSE chunks.
+
+    Handles content_block_delta (text and input_json), message_stop.
+    """
+    events: list[dict[str, Any]] = []
+    cmpl_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+    accumulated_text = ""
+    tool_blocks: dict[int, dict[str, Any]] = {}
+    current_tool_idx = 0
+
+    for event in anthropic_events:
+        ev_type = event.get("type", "")
+
+        if ev_type == "content_block_start":
+            idx = event.get("index", 0)
+            block = event.get("content_block", {})
+            if block.get("type") == "text":
+                tool_blocks[idx] = {"type": "text", "chunks": []}
+            elif block.get("type") == "tool_use":
+                tool_blocks[idx] = {
+                    "type": "tool_use",
+                    "id": block.get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                    "name": block.get("name", ""),
+                    "args": "",
+                }
+
+        elif ev_type == "content_block_delta":
+            delta = event.get("delta", {})
+            delta_type = delta.get("type", "")
+            idx = event.get("index", 0)
+
+            if delta_type == "text_delta":
+                accumulated_text += delta.get("text", "")
+                events.append({
+                    "id": cmpl_id,
+                    "object": "chat.completion.chunk",
+                    "model": model,
+                    "choices": [{
+                        "index": 0,
+                        "delta": {"content": delta.get("text", "")},
+                        "finish_reason": None,
+                    }],
+                })
+
+            elif delta_type == "input_json_delta" and idx in tool_blocks:
+                partial = delta.get("partial_json", "")
+                tool_blocks[idx]["args"] += partial
+                events.append({
+                    "id": cmpl_id,
+                    "object": "chat.completion.chunk",
+                    "model": model,
+                    "choices": [{
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [{
+                                "index": current_tool_idx,
+                                "id": tool_blocks[idx].get("id", ""),
+                                "type": "function",
+                                "function": {"arguments": partial},
+                            }]
+                        },
+                        "finish_reason": None,
+                    }],
+                })
+                current_tool_idx += 1
+
+        elif ev_type == "message_stop":
+            stop_reason = event.get("stop_reason", "end_turn")
+            finish_reason = _STOP_REASON_MAP.get(stop_reason, "stop")
+            events.append({
+                "id": cmpl_id,
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [{
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": finish_reason,
+                }],
+            })
+
+    # If we have accumulated text but no SSE events were generated,
+    # send the full text as a single chunk
+    if not events and accumulated_text:
+        events.append({
+            "id": cmpl_id,
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "delta": {"role": "assistant", "content": accumulated_text},
+                "finish_reason": None,
+            }],
+        })
+        events.append({
+            "id": cmpl_id,
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }],
+        })
+
+    return events

--- a/src/forge/proxy/convert.py
+++ b/src/forge/proxy/convert.py
@@ -7,10 +7,10 @@ import uuid
 from typing import Any
 
 from forge.core.messages import Message, MessageMeta, MessageRole, MessageType, ToolCallInfo
-from forge.core.workflow import ToolCall, TextResponse
-
+from forge.core.workflow import ToolCall
 
 # ── Inbound: OpenAI request → forge Messages ─────────────────────
+
 
 def openai_to_messages(openai_messages: list[dict[str, Any]]) -> list[Message]:
     """Convert OpenAI chat completions messages to forge Message objects.
@@ -35,14 +35,16 @@ def openai_to_messages(openai_messages: list[dict[str, Any]]) -> list[Message]:
             content = "\n".join(parts)
 
         if role_str == "system":
-            messages.append(Message(
-                MessageRole.SYSTEM,
-                content,
-                MessageMeta(MessageType.SYSTEM_PROMPT),
-            ))
+            messages.append(
+                Message(
+                    MessageRole.SYSTEM,
+                    content,
+                    MessageMeta(MessageType.SYSTEM_PROMPT),
+                )
+            )
 
         elif role_str == "assistant":
-            if "tool_calls" in msg and msg["tool_calls"]:
+            if msg.get("tool_calls"):
                 tc_infos = []
                 for tc in msg["tool_calls"]:
                     func = tc.get("function", {})
@@ -50,47 +52,58 @@ def openai_to_messages(openai_messages: list[dict[str, Any]]) -> list[Message]:
                     if isinstance(args, str):
                         args = json.loads(args)
                     tc_id = tc.get("id", f"call_{uuid.uuid4().hex[:8]}")
-                    tc_infos.append(ToolCallInfo(
-                        name=func.get("name", ""),
-                        args=args,
-                        call_id=tc_id,
-                    ))
-                messages.append(Message(
-                    MessageRole.ASSISTANT,
-                    content,
-                    MessageMeta(MessageType.TOOL_CALL),
-                    tool_calls=tc_infos,
-                ))
+                    tc_infos.append(
+                        ToolCallInfo(
+                            name=func.get("name", ""),
+                            args=args,
+                            call_id=tc_id,
+                        )
+                    )
+                messages.append(
+                    Message(
+                        MessageRole.ASSISTANT,
+                        content,
+                        MessageMeta(MessageType.TOOL_CALL),
+                        tool_calls=tc_infos,
+                    )
+                )
             else:
-                messages.append(Message(
-                    MessageRole.ASSISTANT,
-                    content,
-                    MessageMeta(MessageType.TEXT_RESPONSE),
-                ))
+                messages.append(
+                    Message(
+                        MessageRole.ASSISTANT,
+                        content,
+                        MessageMeta(MessageType.TEXT_RESPONSE),
+                    )
+                )
 
         elif role_str == "tool":
             tool_call_id = msg.get("tool_call_id", "")
             tool_name = msg.get("name", "")
-            messages.append(Message(
-                MessageRole.TOOL,
-                content,
-                MessageMeta(MessageType.TOOL_RESULT),
-                tool_name=tool_name,
-                tool_call_id=tool_call_id,
-            ))
+            messages.append(
+                Message(
+                    MessageRole.TOOL,
+                    content,
+                    MessageMeta(MessageType.TOOL_RESULT),
+                    tool_name=tool_name,
+                    tool_call_id=tool_call_id,
+                )
+            )
 
         else:
             # "user" or anything else
-            messages.append(Message(
-                MessageRole.USER,
-                content,
-                MessageMeta(MessageType.USER_INPUT),
-            ))
+            messages.append(
+                Message(
+                    MessageRole.USER,
+                    content,
+                    MessageMeta(MessageType.USER_INPUT),
+                )
+            )
 
     return messages
 
 
 # ── Outbound: forge response → OpenAI format ─────────────────────
+
 
 def tool_calls_to_openai(
     tool_calls: list[ToolCall],
@@ -98,29 +111,33 @@ def tool_calls_to_openai(
 ) -> dict[str, Any]:
     """Convert forge ToolCalls to an OpenAI chat completions response object."""
     tc_list = []
-    for i, tc in enumerate(tool_calls):
-        tc_list.append({
-            "id": f"call_{uuid.uuid4().hex[:8]}",
-            "type": "function",
-            "function": {
-                "name": tc.tool,
-                "arguments": json.dumps(tc.args),
-            },
-        })
+    for _i, tc in enumerate(tool_calls):
+        tc_list.append(
+            {
+                "id": f"call_{uuid.uuid4().hex[:8]}",
+                "type": "function",
+                "function": {
+                    "name": tc.tool,
+                    "arguments": json.dumps(tc.args),
+                },
+            }
+        )
 
     return {
         "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
         "object": "chat.completion",
         "model": model,
-        "choices": [{
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": tool_calls[0].reasoning or None,
-                "tool_calls": tc_list,
-            },
-            "finish_reason": "tool_calls",
-        }],
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": tool_calls[0].reasoning or None,
+                    "tool_calls": tc_list,
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
         "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
     }
 
@@ -134,19 +151,22 @@ def text_response_to_openai(
         "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
         "object": "chat.completion",
         "model": model,
-        "choices": [{
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": text,
-            },
-            "finish_reason": "stop",
-        }],
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": text,
+                },
+                "finish_reason": "stop",
+            }
+        ],
         "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
     }
 
 
 # ── SSE streaming helpers ────────────────────────────────────────
+
 
 def tool_calls_to_sse_events(
     tool_calls: list[ToolCall],
@@ -162,53 +182,67 @@ def tool_calls_to_sse_events(
 
     # If there's reasoning, send it as a content delta first
     if tool_calls[0].reasoning:
-        events.append({
-            "id": cmpl_id,
-            "object": "chat.completion.chunk",
-            "model": model,
-            "choices": [{
-                "index": 0,
-                "delta": {"role": "assistant", "content": tool_calls[0].reasoning},
-                "finish_reason": None,
-            }],
-        })
+        events.append(
+            {
+                "id": cmpl_id,
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": tool_calls[0].reasoning},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        )
 
     # Tool call deltas
     for i, tc in enumerate(tool_calls):
         tc_id = f"call_{uuid.uuid4().hex[:8]}"
         # First chunk for this tool: name + start of args
-        events.append({
+        events.append(
+            {
+                "id": cmpl_id,
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": i,
+                                    "id": tc_id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": tc.tool,
+                                        "arguments": json.dumps(tc.args),
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        )
+
+    # Final chunk with finish_reason
+    events.append(
+        {
             "id": cmpl_id,
             "object": "chat.completion.chunk",
             "model": model,
-            "choices": [{
-                "index": 0,
-                "delta": {
-                    "tool_calls": [{
-                        "index": i,
-                        "id": tc_id,
-                        "type": "function",
-                        "function": {
-                            "name": tc.tool,
-                            "arguments": json.dumps(tc.args),
-                        },
-                    }],
-                },
-                "finish_reason": None,
-            }],
-        })
-
-    # Final chunk with finish_reason
-    events.append({
-        "id": cmpl_id,
-        "object": "chat.completion.chunk",
-        "model": model,
-        "choices": [{
-            "index": 0,
-            "delta": {},
-            "finish_reason": "tool_calls",
-        }],
-    })
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "tool_calls",
+                }
+            ],
+        }
+    )
 
     return events
 
@@ -227,7 +261,7 @@ def text_to_sse_events(
     events: list[dict[str, Any]] = []
 
     if chunk_size > 0 and len(text) > chunk_size:
-        chunks = [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)]
+        chunks = [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
     else:
         chunks = [text]
 
@@ -235,28 +269,36 @@ def text_to_sse_events(
         delta: dict[str, Any] = {"content": chunk}
         if i == 0:
             delta["role"] = "assistant"
-        events.append({
+        events.append(
+            {
+                "id": cmpl_id,
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": delta,
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        )
+
+    # Final chunk
+    events.append(
+        {
             "id": cmpl_id,
             "object": "chat.completion.chunk",
             "model": model,
-            "choices": [{
-                "index": 0,
-                "delta": delta,
-                "finish_reason": None,
-            }],
-        })
-
-    # Final chunk
-    events.append({
-        "id": cmpl_id,
-        "object": "chat.completion.chunk",
-        "model": model,
-        "choices": [{
-            "index": 0,
-            "delta": {},
-            "finish_reason": "stop",
-        }],
-    })
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+    )
 
     return events
 
@@ -307,14 +349,16 @@ def anthropic_to_openai_messages(body: dict[str, Any]) -> list[dict[str, Any]]:
                 for block in content_blocks:
                     if isinstance(block, dict):
                         if block.get("type") == "tool_use":
-                            tool_calls.append({
-                                "id": block.get("id", f"call_{uuid.uuid4().hex[:8]}"),
-                                "type": "function",
-                                "function": {
-                                    "name": block.get("name", ""),
-                                    "arguments": json.dumps(block.get("input", {})),
-                                },
-                            })
+                            tool_calls.append(
+                                {
+                                    "id": block.get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                                    "type": "function",
+                                    "function": {
+                                        "name": block.get("name", ""),
+                                        "arguments": json.dumps(block.get("input", {})),
+                                    },
+                                }
+                            )
                         elif block.get("type") == "text":
                             text_parts.append(block.get("text", ""))
                         elif block.get("type") == "thinking":
@@ -326,24 +370,30 @@ def anthropic_to_openai_messages(body: dict[str, Any]) -> list[dict[str, Any]]:
                     ai_msg["tool_calls"] = tool_calls
                 messages.append(ai_msg)
             else:
-                messages.append({
-                    "role": "assistant",
-                    "content": content_blocks or "",
-                })
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": content_blocks or "",
+                    }
+                )
 
         elif role == "user":
             if isinstance(content_blocks, list):
                 # Check if there are tool_result blocks
                 tool_results = [b for b in content_blocks if isinstance(b, dict) and b.get("type") == "tool_result"]
-                text_blocks = [b for b in content_blocks if isinstance(b, dict) and b.get("type") in ("text", "thinking")]
+                text_blocks = [
+                    b for b in content_blocks if isinstance(b, dict) and b.get("type") in ("text", "thinking")
+                ]
 
                 for tr in tool_results:
-                    messages.append({
-                        "role": "tool",
-                        "tool_call_id": tr.get("tool_use_id", ""),
-                        "content": tr.get("content", ""),
-                        "name": tr.get("name", ""),
-                    })
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tr.get("tool_use_id", ""),
+                            "content": tr.get("content", ""),
+                            "name": tr.get("name", ""),
+                        }
+                    )
 
                 if text_blocks:
                     text_content = ""
@@ -352,15 +402,19 @@ def anthropic_to_openai_messages(body: dict[str, Any]) -> list[dict[str, Any]]:
                             text_content += f"<think>{tb.get('text', '')}</think>"
                         else:
                             text_content += tb.get("text", "")
-                    messages.append({
-                        "role": "user",
-                        "content": text_content,
-                    })
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": text_content,
+                        }
+                    )
             else:
-                messages.append({
-                    "role": "user",
-                    "content": content_blocks or "",
-                })
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": content_blocks or "",
+                    }
+                )
 
     return messages
 
@@ -395,12 +449,14 @@ def openai_to_anthropic_messages(messages: list[dict[str, Any]]) -> dict[str, An
                     args = func.get("arguments", "{}")
                     if isinstance(args, str):
                         args = json.loads(args)
-                    blocks.append({
-                        "type": "tool_use",
-                        "id": tc.get("id", f"toolu_{uuid.uuid4().hex[:8]}"),
-                        "name": func.get("name", ""),
-                        "input": args,
-                    })
+                    blocks.append(
+                        {
+                            "type": "tool_use",
+                            "id": tc.get("id", f"toolu_{uuid.uuid4().hex[:8]}"),
+                            "name": func.get("name", ""),
+                            "input": args,
+                        }
+                    )
             anthropic_msgs.append({"role": "assistant", "content": blocks if blocks else ""})
 
         elif role == "tool":
@@ -462,12 +518,14 @@ def openai_to_anthropic_response(openai_resp: dict[str, Any], model: str) -> dic
             args = func.get("arguments", "{}")
             if isinstance(args, str):
                 args = json.loads(args)
-            content_blocks.append({
-                "type": "tool_use",
-                "id": tc.get("id", f"toolu_{uuid.uuid4().hex[:8]}"),
-                "name": func.get("name", ""),
-                "input": args,
-            })
+            content_blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": tc.get("id", f"toolu_{uuid.uuid4().hex[:8]}"),
+                    "name": func.get("name", ""),
+                    "input": args,
+                }
+            )
         # Reasoning/thinking goes as text block before tool_use
         if reasoning:
             content_blocks.insert(0, {"type": "text", "text": reasoning})
@@ -500,8 +558,12 @@ def openai_to_anthropic_sse(openai_events: list[dict[str, Any]], model: str) -> 
     events: list[dict[str, Any]] = []
     # Track tool_use blocks by index for streaming
     tool_indices: dict[int, dict[str, Any]] = {}
-    cmpl_id = openai_events[0].get("id", f"msg_{uuid.uuid4().hex[:12]}") if openai_events else f"msg_{uuid.uuid4().hex[:12]}"
+    cmpl_id = (
+        openai_events[0].get("id", f"msg_{uuid.uuid4().hex[:12]}") if openai_events else f"msg_{uuid.uuid4().hex[:12]}"
+    )
     accumulated_text = ""
+    next_index = 0  # Track next available content block index
+    text_started = False  # Whether content_block_start for text has been emitted
 
     for event in openai_events:
         choices = event.get("choices", [])
@@ -512,20 +574,23 @@ def openai_to_anthropic_sse(openai_events: list[dict[str, Any]], model: str) -> 
             # Text delta
             if "content" in delta and delta["content"] is not None:
                 accumulated_text += delta["content"]
-                events.append({
-                    "type": "content_block_start",
-                    "index": 0,
-                    "content_block": {"type": "text", "text": ""},
-                })
-                events.append({
-                    "type": "content_block_delta",
-                    "index": 0,
-                    "delta": {"type": "text_delta", "text": delta["content"]},
-                })
-                events.append({
-                    "type": "content_block_stop",
-                    "index": 0,
-                })
+                # Only emit content_block_start on the first text delta
+                if not text_started:
+                    events.append(
+                        {
+                            "type": "content_block_start",
+                            "index": next_index,
+                            "content_block": {"type": "text", "text": ""},
+                        }
+                    )
+                    text_started = True
+                events.append(
+                    {
+                        "type": "content_block_delta",
+                        "index": next_index,
+                        "delta": {"type": "text_delta", "text": delta["content"]},
+                    }
+                )
 
             # Tool call deltas
             tool_calls = delta.get("tool_calls", [])
@@ -539,29 +604,54 @@ def openai_to_anthropic_sse(openai_events: list[dict[str, Any]], model: str) -> 
                     if "function" in tc and "arguments" in tc.get("function", {}):
                         tool_indices[idx]["args"] += tc["function"]["arguments"]
 
-            # Final chunk
+            # Final chunk — emit content_block_stop for text and all tool_use blocks
             if finish_reason:
-                # Emit tool_use blocks
-                for tidx, tdata in sorted(tool_indices.items()):
-                    events.append({
-                        "type": "content_block_start",
-                        "index": tidx + 1,
-                        "content_block": {"type": "tool_use", "name": tdata["name"], "id": tdata["id"]},
-                    })
-                    events.append({
-                        "type": "content_block_delta",
-                        "index": tidx + 1,
-                        "delta": {"type": "input_json_delta", "partial_json": tdata["args"]},
-                    })
-                    events.append({
-                        "type": "content_block_stop",
-                        "index": tidx + 1,
-                    })
+                # Close text block if it was started
+                if text_started:
+                    events.append(
+                        {
+                            "type": "content_block_stop",
+                            "index": next_index,
+                        }
+                    )
 
-                events.append({
-                    "type": "message_stop",
-                    "stop_reason": _STOP_REASON_MAP_REV.get(finish_reason, "end_turn"),
-                })
+                # Emit tool_use blocks
+                for _tidx, tdata in sorted(tool_indices.items()):
+                    events.append(
+                        {
+                            "type": "content_block_start",
+                            "index": next_index,
+                            "content_block": {
+                                "type": "tool_use",
+                                "name": tdata["name"],
+                                "id": tdata["id"],
+                                "input": json.loads(tdata["args"])
+                                if isinstance(tdata["args"], str) and tdata["args"]
+                                else tdata["args"],
+                            },
+                        }
+                    )
+                    events.append(
+                        {
+                            "type": "content_block_delta",
+                            "index": next_index,
+                            "delta": {"type": "input_json_delta", "partial_json": tdata["args"]},
+                        }
+                    )
+                    events.append(
+                        {
+                            "type": "content_block_stop",
+                            "index": next_index,
+                        }
+                    )
+                    next_index += 1
+
+                events.append(
+                    {
+                        "type": "message_stop",
+                        "stop_reason": _STOP_REASON_MAP_REV.get(finish_reason, "end_turn"),
+                    }
+                )
 
     # Wrap in Anthropic SSE message format
     wrapped: list[dict[str, Any]] = []
@@ -569,26 +659,29 @@ def openai_to_anthropic_sse(openai_events: list[dict[str, Any]], model: str) -> 
         wrapped.append({**ev, "id": cmpl_id, "model": model})
 
     # Add message_start
-    wrapped.insert(0, {
-        "id": cmpl_id,
-        "type": "message_start",
-        "model": model,
-        "message": {
+    wrapped.insert(
+        0,
+        {
             "id": cmpl_id,
-            "type": "message",
-            "role": "assistant",
+            "type": "message_start",
             "model": model,
-            "content": [],
-            "stop_reason": "end_turn",
-            "stop_sequence": None,
-            "usage": {"input_tokens": 0, "output_tokens": 0},
+            "message": {
+                "id": cmpl_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            },
         },
-    })
-    # Add message_stop at end
-    wrapped.append({
-        "id": cmpl_id,
-        "type": "message_stop",
-    })
+    )
+
+    # Add message_stop if not already emitted (e.g. empty events)
+    has_stop = any(ev.get("type") == "message_stop" for ev in wrapped)
+    if not has_stop:
+        wrapped.append({"id": cmpl_id, "type": "message_stop"})
 
     return wrapped
 
@@ -608,14 +701,16 @@ def anthropic_to_openai_response(anthropic_resp: dict[str, Any], model: str) -> 
     for block in content_blocks:
         if isinstance(block, dict):
             if block.get("type") == "tool_use":
-                tool_calls.append({
-                    "id": block.get("id", f"call_{uuid.uuid4().hex[:8]}"),
-                    "type": "function",
-                    "function": {
-                        "name": block.get("name", ""),
-                        "arguments": json.dumps(block.get("input", {})),
-                    },
-                })
+                tool_calls.append(
+                    {
+                        "id": block.get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                        "type": "function",
+                        "function": {
+                            "name": block.get("name", ""),
+                            "arguments": json.dumps(block.get("input", {})),
+                        },
+                    }
+                )
             elif block.get("type") == "text":
                 text_parts.append(block.get("text", ""))
             elif block.get("type") == "thinking":
@@ -640,11 +735,13 @@ def anthropic_to_openai_response(anthropic_resp: dict[str, Any], model: str) -> 
         "id": anthropic_resp.get("id", f"chatcmpl-{uuid.uuid4().hex[:12]}"),
         "object": "chat.completion",
         "model": model,
-        "choices": [{
-            "index": 0,
-            "message": message,
-            "finish_reason": finish_reason,
-        }],
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": finish_reason,
+            }
+        ],
         "usage": openai_usage,
     }
 
@@ -683,75 +780,97 @@ def anthropic_to_openai_sse(anthropic_events: list[dict[str, Any]], model: str) 
 
             if delta_type == "text_delta":
                 accumulated_text += delta.get("text", "")
-                events.append({
-                    "id": cmpl_id,
-                    "object": "chat.completion.chunk",
-                    "model": model,
-                    "choices": [{
-                        "index": 0,
-                        "delta": {"content": delta.get("text", "")},
-                        "finish_reason": None,
-                    }],
-                })
+                events.append(
+                    {
+                        "id": cmpl_id,
+                        "object": "chat.completion.chunk",
+                        "model": model,
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": delta.get("text", "")},
+                                "finish_reason": None,
+                            }
+                        ],
+                    }
+                )
 
             elif delta_type == "input_json_delta" and idx in tool_blocks:
                 partial = delta.get("partial_json", "")
                 tool_blocks[idx]["args"] += partial
-                events.append({
-                    "id": cmpl_id,
-                    "object": "chat.completion.chunk",
-                    "model": model,
-                    "choices": [{
-                        "index": 0,
-                        "delta": {
-                            "tool_calls": [{
-                                "index": current_tool_idx,
-                                "id": tool_blocks[idx].get("id", ""),
-                                "type": "function",
-                                "function": {"arguments": partial},
-                            }]
-                        },
-                        "finish_reason": None,
-                    }],
-                })
+                events.append(
+                    {
+                        "id": cmpl_id,
+                        "object": "chat.completion.chunk",
+                        "model": model,
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": current_tool_idx,
+                                            "id": tool_blocks[idx].get("id", ""),
+                                            "type": "function",
+                                            "function": {"arguments": partial},
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ],
+                    }
+                )
                 current_tool_idx += 1
 
         elif ev_type == "message_stop":
             stop_reason = event.get("stop_reason", "end_turn")
             finish_reason = _STOP_REASON_MAP.get(stop_reason, "stop")
-            events.append({
-                "id": cmpl_id,
-                "object": "chat.completion.chunk",
-                "model": model,
-                "choices": [{
-                    "index": 0,
-                    "delta": {},
-                    "finish_reason": finish_reason,
-                }],
-            })
+            events.append(
+                {
+                    "id": cmpl_id,
+                    "object": "chat.completion.chunk",
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": finish_reason,
+                        }
+                    ],
+                }
+            )
 
     # If we have accumulated text but no SSE events were generated,
     # send the full text as a single chunk
     if not events and accumulated_text:
-        events.append({
-            "id": cmpl_id,
-            "object": "chat.completion.chunk",
-            "model": model,
-            "choices": [{
-                "index": 0,
-                "delta": {"role": "assistant", "content": accumulated_text},
-                "finish_reason": None,
-            }],
-        })
-        events.append({
-            "id": cmpl_id,
-            "object": "chat.completion.chunk",
-            "model": model,
-            "choices": [{
-                "index": 0,
-                "delta": {},
-                "finish_reason": "stop",
-            }],
-        })
+        events.append(
+            {
+                "id": cmpl_id,
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": accumulated_text},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        )
+        events.append(
+            {
+                "id": cmpl_id,
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        )
 
     return events

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -18,6 +18,11 @@ from forge.proxy.convert import (
     tool_calls_to_sse_events,
     text_response_to_openai,
     text_to_sse_events,
+    anthropic_to_openai_messages,
+    openai_to_anthropic_response,
+    openai_to_anthropic_sse,
+    anthropic_to_openai_response,
+    anthropic_to_openai_sse,
 )
 from forge.tools.respond import RESPOND_TOOL_NAME, respond_spec
 
@@ -30,6 +35,57 @@ logger = logging.getLogger("forge.proxy")
 # ``chat_template_kwargs`` is a nested dict of Jinja template variables
 # (e.g. {"reasoning_effort": "high"}) — passed through to the LlamafileClient
 # as part of the ``sampling`` kwarg; OllamaClient drops it (no analog field).
+
+
+def _format_response(
+    response: list[ToolCall] | TextResponse | str | None,
+    is_stream: bool,
+    model: str,
+    anthropic_backend: bool,
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Format an inference result into the appropriate wire format."""
+    if response is None or isinstance(response, str):
+        text = response or ""
+        return _format_text(text, is_stream, model, anthropic_backend)
+    elif isinstance(response, TextResponse):
+        return _format_text(response.content, is_stream, model, anthropic_backend)
+    else:
+        # list[ToolCall]
+        return _format_tool_calls(response, is_stream, model, anthropic_backend)
+
+
+def _format_text(
+    text: str,
+    is_stream: bool,
+    model: str,
+    anthropic_backend: bool,
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Format a text response."""
+    if anthropic_backend:
+        if is_stream:
+            return openai_to_anthropic_sse(text_to_sse_events(text, model), model)
+        return openai_to_anthropic_response(text_response_to_openai(text, model), model)
+    else:
+        if is_stream:
+            return text_to_sse_events(text, model)
+        return text_response_to_openai(text, model)
+
+
+def _format_tool_calls(
+    tool_calls: list[ToolCall],
+    is_stream: bool,
+    model: str,
+    anthropic_backend: bool,
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Format a tool call response."""
+    if anthropic_backend:
+        if is_stream:
+            return openai_to_anthropic_sse(tool_calls_to_sse_events(tool_calls, model), model)
+        return openai_to_anthropic_response(tool_calls_to_openai(tool_calls, model), model)
+    else:
+        if is_stream:
+            return tool_calls_to_sse_events(tool_calls, model)
+        return tool_calls_to_openai(tool_calls, model)
 _SAMPLING_FIELDS = (
     "temperature", "top_p", "top_k", "min_p",
     "repeat_penalty", "presence_penalty", "seed",
@@ -78,11 +134,13 @@ async def handle_chat_completions(
     context_manager: ContextManager,
     max_retries: int = 3,
     rescue_enabled: bool = True,
+    anthropic_backend: bool = False,
 ) -> dict[str, Any] | list[dict[str, Any]]:
     """Handle a /v1/chat/completions request.
 
     Converts inbound OpenAI messages to forge Messages, runs inference
-    with guardrails, and converts the result back to OpenAI format.
+    with guardrails, and converts the result back to the appropriate
+    format (OpenAI or Anthropic).
 
     Args:
         body: Parsed JSON request body.
@@ -90,9 +148,10 @@ async def handle_chat_completions(
         context_manager: For context compaction.
         max_retries: Max consecutive retries for bad responses.
         rescue_enabled: Whether to attempt rescue parsing.
+        anthropic_backend: If True, return Anthropic-format responses.
 
     Returns:
-        If stream=false: a single OpenAI response dict.
+        If stream=false: a response dict (OpenAI or Anthropic format).
         If stream=true: a list of SSE chunk dicts.
     """
     openai_messages = body.get("messages", [])
@@ -122,9 +181,7 @@ async def handle_chat_completions(
         api_messages = fold_and_serialize(messages, api_format)
         response = await client.send(api_messages, tools=None, sampling=sampling)
         text = response.content if isinstance(response, TextResponse) else ""
-        if is_stream:
-            return text_to_sse_events(text, model=model_name)
-        return text_response_to_openai(text, model=model_name)
+        return _format_response(text, is_stream, model_name, anthropic_backend)
 
     # Set up guardrails
     validator = ResponseValidator(tool_names, rescue_enabled=rescue_enabled)
@@ -147,15 +204,11 @@ async def handle_chat_completions(
         # error. The client's own agentic loop can decide what to do.
         raw = exc.raw_response or ""
         logger.warning("Retries exhausted, passing through text: %.120s", raw)
-        if is_stream:
-            return text_to_sse_events(raw, model=model_name)
-        return text_response_to_openai(raw, model=model_name)
+        return _format_response(raw, is_stream, model_name, anthropic_backend)
 
     # run_inference returns None when max_attempts exhausted
     if result is None:
-        if is_stream:
-            return text_to_sse_events("", model=model_name)
-        return text_response_to_openai("", model=model_name)
+        return _format_response("", is_stream, model_name, anthropic_backend)
 
     tool_calls = result.response
 
@@ -169,18 +222,79 @@ async def handle_chat_completions(
         # Pure respond — convert to text
         text = respond_calls[0].args.get("message", "")
         logger.info("Stripping respond() call, returning as text")
-        if is_stream:
-            return text_to_sse_events(text, model=model_name)
-        return text_response_to_openai(text, model=model_name)
+        return _format_response(text, is_stream, model_name, anthropic_backend)
 
     if other_calls:
         # Real tool calls (possibly mixed with respond) — return the
         # real tool calls only, drop respond.
-        if is_stream:
-            return tool_calls_to_sse_events(other_calls, model=model_name)
-        return tool_calls_to_openai(other_calls, model=model_name)
+        return _format_response(other_calls, is_stream, model_name, anthropic_backend)
 
     # Shouldn't happen, but handle empty tool_calls gracefully
-    if is_stream:
-        return text_to_sse_events("", model=model_name)
-    return text_response_to_openai("", model=model_name)
+    return _format_response("", is_stream, model_name, anthropic_backend)
+
+
+async def handle_messages(
+    body: dict[str, Any],
+    client: LLMClient,
+    context_manager: ContextManager,
+    max_retries: int = 3,
+    rescue_enabled: bool = True,
+    anthropic_backend: bool = False,
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Handle a /v1/messages request (Anthropic incoming format).
+
+    Converts inbound Anthropic messages to OpenAI format, then delegates
+    to handle_chat_completions for the inference pipeline.
+
+    Args:
+        body: Parsed JSON request body in Anthropic format.
+        client: The forge LLM client for the backend.
+        context_manager: For context compaction.
+        max_retries: Max consecutive retries for bad responses.
+        rescue_enabled: Whether to attempt rescue parsing.
+        anthropic_backend: If True, return Anthropic-format responses.
+
+    Returns:
+        If stream=false: a response dict.
+        If stream=true: a list of SSE chunk dicts.
+    """
+    # Convert Anthropic body to OpenAI messages
+    openai_messages = anthropic_to_openai_messages(body)
+
+    # Build an OpenAI-format body for handle_chat_completions
+    openai_body: dict[str, Any] = {
+        "model": body.get("model", "forge"),
+        "messages": openai_messages,
+        "stream": body.get("stream", False),
+    }
+
+    # Convert Anthropic tools to OpenAI tools
+    anthropic_tools = body.get("tools")
+    if anthropic_tools:
+        openai_body["tools"] = []
+        for tool in anthropic_tools:
+            openai_body["tools"].append({
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "parameters": tool.get("input_schema", {}),
+                },
+            })
+
+    # Map Anthropic sampling params to OpenAI
+    if "temperature" in body:
+        openai_body["temperature"] = body["temperature"]
+    if "top_p" in body:
+        openai_body["top_p"] = body["top_p"]
+    if "top_k" in body:
+        openai_body["top_k"] = body["top_k"]
+
+    return await handle_chat_completions(
+        body=openai_body,
+        client=client,
+        context_manager=context_manager,
+        max_retries=max_retries,
+        rescue_enabled=rescue_enabled,
+        anthropic_backend=anthropic_backend,
+    )

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -2,27 +2,24 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
 from forge.clients.base import LLMClient
 from forge.context.manager import ContextManager
 from forge.core.inference import fold_and_serialize, run_inference
-from forge.core.workflow import ToolCall, ToolSpec, TextResponse
+from forge.core.workflow import TextResponse, ToolCall, ToolSpec
 from forge.errors import ToolCallError
 from forge.guardrails import ErrorTracker, ResponseValidator
 from forge.proxy.convert import (
-    openai_to_messages,
-    tool_calls_to_openai,
-    tool_calls_to_sse_events,
-    text_response_to_openai,
-    text_to_sse_events,
     anthropic_to_openai_messages,
     openai_to_anthropic_response,
     openai_to_anthropic_sse,
-    anthropic_to_openai_response,
-    anthropic_to_openai_sse,
+    openai_to_messages,
+    text_response_to_openai,
+    text_to_sse_events,
+    tool_calls_to_openai,
+    tool_calls_to_sse_events,
 )
 from forge.tools.respond import RESPOND_TOOL_NAME, respond_spec
 
@@ -87,9 +84,15 @@ def _format_tool_calls(
             return tool_calls_to_sse_events(tool_calls, model)
         return tool_calls_to_openai(tool_calls, model)
 _SAMPLING_FIELDS = (
-    "temperature", "top_p", "top_k", "min_p",
-    "repeat_penalty", "presence_penalty", "seed",
-    "chat_template_kwargs", "model",
+    "temperature",
+    "top_p",
+    "top_k",
+    "min_p",
+    "repeat_penalty",
+    "presence_penalty",
+    "seed",
+    "chat_template_kwargs",
+    "model",
 )
 
 
@@ -115,11 +118,13 @@ def _extract_tool_specs(request_tools: list[dict[str, Any]] | None) -> list[Tool
         name = func.get("name", "")
         description = func.get("description", "")
         parameters = func.get("parameters", {})
-        specs.append(ToolSpec.from_json_schema(
-            name=name,
-            description=description,
-            schema=parameters,
-        ))
+        specs.append(
+            ToolSpec.from_json_schema(
+                name=name,
+                description=description,
+                schema=parameters,
+            )
+        )
     return specs
 
 
@@ -159,6 +164,7 @@ async def handle_chat_completions(
     is_stream = body.get("stream", False)
     model_name = body.get("model", "forge")
     sampling = _extract_sampling(body)
+    max_tokens = body.get("max_tokens")
 
     # Convert inbound
     messages = openai_to_messages(openai_messages)
@@ -179,9 +185,11 @@ async def handle_chat_completions(
         logger.info("No tools in request, passing through to backend")
         api_format = getattr(client, "api_format", "ollama")
         api_messages = fold_and_serialize(messages, api_format)
-        response = await client.send(api_messages, tools=None, sampling=sampling)
+        response = await client.send(api_messages, tools=None, sampling=sampling, max_tokens=max_tokens)
         text = response.content if isinstance(response, TextResponse) else ""
         return _format_response(text, is_stream, model_name, anthropic_backend)
+
+    logger.info("Guardrails active: tools=%s", tool_names)
 
     # Set up guardrails
     validator = ResponseValidator(tool_names, rescue_enabled=rescue_enabled)
@@ -197,6 +205,7 @@ async def handle_chat_completions(
             error_tracker=error_tracker,
             tool_specs=tool_specs,
             sampling=sampling,
+            max_tokens=max_tokens,
         )
     except ToolCallError as exc:
         # Retries exhausted — the model kept returning text instead of tool
@@ -211,6 +220,7 @@ async def handle_chat_completions(
         return _format_response("", is_stream, model_name, anthropic_backend)
 
     tool_calls = result.response
+    logger.info("Model returned %d tool call(s): %s", len(tool_calls), [tc.tool for tc in tool_calls])
 
     # Strip respond() calls — convert to plain text for the client.
     # If the model called respond(message="..."), the client sees a
@@ -273,14 +283,16 @@ async def handle_messages(
     if anthropic_tools:
         openai_body["tools"] = []
         for tool in anthropic_tools:
-            openai_body["tools"].append({
-                "type": "function",
-                "function": {
-                    "name": tool["name"],
-                    "description": tool.get("description", ""),
-                    "parameters": tool.get("input_schema", {}),
-                },
-            })
+            openai_body["tools"].append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool["name"],
+                        "description": tool.get("description", ""),
+                        "parameters": tool.get("input_schema", {}),
+                    },
+                }
+            )
 
     # Map Anthropic sampling params to OpenAI
     if "temperature" in body:

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -13,6 +13,7 @@ import threading
 from pathlib import Path
 from typing import Any
 
+from forge.clients.anthropic import AnthropicClient
 from forge.clients.base import LLMClient
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
@@ -62,9 +63,11 @@ class ProxyServer:
     ) -> None:
         """
         Args:
-            backend_url: URL of an externally managed backend (external mode).
-            backend: Backend type — "llamaserver" or "ollama" (managed mode).
-            model: Model name (managed mode, required for ollama).
+            backend_url: URL of an externally managed backend (external mode),
+                or Anthropic-compatible endpoint URL (with --backend anthropic).
+            backend: Backend type — "llamaserver", "ollama", "llamafile", or
+                "anthropic" (managed mode).
+            model: Model name (managed mode, required for ollama/anthropic).
             gguf: Path to GGUF file (managed mode, llamaserver/llamafile).
             backend_port: Port for the managed backend (default 8080).
             budget_mode: How to determine context budget.
@@ -79,6 +82,8 @@ class ProxyServer:
         """
         if backend_url is None and backend is None:
             raise ValueError("Provide either backend_url (external) or backend (managed)")
+
+        self._anthropic_base_url = backend_url if backend == "anthropic" else None
 
         self._backend_url = backend_url
         self._backend = backend
@@ -157,7 +162,19 @@ class ProxyServer:
         client: LLMClient
         context_manager: ContextManager
 
-        if self._backend_url is not None:
+        if self._backend == "anthropic":
+            # Anthropic backend — uses AnthropicClient; --backend-url is an
+            # optional override for a llama-server-compatible Anthropic endpoint.
+            assert self._model is not None
+            client = AnthropicClient(
+                model=self._model,
+                base_url=self._anthropic_base_url,
+            )
+            context_manager = ContextManager(
+                strategy=TieredCompact(),
+                budget_tokens=self._budget_tokens or 8192,
+            )
+        elif self._backend_url is not None:
             # External mode — connect to existing backend
             # LlamafileClient expects base_url with /v1 suffix
             base = self._backend_url.rstrip("/")
@@ -225,6 +242,7 @@ class ProxyServer:
             serialize_requests=self._serialize,
             max_retries=self._max_retries,
             rescue_enabled=self._rescue_enabled,
+            anthropic_backend=self._backend == "anthropic",
         )
         await self._http_server.start()
         self._started = True

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -11,7 +11,6 @@ import asyncio
 import logging
 import threading
 from pathlib import Path
-from typing import Any
 
 from forge.clients.anthropic import AnthropicClient
 from forge.clients.base import LLMClient
@@ -125,7 +124,9 @@ class ProxyServer:
 
         ready = threading.Event()
         self._thread = threading.Thread(
-            target=self._run_loop, args=(ready,), daemon=True,
+            target=self._run_loop,
+            args=(ready,),
+            daemon=True,
         )
         self._thread.start()
         ready.wait(timeout=120)

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -64,7 +64,9 @@ class HTTPServer:
         if self._serialize:
             self._worker_task = asyncio.create_task(self._inference_worker())
         self._server = await asyncio.start_server(
-            self._handle_connection, self._host, self._port,
+            self._handle_connection,
+            self._host,
+            self._port,
         )
         logger.info("Proxy listening on %s:%d", self._host, self._port)
 
@@ -116,7 +118,8 @@ class HTTPServer:
         try:
             # Read request line
             request_line = await asyncio.wait_for(
-                reader.readline(), timeout=30.0,
+                reader.readline(),
+                timeout=30.0,
             )
             if not request_line:
                 return
@@ -128,6 +131,7 @@ class HTTPServer:
                 return
 
             method, path = parts[0], parts[1]
+            pure_path = path.split("?")[0]
             logger.info(">> %s %s", method, path)
 
             # Read headers
@@ -141,24 +145,25 @@ class HTTPServer:
                     await self._send_error(writer, 413, "Request too large")
                     return
                 body_bytes = await asyncio.wait_for(
-                    reader.readexactly(content_length), timeout=60.0,
+                    reader.readexactly(content_length),
+                    timeout=60.0,
                 )
 
-            # Route
-            if method == "GET" and path == "/health":
+            # Route (use pure_path to ignore query strings)
+            if method == "GET" and pure_path == "/health":
                 await self._handle_health(writer)
-            elif method == "GET" and path == "/v1/models":
+            elif method == "GET" and pure_path == "/v1/models":
                 await self._handle_models(writer)
-            elif method == "POST" and path == "/v1/chat/completions":
+            elif method == "POST" and pure_path == "/v1/chat/completions":
                 await self._handle_completions(writer, body_bytes)
-            elif method == "POST" and path == "/v1/messages":
+            elif method == "POST" and pure_path == "/v1/messages":
                 await self._handle_messages(writer, body_bytes)
             elif method == "OPTIONS":
                 await self._send_cors_preflight(writer)
             else:
                 await self._send_error(writer, 404, "Not found")
 
-        except (asyncio.TimeoutError, asyncio.IncompleteReadError, ConnectionError):
+        except (TimeoutError, asyncio.IncompleteReadError, ConnectionError):
             pass
         except Exception:
             logger.exception("Unhandled error in connection handler")
@@ -193,10 +198,12 @@ class HTTPServer:
 
     async def _handle_models(self, writer: asyncio.StreamWriter) -> None:
         """GET /v1/models — returns a minimal model list."""
-        body = json.dumps({
-            "object": "list",
-            "data": [{"id": "forge", "object": "model"}],
-        })
+        body = json.dumps(
+            {
+                "object": "list",
+                "data": [{"id": "forge", "object": "model"}],
+            }
+        )
         await self._send_json(writer, 200, body)
 
     async def _handle_completions(
@@ -216,7 +223,10 @@ class HTTPServer:
         tool_count = len(body.get("tools", []))
         logger.info(
             "   stream=%s messages=%d tools=%d model=%s",
-            is_stream, msg_count, tool_count, body.get("model", "?"),
+            is_stream,
+            msg_count,
+            tool_count,
+            body.get("model", "?"),
         )
 
         if self._serialize:
@@ -278,7 +288,10 @@ class HTTPServer:
         tool_count = len(body.get("tools", []))
         logger.info(
             "   [anthropic] stream=%s messages=%d tools=%d model=%s",
-            is_stream, msg_count, tool_count, body.get("model", "?"),
+            is_stream,
+            msg_count,
+            tool_count,
+            body.get("model", "?"),
         )
 
         if self._serialize:
@@ -318,7 +331,8 @@ class HTTPServer:
             await self._send_json(writer, 200, json.dumps(result))
 
     async def _run_anthropic_handler(
-        self, body: dict[str, Any],
+        self,
+        body: dict[str, Any],
     ) -> dict[str, Any] | list[dict[str, Any]] | Exception:
         """Run the Anthropic handler, catching errors."""
         try:
@@ -350,14 +364,16 @@ class HTTPServer:
                 return None
             try:
                 await asyncio.wait_for(
-                    asyncio.shield(item.future), timeout=1.0,
+                    asyncio.shield(item.future),
+                    timeout=1.0,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 continue
         return item.future.result()
 
     async def _run_handler(
-        self, body: dict[str, Any],
+        self,
+        body: dict[str, Any],
     ) -> dict[str, Any] | list[dict[str, Any]] | Exception:
         """Run the handler, catching errors."""
         try:
@@ -374,7 +390,10 @@ class HTTPServer:
             return exc
 
     async def _send_json(
-        self, writer: asyncio.StreamWriter, status: int, body: str,
+        self,
+        writer: asyncio.StreamWriter,
+        status: int,
+        body: str,
     ) -> None:
         """Send a JSON HTTP response."""
         response = (
@@ -404,14 +423,19 @@ class HTTPServer:
         await writer.drain()
 
     async def _send_sse_body(
-        self, writer: asyncio.StreamWriter, events: list[dict[str, Any]],
+        self,
+        writer: asyncio.StreamWriter,
+        events: list[dict[str, Any]],
     ) -> None:
         """Send SSE event data and terminator. Headers must already be sent."""
         for event in events:
             if writer.is_closing():
                 return
-            data = f"data: {json.dumps(event)}\n\n".encode()
-            writer.write(f"{len(data):x}\r\n".encode() + data + b"\r\n")
+            event_type = event.get("type", "")
+            data_line = f"data: {json.dumps(event)}\n"
+            event_line = f"event: {event_type}\n" if event_type else ""
+            body = f"{event_line}{data_line}\n".encode()
+            writer.write(f"{len(body):x}\r\n".encode() + body + b"\r\n")
             await writer.drain()
 
         done = b"data: [DONE]\n\n"
@@ -422,7 +446,10 @@ class HTTPServer:
         logger.info("<< SSE complete, [DONE] sent")
 
     async def _send_error(
-        self, writer: asyncio.StreamWriter, status: int, message: str,
+        self,
+        writer: asyncio.StreamWriter,
+        status: int,
+        message: str,
     ) -> None:
         """Send an error JSON response."""
         body = json.dumps({"error": {"message": message, "type": "proxy_error"}})

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from forge.clients.base import LLMClient
 from forge.context.manager import ContextManager
-from forge.proxy.handler import handle_chat_completions
+from forge.proxy.handler import handle_chat_completions, handle_messages
 
 logger = logging.getLogger("forge.proxy")
 
@@ -30,6 +30,7 @@ class _QueueItem:
     body: dict[str, Any]
     future: asyncio.Future = field(default_factory=lambda: asyncio.get_event_loop().create_future())
     cancelled: bool = False
+    handler_func: Any = None
 
 
 class HTTPServer:
@@ -44,6 +45,7 @@ class HTTPServer:
         serialize_requests: bool = True,
         max_retries: int = 3,
         rescue_enabled: bool = True,
+        anthropic_backend: bool = False,
     ) -> None:
         self._client = client
         self._context_manager = context_manager
@@ -51,6 +53,7 @@ class HTTPServer:
         self._port = port
         self._max_retries = max_retries
         self._rescue_enabled = rescue_enabled
+        self._anthropic_backend = anthropic_backend
         self._server: asyncio.Server | None = None
         self._serialize = serialize_requests
         self._queue: asyncio.Queue[_QueueItem] = asyncio.Queue()
@@ -90,7 +93,10 @@ class HTTPServer:
                 if item.cancelled or item.future.cancelled():
                     logger.info("   Skipping cancelled request")
                     continue
-                result = await self._run_handler(item.body)
+                if item.handler_func is not None:
+                    result = await item.handler_func(item.body)
+                else:
+                    result = await self._run_handler(item.body)
                 if not item.future.done():
                     item.future.set_result(result)
             except asyncio.CancelledError:
@@ -145,6 +151,8 @@ class HTTPServer:
                 await self._handle_models(writer)
             elif method == "POST" and path == "/v1/chat/completions":
                 await self._handle_completions(writer, body_bytes)
+            elif method == "POST" and path == "/v1/messages":
+                await self._handle_messages(writer, body_bytes)
             elif method == "OPTIONS":
                 await self._send_cors_preflight(writer)
             else:
@@ -253,6 +261,79 @@ class HTTPServer:
             logger.info("<< JSON 200")
             await self._send_json(writer, 200, json.dumps(result))
 
+    async def _handle_messages(
+        self,
+        writer: asyncio.StreamWriter,
+        body_bytes: bytes,
+    ) -> None:
+        """POST /v1/messages — Anthropic-compatible endpoint."""
+        try:
+            body = json.loads(body_bytes)
+        except json.JSONDecodeError:
+            await self._send_error(writer, 400, "Invalid JSON")
+            return
+
+        is_stream = body.get("stream", False)
+        msg_count = len(body.get("messages", []))
+        tool_count = len(body.get("tools", []))
+        logger.info(
+            "   [anthropic] stream=%s messages=%d tools=%d model=%s",
+            is_stream, msg_count, tool_count, body.get("model", "?"),
+        )
+
+        if self._serialize:
+            item = _QueueItem(body=body, handler_func=self._run_anthropic_handler)
+            queue_depth = self._queue.qsize()
+            if queue_depth > 0:
+                logger.info("   Queued (depth=%d)", queue_depth + 1)
+
+            if is_stream:
+                await self._send_sse_header(writer)
+
+            self._queue.put_nowait(item)
+            result = await self._await_with_disconnect(item, writer)
+        else:
+            if is_stream:
+                await self._send_sse_header(writer)
+            result = await self._run_anthropic_handler(body)
+
+        if result is None:
+            logger.info("<< Client disconnected, discarding result")
+            return
+
+        if isinstance(result, Exception):
+            error_msg = str(result)
+            logger.info("<< ERROR: %s", error_msg[:120])
+            if is_stream:
+                await self._send_sse_body(writer, [{"error": error_msg}])
+            else:
+                await self._send_error(writer, 502, error_msg)
+            return
+
+        if is_stream:
+            logger.info("<< SSE %d events", len(result))
+            await self._send_sse_body(writer, result)
+        else:
+            logger.info("<< JSON 200")
+            await self._send_json(writer, 200, json.dumps(result))
+
+    async def _run_anthropic_handler(
+        self, body: dict[str, Any],
+    ) -> dict[str, Any] | list[dict[str, Any]] | Exception:
+        """Run the Anthropic handler, catching errors."""
+        try:
+            return await handle_messages(
+                body=body,
+                client=self._client,
+                context_manager=self._context_manager,
+                max_retries=self._max_retries,
+                rescue_enabled=self._rescue_enabled,
+                anthropic_backend=self._anthropic_backend,
+            )
+        except Exception as exc:
+            logger.exception("Handler error")
+            return exc
+
     async def _await_with_disconnect(
         self,
         item: _QueueItem,
@@ -286,6 +367,7 @@ class HTTPServer:
                 context_manager=self._context_manager,
                 max_retries=self._max_retries,
                 rescue_enabled=self._rescue_enabled,
+                anthropic_backend=self._anthropic_backend,
             )
         except Exception as exc:
             logger.exception("Handler error")

--- a/tests/eval/eval_runner.py
+++ b/tests/eval/eval_runner.py
@@ -9,24 +9,28 @@ from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from forge.clients.base import ChunkType, LLMClient, StreamChunk
+from forge.clients.base import LLMClient, StreamChunk
 from forge.context.manager import CompactEvent, ContextManager
 from forge.context.strategies import CompactStrategy, NoCompact, SlidingWindowCompact, TieredCompact
 from forge.core.messages import Message, MessageType
 from forge.core.runner import WorkflowRunner
-from forge.core.workflow import ToolCall, ToolDef, ToolSpec, Workflow
+from forge.core.workflow import ToolDef, ToolSpec, Workflow
 from forge.errors import ForgeError, StreamError
 from forge.server import BudgetMode, ServerManager
-
 from tests.eval.ablation import ABLATION_PRESETS, AblationConfig
 from tests.eval.scenarios import ALL_SCENARIOS, EvalScenario
 
 # Scenarios that always use their own hardcoded budget (MANUAL override).
 _COMPACTION_SCENARIOS = {
-    "compaction_stress", "phase2_compaction",
-    "compaction_stress_stateful", "phase2_compaction_stateful",
-    "inventory_audit", "supplier_deep_dive",
-    "compaction_chain_p1", "compaction_chain_p2", "compaction_chain_p3",
+    "compaction_stress",
+    "phase2_compaction",
+    "compaction_stress_stateful",
+    "phase2_compaction_stateful",
+    "inventory_audit",
+    "supplier_deep_dive",
+    "compaction_chain_p1",
+    "compaction_chain_p2",
+    "compaction_chain_p3",
 }
 
 
@@ -89,9 +93,10 @@ class CountingClientWrapper:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        **kwargs,
     ) -> Any:
         self.call_count += 1
-        result = await self._client.send(messages, tools=tools, sampling=sampling)
+        result = await self._client.send(messages, tools=tools, sampling=sampling, **kwargs)
         self._collect_usage()
         return result
 
@@ -100,9 +105,10 @@ class CountingClientWrapper:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        **kwargs,
     ) -> AsyncIterator[StreamChunk]:
         self.call_count += 1
-        async for chunk in self._client.send_stream(messages, tools=tools, sampling=sampling):
+        async for chunk in self._client.send_stream(messages, tools=tools, sampling=sampling, **kwargs):
             yield chunk
         self._collect_usage()
 
@@ -244,6 +250,7 @@ async def run_scenario(
     elif len(callbacks) == 1:
         on_message = callbacks[0]
     else:
+
         def on_message(msg: Message) -> None:
             for cb in callbacks:
                 cb(msg)
@@ -387,9 +394,7 @@ async def run_eval(
             ``client.set_num_ctx()`` per-scenario for Ollama backends.
     """
     if tags:
-        scenarios = [
-            s for s in scenarios if any(t in s.tags for t in tags)
-        ]
+        scenarios = [s for s in scenarios if any(t in s.tags for t in tags)]
     if names:
         scenarios = [s for s in scenarios if s.name in names]
 
@@ -427,8 +432,7 @@ async def run_eval(
         scenario_results: list[RunResult] = []
         for run_idx in range(config.runs_per_scenario):
             print(
-                f"  Running {scenario.name} "
-                f"[{run_idx + 1}/{config.runs_per_scenario}]...",
+                f"  Running {scenario.name} [{run_idx + 1}/{config.runs_per_scenario}]...",
                 flush=True,
             )
             result = await run_scenario(client, scenario, per_scenario_config, ablation=ablation)
@@ -451,8 +455,7 @@ async def run_eval(
                 if cost > 0:
                     cost_str = f", ${cost:.4f}"
             print(
-                f"    {status} — {result.iterations_used} iterations, "
-                f"{result.elapsed_seconds:.1f}s{cost_str}",
+                f"    {status} — {result.iterations_used} iterations, {result.elapsed_seconds:.1f}s{cost_str}",
                 flush=True,
             )
         results[scenario.name] = scenario_results
@@ -515,7 +518,8 @@ async def main() -> None:
         help="Disable message history collection",
     )
     parser.add_argument(
-        "--verbose", "-v",
+        "--verbose",
+        "-v",
         action="store_true",
         help="Print live per-message trace during each run",
     )
@@ -577,6 +581,7 @@ async def main() -> None:
     # Display name for reports / cost lookup. For llamafile this is the GGUF
     # stem (matches what self.model in the client resolves to).
     from pathlib import Path as _Path
+
     display_name = args.model if args.backend != "llamafile" else _Path(args.gguf).stem
 
     # Build client
@@ -586,7 +591,9 @@ async def main() -> None:
 
         think_val = {"true": True, "false": False, "auto": None}[args.think]
         client: LLMClient = OllamaClient(
-            model=args.model, think=think_val, **url_kw,
+            model=args.model,
+            think=think_val,
+            **url_kw,
             recommended_sampling=True,
         )
     elif args.backend == "anthropic":
@@ -598,8 +605,11 @@ async def main() -> None:
 
         think_val = {"true": True, "false": False, "auto": None}[args.think]
         client = LlamafileClient(
-            gguf_path=args.gguf, mode=args.llamafile_mode, think=think_val,
-            cache_prompt=not args.no_cache_prompt, **url_kw,
+            gguf_path=args.gguf,
+            mode=args.llamafile_mode,
+            think=think_val,
+            cache_prompt=not args.no_cache_prompt,
+            **url_kw,
             recommended_sampling=True,
         )
 
@@ -669,9 +679,12 @@ async def main() -> None:
     print()
 
     results = await run_eval(
-        client, ALL_SCENARIOS, config,
+        client,
+        ALL_SCENARIOS,
+        config,
         resolved_budget=resolved_budget,
-        tags=args.tags, names=args.scenario,
+        tags=args.tags,
+        names=args.scenario,
         ablation=ablation,
     )
 
@@ -687,10 +700,7 @@ async def main() -> None:
         from tests.eval.batch_eval import _compute_cost
 
         total_cost = _compute_cost(args.model, total_input, total_output)
-        print(
-            f"Token usage: {total_input:,} input + {total_output:,} output"
-            f" = {total_input + total_output:,} total"
-        )
+        print(f"Token usage: {total_input:,} input + {total_output:,} output = {total_input + total_output:,} total")
         if total_cost > 0:
             n_runs = len(all_runs)
             print(f"Total cost: ${total_cost:.4f} ({n_runs} runs, ${total_cost / n_runs:.4f}/run)")

--- a/tests/unit/test_anthropic_client.py
+++ b/tests/unit/test_anthropic_client.py
@@ -405,3 +405,22 @@ class TestParseResponse:
         result = AnthropicClient._parse_response(response)
         assert isinstance(result, TextResponse)
         assert result.content == ""
+
+
+# ── Client construction ──────────────────────────────────────────
+
+
+class TestClientConstruction:
+    def test_base_url_passed_to_sdk(self) -> None:
+        """base_url is forwarded to the Anthropic SDK."""
+        client = AnthropicClient(
+            model="claude-sonnet-4",
+            api_key="test-key",
+            base_url="http://localhost:1234/v1",
+        )
+        assert str(client._client._base_url) == "http://localhost:1234/v1/"
+
+    def test_no_base_url_by_default(self) -> None:
+        """Without base_url, SDK uses default Anthropic endpoint (not env override)."""
+        client = AnthropicClient(model="claude-sonnet-4", api_key="test-key")
+        assert str(client._client._base_url) == "https://api.anthropic.com"

--- a/tests/unit/test_anthropic_convert.py
+++ b/tests/unit/test_anthropic_convert.py
@@ -1,0 +1,542 @@
+"""Tests for forge.proxy.convert — Anthropic ↔ OpenAI conversion functions.
+
+All tests exercise the 6 conversion functions directly.
+No API calls or mocks needed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from forge.proxy.convert import (
+    anthropic_to_openai_messages,
+    anthropic_to_openai_response,
+    anthropic_to_openai_sse,
+    openai_to_anthropic_messages,
+    openai_to_anthropic_response,
+    openai_to_anthropic_sse,
+)
+
+
+# ── anthropic_to_openai_messages ──────────────────────────────────
+
+
+class TestAnthropicToOpenAIMessages:
+    """Convert Anthropic API request body → OpenAI messages list."""
+
+    def test_simple_text(self) -> None:
+        body: dict[str, Any] = {
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert result == [{"role": "user", "content": "Hello"}]
+
+    def test_system_string(self) -> None:
+        body: dict[str, Any] = {
+            "system": "You are helpful.",
+            "messages": [{"role": "user", "content": "Hi"}],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert len(result) == 2
+        assert result[0] == {"role": "system", "content": "You are helpful."}
+        assert result[1] == {"role": "user", "content": "Hi"}
+
+    def test_assistant_tool_use(self) -> None:
+        body: dict[str, Any] = {
+            "messages": [
+                {"role": "user", "content": "Weather in Paris?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "toolu_001", "name": "get_weather", "input": {"city": "Paris"}},
+                    ],
+                },
+            ],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert len(result) == 2
+        tc = result[1]["tool_calls"][0]
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "get_weather"
+        assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+        assert tc["id"] == "toolu_001"
+
+    def test_assistant_text_and_tool(self) -> None:
+        body: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Let me check."},
+                        {"type": "tool_use", "id": "t1", "name": "search", "input": {"q": "test"}},
+                    ],
+                },
+            ],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "Let me check."
+        assert len(result[0]["tool_calls"]) == 1
+
+    def test_tool_result_becomes_tool_role(self) -> None:
+        body: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "t1", "content": "22C"},
+                    ],
+                },
+            ],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert result[0] == {
+            "role": "tool",
+            "tool_call_id": "t1",
+            "content": "22C",
+            "name": "",
+        }
+
+    def test_thinking_block(self) -> None:
+        body: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "thinking", "text": "I think..."}],
+                },
+            ],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert result[0]["content"] == "<think>I think...</think>"
+
+    def test_full_conversation(self) -> None:
+        body: dict[str, Any] = {
+            "system": "You are a weather bot.",
+            "messages": [
+                {"role": "user", "content": "Weather in Paris?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "t1", "name": "get_weather", "input": {"city": "Paris"}},
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "t1", "content": "22C sunny"},
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "It's 22C and sunny in Paris."}],
+                },
+            ],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert len(result) == 5
+        assert result[0]["role"] == "system"
+        assert result[1]["role"] == "user"
+        assert result[2]["role"] == "assistant"
+        assert "tool_calls" in result[2]
+        assert result[3]["role"] == "tool"
+        assert result[4]["role"] == "assistant"
+
+    def test_empty_messages(self) -> None:
+        result = anthropic_to_openai_messages({})
+        assert result == []
+
+    def test_string_content(self) -> None:
+        body: dict[str, Any] = {
+            "messages": [{"role": "user", "content": "plain text"}],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert result == [{"role": "user", "content": "plain text"}]
+
+
+# ── openai_to_anthropic_messages ──────────────────────────────────
+
+
+class TestOpenAIToAnthropicMessages:
+    """Convert OpenAI messages list → Anthropic body fields."""
+
+    def test_simple_text(self) -> None:
+        msgs = [{"role": "user", "content": "Hello"}]
+        result = openai_to_anthropic_messages(msgs)
+        assert result == {"messages": [{"role": "user", "content": "Hello"}]}
+
+    def test_system_extracted(self) -> None:
+        msgs = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "Hi"},
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        assert result["system"] == "Be helpful."
+        assert len(result["messages"]) == 1
+
+    def test_tool_call_conversion(self) -> None:
+        msgs = [
+            {"role": "assistant", "content": "", "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "call_001",
+                    "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                }
+            ]},
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        block = result["messages"][0]["content"][0]
+        assert block["type"] == "tool_use"
+        assert block["id"] == "call_001"
+        assert block["name"] == "get_weather"
+        assert block["input"] == {"city": "Paris"}
+
+    def test_tool_result_becomes_user_with_block(self) -> None:
+        msgs = [
+            {"role": "tool", "tool_call_id": "call_001", "content": "22C"},
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        assert result["messages"][0]["role"] == "user"
+        block = result["messages"][0]["content"][0]
+        assert block["type"] == "tool_result"
+        assert block["tool_use_id"] == "call_001"
+        assert block["content"] == "22C"
+
+    def test_tool_result_with_error(self) -> None:
+        msgs = [
+            {"role": "tool", "tool_call_id": "call_001", "content": "error", "is_error": True},
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        block = result["messages"][0]["content"][0]
+        assert block["is_error"] is True
+
+    def test_assistant_text_with_tool(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "Let me check.",
+                "tool_calls": [
+                    {"type": "function", "id": "t1", "function": {"name": "search", "arguments": '{"q":"x"}'}},
+                ],
+            },
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        blocks = result["messages"][0]["content"]
+        assert len(blocks) == 2
+        assert blocks[0] == {"type": "text", "text": "Let me check."}
+        assert blocks[1]["type"] == "tool_use"
+
+    def test_arguments_as_dict(self) -> None:
+        """Arguments already parsed as dict still works."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"type": "function", "id": "t1", "function": {"name": "f", "arguments": {"key": "val"}}},
+                ],
+            },
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        assert result["messages"][0]["content"][0]["input"] == {"key": "val"}
+
+    def test_content_as_list_normalized(self) -> None:
+        """User message with content as list of blocks gets normalized."""
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": "Hello"}, {"type": "thinking", "text": "Hmm"}]},
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        assert result["messages"][0]["content"] == [
+            {"type": "text", "text": "Hello"},
+            {"type": "thinking", "text": "Hmm"},
+        ]
+
+    def test_empty_content(self) -> None:
+        msgs = [{"role": "assistant", "content": ""}]
+        result = openai_to_anthropic_messages(msgs)
+        assert result["messages"][0]["content"] == ""
+
+
+# ── openai_to_anthropic_response ──────────────────────────────────
+
+
+class TestOpenAItoAnthropicResponse:
+    """Convert OpenAI non-streaming response → Anthropic response."""
+
+    def test_text_response(self) -> None:
+        openai_resp = {
+            "id": "chatcmpl-abc",
+            "choices": [{"message": {"content": "Hello!", "role": "assistant"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        result = openai_to_anthropic_response(openai_resp, "claude-sonnet-4")
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["model"] == "claude-sonnet-4"
+        assert result["stop_reason"] == "end_turn"
+        assert len(result["content"]) == 1
+        assert result["content"][0] == {"type": "text", "text": "Hello!"}
+        assert result["usage"]["input_tokens"] == 10
+        assert result["usage"]["output_tokens"] == 5
+
+    def test_tool_call_response(self) -> None:
+        openai_resp = {
+            "id": "chatcmpl-xyz",
+            "choices": [{
+                "message": {
+                    "content": "Checking...",
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "type": "function",
+                        "id": "call_001",
+                        "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+            "usage": {"prompt_tokens": 20, "completion_tokens": 10},
+        }
+        result = openai_to_anthropic_response(openai_resp, "claude-haiku")
+        assert result["stop_reason"] == "tool_use"
+        assert len(result["content"]) == 2
+        assert result["content"][0] == {"type": "text", "text": "Checking..."}
+        tc = result["content"][1]
+        assert tc["type"] == "tool_use"
+        assert tc["name"] == "get_weather"
+        assert tc["input"] == {"city": "Paris"}
+
+    def test_finish_reason_mapping(self) -> None:
+        """Verify all finish_reason → stop_reason mappings."""
+        mapping = {
+            "stop": "end_turn",
+            "length": "max_tokens",
+            "tool_calls": "tool_use",
+        }
+        for finish, expected_stop in mapping.items():
+            openai_resp = {
+                "choices": [{"finish_reason": finish}],
+                "usage": {},
+            }
+            result = openai_to_anthropic_response(openai_resp, "model")
+            assert result["stop_reason"] == expected_stop, f"Failed for finish_reason={finish}"
+
+    def test_empty_content(self) -> None:
+        openai_resp = {
+            "choices": [{"message": {"content": "", "role": "assistant"}, "finish_reason": "stop"}],
+            "usage": {},
+        }
+        result = openai_to_anthropic_response(openai_resp, "model")
+        assert result["content"][0] == {"type": "text", "text": ""}
+
+
+# ── openai_to_anthropic_sse ──────────────────────────────────────
+
+
+class TestOpenAItoAnthropicSSE:
+    """Convert OpenAI SSE chunks → Anthropic SSE events."""
+
+    def test_text_stream(self) -> None:
+        events = [
+            {"id": "chatcmpl-1", "choices": [{"delta": {"content": "Hello"}, "finish_reason": None}]},
+            {"id": "chatcmpl-1", "choices": [{"delta": {"content": " world"}, "finish_reason": "stop"}]},
+        ]
+        result = openai_to_anthropic_sse(events, "claude-sonnet-4")
+        # Should have message_start, content blocks, message_stop
+        assert result[0]["type"] == "message_start"
+        # Find message_stop
+        stop_events = [e for e in result if e.get("type") == "message_stop"]
+        assert len(stop_events) >= 1
+        # Check text delta events exist
+        text_deltas = [e for e in result if e.get("delta", {}).get("type") == "text_delta"]
+        assert len(text_deltas) >= 2  # "Hello" and " world"
+
+    def test_tool_call_stream(self) -> None:
+        events = [
+            {"id": "chatcmpl-2", "choices": [{
+                "delta": {"tool_calls": [{
+                    "index": 0,
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                }]},
+                "finish_reason": None,
+            }]},
+            {"id": "chatcmpl-2", "choices": [{
+                "delta": {"tool_calls": [{
+                    "index": 0,
+                    "function": {"arguments": '{"city": "'},
+                }]},
+                "finish_reason": None,
+            }]},
+            {"id": "chatcmpl-2", "choices": [{
+                "delta": {"tool_calls": [{
+                    "index": 0,
+                    "function": {"arguments": 'Paris"}'},
+                }]},
+                "finish_reason": "tool_calls",
+            }]},
+        ]
+        result = openai_to_anthropic_sse(events, "model")
+        # Should have tool_use content blocks
+        tool_starts = [e for e in result if e.get("content_block", {}).get("type") == "tool_use"]
+        assert len(tool_starts) >= 1
+        input_deltas = [e for e in result if e.get("delta", {}).get("type") == "input_json_delta"]
+        assert len(input_deltas) >= 1
+
+    def test_wrapped_with_id_and_model(self) -> None:
+        events = [
+            {"id": "chatcmpl-3", "choices": [{"delta": {"content": "x"}, "finish_reason": "stop"}]},
+        ]
+        result = openai_to_anthropic_sse(events, "claude-haiku")
+        for ev in result:
+            assert ev.get("id") == "chatcmpl-3"
+            if ev.get("type") not in ("message_stop",):
+                assert ev.get("model") == "claude-haiku"
+
+    def test_message_stop_at_end(self) -> None:
+        events = [
+            {"id": "chatcmpl-4", "choices": [{"delta": {"content": "Hi"}, "finish_reason": "stop"}]},
+        ]
+        result = openai_to_anthropic_sse(events, "model")
+        assert result[-1]["type"] == "message_stop"
+
+
+# ── anthropic_to_openai_response ──────────────────────────────────
+
+
+class TestAnthropicToOpenAIResponse:
+    """Convert Anthropic non-streaming response → OpenAI response."""
+
+    def test_text_response(self) -> None:
+        anthropic_resp = {
+            "id": "msg_abc",
+            "content": [{"type": "text", "text": "Hello!"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        result = anthropic_to_openai_response(anthropic_resp, "claude-sonnet-4")
+        assert result["object"] == "chat.completion"
+        assert result["model"] == "claude-sonnet-4"
+        assert result["choices"][0]["finish_reason"] == "stop"
+        msg = result["choices"][0]["message"]
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "Hello!"
+        assert result["usage"]["prompt_tokens"] == 10
+        assert result["usage"]["completion_tokens"] == 5
+        assert result["usage"]["total_tokens"] == 15
+
+    def test_tool_call_response(self) -> None:
+        anthropic_resp = {
+            "id": "msg_xyz",
+            "content": [
+                {"type": "tool_use", "id": "toolu_001", "name": "get_weather", "input": {"city": "Paris"}},
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 15, "output_tokens": 8},
+        }
+        result = anthropic_to_openai_response(anthropic_resp, "model")
+        assert result["choices"][0]["finish_reason"] == "tool_calls"
+        tc = result["choices"][0]["message"]["tool_calls"][0]
+        assert tc["id"] == "toolu_001"
+        assert tc["function"]["name"] == "get_weather"
+        assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+
+    def test_text_and_tool(self) -> None:
+        anthropic_resp = {
+            "content": [
+                {"type": "text", "text": "Let me check."},
+                {"type": "tool_use", "id": "t1", "name": "search", "input": {"q": "x"}},
+            ],
+            "stop_reason": "tool_use",
+            "usage": {},
+        }
+        result = anthropic_to_openai_response(anthropic_resp, "model")
+        msg = result["choices"][0]["message"]
+        assert "tool_calls" in msg
+        assert len(msg["tool_calls"]) == 1
+        assert msg["content"] == "Let me check."
+
+    def test_thinking_block(self) -> None:
+        anthropic_resp = {
+            "content": [{"type": "thinking", "text": "I think..."}],
+            "stop_reason": "end_turn",
+            "usage": {},
+        }
+        result = anthropic_to_openai_response(anthropic_resp, "model")
+        assert result["choices"][0]["message"]["content"] == "<think>I think...</think>"
+
+    def test_stop_reason_mapping(self) -> None:
+        for stop, expected_finish in [
+            ("end_turn", "stop"),
+            ("max_tokens", "length"),
+            ("tool_use", "tool_calls"),
+        ]:
+            resp = {"content": [], "stop_reason": stop, "usage": {}}
+            result = anthropic_to_openai_response(resp, "model")
+            assert result["choices"][0]["finish_reason"] == expected_finish, f"Failed for stop_reason={stop}"
+
+    def test_empty_response(self) -> None:
+        anthropic_resp = {
+            "content": [],
+            "stop_reason": "end_turn",
+            "usage": {},
+        }
+        result = anthropic_to_openai_response(anthropic_resp, "model")
+        assert result["choices"][0]["message"]["content"] == ""
+
+
+# ── anthropic_to_openai_sse ──────────────────────────────────────
+
+
+class TestAnthropicToOpenAISSE:
+    """Convert Anthropic SSE events → OpenAI SSE chunks."""
+
+    def test_text_stream(self) -> None:
+        events = [
+            {"type": "message_start", "model": "claude-sonnet-4"},
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": " world"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop", "stop_reason": "end_turn"},
+        ]
+        result = anthropic_to_openai_sse(events, "claude-sonnet-4")
+        # Should have chunks with content deltas
+        content_chunks = [e for e in result if e.get("choices", [{}])[0].get("delta", {}).get("content")]
+        assert len(content_chunks) >= 2  # "Hello" and " world"
+        # Final chunk should have finish_reason
+        final = result[-1]
+        assert final["choices"][0]["finish_reason"] == "stop"
+
+    def test_tool_call_stream(self) -> None:
+        events = [
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_001", "name": "get_weather"}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": '{"city": "'}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": 'Paris"}'}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop", "stop_reason": "tool_use"},
+        ]
+        result = anthropic_to_openai_sse(events, "model")
+        tool_chunks = [e for e in result if "tool_calls" in e.get("choices", [{}])[0].get("delta", {})]
+        assert len(tool_chunks) >= 2
+
+    def test_stop_reason_mapping(self) -> None:
+        for stop, expected_finish in [
+            ("end_turn", "stop"),
+            ("max_tokens", "length"),
+            ("tool_use", "tool_calls"),
+        ]:
+            events = [
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "x"}},
+                {"type": "content_block_stop", "index": 0},
+                {"type": "message_stop", "stop_reason": stop},
+            ]
+            result = anthropic_to_openai_sse(events, "model")
+            final = result[-1]
+            assert final["choices"][0]["finish_reason"] == expected_finish, f"Failed for stop_reason={stop}"
+
+    def test_empty_stream(self) -> None:
+        events: list[dict[str, Any]] = []
+        result = anthropic_to_openai_sse(events, "model")
+        assert result == []

--- a/tests/unit/test_anthropic_handler.py
+++ b/tests/unit/test_anthropic_handler.py
@@ -1,0 +1,416 @@
+"""Tests for forge.proxy.handler — Anthropic backend and /v1/messages.
+
+Tests the handler's anthropic_backend flag and handle_messages entry point,
+plus the server's /v1/messages endpoint with anthropic_backend=True.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from forge.context.manager import ContextManager
+from forge.context.strategies import NoCompact
+from forge.core.workflow import TextResponse, ToolCall
+from forge.proxy.handler import handle_chat_completions, handle_messages
+from forge.proxy.server import HTTPServer
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+def _mock_client(response):
+    """Create a mock LLMClient that returns the given response."""
+    client = AsyncMock()
+    client.api_format = "ollama"
+    client.send = AsyncMock(return_value=response)
+    return client
+
+
+# ── handle_chat_completions with anthropic_backend=True ──────
+
+
+class TestHandleChatCompletionsAnthropicBackend:
+    """Verify responses are converted to Anthropic format."""
+
+    @pytest.fixture
+    def ctx(self):
+        return ContextManager(strategy=NoCompact(), budget_tokens=8192)
+
+    @pytest.mark.asyncio
+    async def test_text_response_anthropic_format(self, ctx):
+        client = _mock_client(TextResponse(content="Hello!"))
+        body = {
+            "model": "forge",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": False,
+        }
+        result = await handle_chat_completions(
+            body=body, client=client, context_manager=ctx,
+            anthropic_backend=True,
+        )
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["model"] == "forge"
+        assert result["stop_reason"] == "end_turn"
+        assert result["content"][0] == {"type": "text", "text": "Hello!"}
+        assert "usage" in result
+
+    @pytest.mark.asyncio
+    async def test_tool_call_response_anthropic_format(self, ctx):
+        client = _mock_client([ToolCall(tool="search", args={"q": "test"})])
+        body = {
+            "model": "forge",
+            "messages": [{"role": "user", "content": "search"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search",
+                    "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+                },
+            }],
+            "stream": False,
+        }
+        result = await handle_chat_completions(
+            body=body, client=client, context_manager=ctx,
+            anthropic_backend=True,
+        )
+        assert result["type"] == "message"
+        assert result["stop_reason"] == "tool_use"
+        tool_block = result["content"][0]
+        assert tool_block["type"] == "tool_use"
+        assert tool_block["name"] == "search"
+        assert tool_block["input"] == {"q": "test"}
+
+    @pytest.mark.asyncio
+    async def test_streaming_text_anthropic_sse(self, ctx):
+        client = _mock_client(TextResponse(content="Hi"))
+        body = {
+            "model": "forge",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        }
+        result = await handle_chat_completions(
+            body=body, client=client, context_manager=ctx,
+            anthropic_backend=True,
+        )
+        assert isinstance(result, list)
+        # Should have message_start
+        assert result[0]["type"] == "message_start"
+        # Should have text deltas
+        text_deltas = [e for e in result if e.get("delta", {}).get("type") == "text_delta"]
+        assert len(text_deltas) >= 1
+        # Should end with message_stop
+        assert result[-1]["type"] == "message_stop"
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_call_anthropic_sse(self, ctx):
+        client = _mock_client([ToolCall(tool="get_weather", args={"city": "Paris"})])
+        body = {
+            "model": "forge",
+            "messages": [{"role": "user", "content": "weather"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                },
+            }],
+            "stream": True,
+        }
+        result = await handle_chat_completions(
+            body=body, client=client, context_manager=ctx,
+            anthropic_backend=True,
+        )
+        assert isinstance(result, list)
+        # Should have tool_use content blocks
+        tool_starts = [e for e in result if e.get("content_block", {}).get("type") == "tool_use"]
+        assert len(tool_starts) >= 1
+        # Should have input_json_delta events
+        input_deltas = [e for e in result if e.get("delta", {}).get("type") == "input_json_delta"]
+        assert len(input_deltas) >= 1
+
+    @pytest.mark.asyncio
+    async def test_non_anthropic_backend_stays_openai(self, ctx):
+        """anthropic_backend=False returns OpenAI format (regression check)."""
+        client = _mock_client(TextResponse(content="Hello!"))
+        body = {
+            "model": "forge",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": False,
+        }
+        result = await handle_chat_completions(
+            body=body, client=client, context_manager=ctx,
+            anthropic_backend=False,
+        )
+        assert result["object"] == "chat.completion"
+        assert result["choices"][0]["message"]["content"] == "Hello!"
+
+
+# ── handle_messages (Anthropic incoming) ──────────────────────
+
+
+class TestHandleMessages:
+    """Verify Anthropic-format requests are converted and handled."""
+
+    @pytest.fixture
+    def ctx(self):
+        return ContextManager(strategy=NoCompact(), budget_tokens=8192)
+
+    @pytest.mark.asyncio
+    async def test_text_response_from_anthropic_request(self, ctx):
+        client = _mock_client(TextResponse(content="Hello from forge!"))
+        body = {
+            "model": "claude-sonnet-4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "stream": False,
+        }
+        result = await handle_messages(
+            body=body, client=client, context_manager=ctx,
+            anthropic_backend=True,
+        )
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        # Content should come from the backend (OpenAI format converted)
+        assert result["content"][0]["type"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_system_message_converted(self, ctx):
+        """Top-level system string → system role message."""
+        client = _mock_client(TextResponse(content="Got it"))
+        body = {
+            "system": "You are a weather bot.",
+            "messages": [{"role": "user", "content": "Weather?"}],
+            "max_tokens": 100,
+            "stream": False,
+        }
+        result = await handle_messages(
+            body=body, client=client, context_manager=ctx,
+            anthropic_backend=True,
+        )
+        assert result["type"] == "message"
+
+    @pytest.mark.asyncio
+    async def test_anthropic_tools_converted_to_openai(self, ctx):
+        """Anthropic tool format → OpenAI tool format."""
+        client = _mock_client([ToolCall(tool="get_weather", args={"city": "London"})])
+        body = {
+            "messages": [{"role": "user", "content": "Weather in London?"}],
+            "tools": [{
+                "name": "get_weather",
+                "description": "Get weather",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }],
+            "max_tokens": 100,
+            "stream": False,
+        }
+        result = await handle_messages(
+            body=body, client=client, context_manager=ctx,
+            anthropic_backend=True,
+        )
+        assert result["stop_reason"] == "tool_use"
+        assert result["content"][0]["type"] == "tool_use"
+        assert result["content"][0]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_temperature_forwarded(self, ctx):
+        """Temperature param passed through to handler."""
+        client = _mock_client(TextResponse(content="ok"))
+        body = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "temperature": 0.7,
+            "stream": False,
+        }
+        result = await handle_messages(
+            body=body, client=client, context_manager=ctx,
+            anthropic_backend=True,
+        )
+        assert result["type"] == "message"
+
+    @pytest.mark.asyncio
+    async def test_streaming_anthropic_request(self, ctx):
+        client = _mock_client(TextResponse(content="streaming"))
+        body = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "stream": True,
+        }
+        result = await handle_messages(
+            body=body, client=client, context_manager=ctx,
+            anthropic_backend=True,
+        )
+        assert isinstance(result, list)
+        assert result[0]["type"] == "message_start"
+        assert result[-1]["type"] == "message_stop"
+
+
+# ── HTTPServer /v1/messages with anthropic_backend=True ──────
+
+
+class TestServerAnthropicEndpoint:
+    """Full HTTP request to /v1/messages endpoint."""
+
+    @pytest.fixture
+    async def anthropic_server_factory(self):
+        """Factory that creates an HTTPServer with anthropic_backend=True."""
+        servers = []
+
+        async def _make(response, serialize=False):
+            client = _mock_client(response)
+            ctx = ContextManager(strategy=NoCompact(), budget_tokens=8192)
+            srv = HTTPServer(
+                client=client,
+                context_manager=ctx,
+                host="127.0.0.1",
+                port=0,
+                serialize_requests=serialize,
+                anthropic_backend=True,
+            )
+            await srv.start()
+            sock = srv._server.sockets[0]
+            port = sock.getsockname()[1]
+            servers.append(srv)
+            return srv, port
+
+        yield _make
+
+        for srv in servers:
+            await srv.stop()
+
+    async def _anthropic_request(self, port, body):
+        """Send an Anthropic-format request and return (is_stream, result).
+
+        For streaming: returns (True, list of SSE data line strings).
+        For non-streaming: returns (False, parsed JSON dict).
+        """
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            body_bytes = json.dumps(body).encode()
+            request = (
+                f"POST /v1/messages HTTP/1.1\r\n"
+                f"Host: 127.0.0.1:{port}\r\n"
+                f"Content-Type: application/json\r\n"
+                f"Content-Length: {len(body_bytes)}\r\n"
+                f"\r\n"
+            ).encode() + body_bytes
+
+            writer.write(request)
+            await writer.drain()
+
+            is_stream = body.get("stream", False)
+            response_data = bytearray()
+
+            if is_stream:
+                # SSE uses chunked transfer encoding, ends with 0\r\n\r\n
+                while True:
+                    chunk = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+                    if not chunk:
+                        break
+                    response_data.extend(chunk)
+                    if b"0\r\n\r\n" in response_data:
+                        break
+            else:
+                # JSON response — read headers, then Content-Length bytes
+                header_end = b"\r\n\r\n"
+                while header_end not in response_data:
+                    chunk = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+                    if not chunk:
+                        break
+                    response_data.extend(chunk)
+                header_part = response_data.split(header_end)[0].decode()
+                content_length = 0
+                for line in header_part.split("\r\n"):
+                    if line.lower().startswith("content-length:"):
+                        content_length = int(line.split(":")[1].strip())
+                        break
+                body_start = response_data.index(header_end) + 4
+                body_received = len(response_data) - body_start
+                while body_received < content_length:
+                    chunk = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+                    if not chunk:
+                        break
+                    response_data.extend(chunk)
+                    body_received = len(response_data) - body_start
+
+            response_str = response_data.decode("utf-8", errors="replace")
+
+            if is_stream:
+                data_lines = []
+                for line in response_str.split("\n"):
+                    line = line.strip()
+                    if line.startswith("data: "):
+                        data_lines.append(line[6:])
+                return (True, data_lines)
+            else:
+                # Extract JSON body from HTTP response
+                header_end = response_str.index("\r\n\r\n")
+                json_str = response_str[header_end + 4:].strip()
+                return (False, json.loads(json_str))
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_anthropic_response(self, anthropic_server_factory):
+        srv, port = await anthropic_server_factory(TextResponse(content="Hello!"))
+        body = {
+            "model": "claude-sonnet-4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        }
+        is_stream, result = await self._anthropic_request(port, body)
+        assert is_stream is False
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["content"][0] == {"type": "text", "text": "Hello!"}
+
+    @pytest.mark.asyncio
+    async def test_streaming_anthropic_response(self, anthropic_server_factory):
+        srv, port = await anthropic_server_factory(TextResponse(content="Hi there"))
+        body = {
+            "model": "claude-sonnet-4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "stream": True,
+        }
+        is_stream, data_lines = await self._anthropic_request(port, body)
+        assert is_stream is True
+        assert "[DONE]" in data_lines
+        json_events = [json.loads(d) for d in data_lines if d != "[DONE]"]
+        assert len(json_events) >= 2
+        # First event should be message_start
+        assert json_events[0]["type"] == "message_start"
+        # Last event should be message_stop
+        assert json_events[-1]["type"] == "message_stop"
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_400(self, anthropic_server_factory):
+        srv, port = await anthropic_server_factory(TextResponse(content=""))
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            request = (
+                b"POST /v1/messages HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: 5\r\n"
+                b"\r\n"
+                b"not json"
+            )
+            writer.write(request)
+            await writer.drain()
+            response_data = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+            assert b"400" in response_data
+        finally:
+            writer.close()
+            await writer.wait_closed()

--- a/tests/unit/test_anthropic_proxy_integration.py
+++ b/tests/unit/test_anthropic_proxy_integration.py
@@ -1,0 +1,351 @@
+"""Integration tests for the Anthropic proxy endpoint.
+
+Uses the real Anthropic SDK to send requests to a running proxy instance,
+verifying the full round-trip: SDK → HTTP → handler → mock backend → response.
+
+These are the closest thing we have to external client tests — they validate
+that the proxy correctly implements the Anthropic Messages API contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from anthropic import Anthropic
+
+from forge.context.manager import ContextManager
+from forge.context.strategies import NoCompact
+from forge.core.workflow import TextResponse, ToolCall
+from forge.proxy.server import HTTPServer
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+def _mock_client(response):
+    """Create a mock LLMClient that returns the given response."""
+    client = AsyncMock()
+    client.api_format = "ollama"
+    client.send = AsyncMock(return_value=response)
+    return client
+
+
+@pytest.fixture
+async def anthropic_proxy_server():
+    """Factory that creates an HTTPServer with anthropic_backend=True on a random port."""
+    servers = []
+
+    async def _make(response, serialize=False):
+        client = _mock_client(response)
+        ctx = ContextManager(strategy=NoCompact(), budget_tokens=8192)
+        srv = HTTPServer(
+            client=client,
+            context_manager=ctx,
+            host="127.0.0.1",
+            port=0,
+            serialize_requests=serialize,
+            anthropic_backend=True,
+        )
+        await srv.start()
+        await asyncio.sleep(0)  # let accept loop start
+        sock = srv._server.sockets[0]
+        port = sock.getsockname()[1]
+        servers.append(srv)
+        return srv, port
+
+    yield _make
+
+    for srv in servers:
+        await srv.stop()
+
+
+def _sdk_client(port):
+    """Create an Anthropic SDK client pointing at the proxy."""
+    return Anthropic(
+        base_url=f"http://127.0.0.1:{port}",
+        api_key="test-key",
+        # Short timeout for tests
+        timeout=10.0,
+    )
+
+
+async def _sync_sdk_call(fn, *args, **kwargs):
+    """Run a sync SDK call in a thread so the event loop stays free for the server."""
+    return await asyncio.to_thread(fn, *args, **kwargs)
+
+
+# ── Non-streaming: text response ─────────────────────────────
+
+
+class TestTextResponse:
+    @pytest.mark.asyncio
+    async def test_simple_text_via_sdk(self, anthropic_proxy_server):
+        """SDK sends text request → proxy returns Anthropic text response."""
+        _, port = await anthropic_proxy_server(TextResponse(content="Hello from proxy!"))
+        client = _sdk_client(port)
+        response = await _sync_sdk_call(
+            client.messages.create,
+            model="claude-sonnet-4",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        assert response.type == "message"
+        assert response.role == "assistant"
+        assert response.content[0].type == "text"
+        assert response.content[0].text == "Hello from proxy!"
+        assert response.stop_reason == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_system_message_forwarded(self, anthropic_proxy_server):
+        """System prompt in Anthropic body reaches backend."""
+        _, port = await anthropic_proxy_server(TextResponse(content="Got it"))
+        client = _sdk_client(port)
+        response = await _sync_sdk_call(
+            client.messages.create,
+            model="claude-sonnet-4",
+            max_tokens=1024,
+            system="You are a helpful bot.",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        assert response.type == "message"
+        assert response.content[0].text == "Got it"
+
+    @pytest.mark.asyncio
+    async def test_temperature_forwarded(self, anthropic_proxy_server):
+        """Temperature param is passed through the handler chain."""
+        _, port = await anthropic_proxy_server(TextResponse(content="ok"))
+        client = _sdk_client(port)
+        response = await _sync_sdk_call(
+            client.messages.create,
+            model="claude-sonnet-4",
+            max_tokens=1024,
+            temperature=0.7,
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        assert response.content[0].text == "ok"
+
+
+# ── Non-streaming: tool calls ─────────────────────────────────
+
+
+class TestToolCalls:
+    @pytest.mark.asyncio
+    async def test_single_tool_call_via_sdk(self, anthropic_proxy_server):
+        """SDK sends request with tools → proxy returns tool_use block."""
+        _, port = await anthropic_proxy_server(
+            [ToolCall(tool="get_weather", args={"city": "Paris"})],
+        )
+        client = _sdk_client(port)
+        response = await _sync_sdk_call(
+            client.messages.create,
+            model="claude-sonnet-4",
+            max_tokens=1024,
+            tools=[
+                {
+                    "name": "get_weather",
+                    "description": "Get weather for a city",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                        },
+                        "required": ["city"],
+                    },
+                }
+            ],
+            messages=[{"role": "user", "content": "Weather in Paris?"}],
+        )
+        assert response.type == "message"
+        assert response.stop_reason == "tool_use"
+        assert len(response.content) == 1
+        assert response.content[0].type == "tool_use"
+        assert response.content[0].name == "get_weather"
+        assert response.content[0].input == {"city": "Paris"}
+
+    @pytest.mark.asyncio
+    async def test_multiple_tool_calls_via_sdk(self, anthropic_proxy_server):
+        """Multiple tool calls in one response."""
+        _, port = await anthropic_proxy_server(
+            [
+                ToolCall(tool="f1", args={"a": 1}),
+                ToolCall(tool="f2", args={"b": 2}),
+            ]
+        )
+        client = _sdk_client(port)
+        response = await _sync_sdk_call(
+            client.messages.create,
+            model="claude-sonnet-4",
+            max_tokens=1024,
+            tools=[
+                {
+                    "name": "f1",
+                    "description": "First tool",
+                    "input_schema": {"type": "object", "properties": {"a": {"type": "integer"}}},
+                },
+                {
+                    "name": "f2",
+                    "description": "Second tool",
+                    "input_schema": {"type": "object", "properties": {"b": {"type": "integer"}}},
+                },
+            ],
+            messages=[{"role": "user", "content": "Do both"}],
+        )
+        assert response.stop_reason == "tool_use"
+        assert len(response.content) == 2
+        assert response.content[0].name == "f1"
+        assert response.content[0].input == {"a": 1}
+        assert response.content[1].name == "f2"
+        assert response.content[1].input == {"b": 2}
+
+
+# ── Streaming: text ──────────────────────────────────────────
+
+
+class TestStreamingText:
+    @pytest.mark.asyncio
+    async def test_text_stream_via_sdk(self, anthropic_proxy_server):
+        """SDK streaming request → proxy returns SSE events."""
+        _, port = await anthropic_proxy_server(TextResponse(content="Hi there"))
+        client = _sdk_client(port)
+
+        def _stream():
+            events = []
+            with client.messages.stream(
+                model="claude-sonnet-4",
+                max_tokens=1024,
+                messages=[{"role": "user", "content": "Hi"}],
+            ) as stream:
+                for event in stream:
+                    events.append(event)
+            return events
+
+        events = await _sync_sdk_call(_stream)
+
+        # Should have message_start, content blocks, message_stop
+        types = [type(e).__name__ for e in events]
+        assert any("MessageStart" in t for t in types)
+        assert any("MessageStop" in t for t in types)
+        # Should have text content (TextEvent has .text, RawContentBlockDeltaEvent has .delta.text)
+        text_events = [e for e in events if hasattr(e, "text") and e.text]
+        assert len(text_events) >= 1
+
+    @pytest.mark.asyncio
+    async def test_stream_accumulates_full_text(self, anthropic_proxy_server):
+        """Streaming text accumulates to the full response."""
+        _, port = await anthropic_proxy_server(TextResponse(content="Hello world"))
+        client = _sdk_client(port)
+
+        def _stream():
+            text_parts = []
+            with client.messages.stream(
+                model="claude-sonnet-4",
+                max_tokens=1024,
+                messages=[{"role": "user", "content": "Hi"}],
+            ) as stream:
+                for event in stream:
+                    # TextEvent has .text directly (the SDK's parsed text delta)
+                    if getattr(event, "type", None) == "text":
+                        text_parts.append(event.text)
+            return text_parts
+
+        text_parts = await _sync_sdk_call(_stream)
+        assert "".join(text_parts) == "Hello world"
+
+
+# ── Streaming: tool calls ─────────────────────────────────────
+
+
+class TestStreamingTools:
+    @pytest.mark.asyncio
+    async def test_tool_stream_via_sdk(self, anthropic_proxy_server):
+        """SDK streaming tool call → proxy returns tool_use SSE events."""
+        _, port = await anthropic_proxy_server(
+            [ToolCall(tool="fetch", args={"url": "http://example.com"})],
+        )
+        client = _sdk_client(port)
+
+        def _stream():
+            tool_blocks = []
+            with client.messages.stream(
+                model="claude-sonnet-4",
+                max_tokens=1024,
+                tools=[
+                    {
+                        "name": "fetch",
+                        "description": "Fetch a URL",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"url": {"type": "string"}},
+                        },
+                    }
+                ],
+                messages=[{"role": "user", "content": "Fetch this"}],
+            ) as stream:
+                for event in stream:
+                    # Only collect from content_block_start (not delta)
+                    if (
+                        getattr(event, "type", None) == "content_block_start"
+                        and hasattr(event, "content_block")
+                        and event.content_block is not None
+                        and event.content_block.type == "tool_use"
+                    ):
+                        tool_blocks.append(event.content_block)
+            return tool_blocks
+
+        tool_blocks = await _sync_sdk_call(_stream)
+        assert len(tool_blocks) == 1
+        assert tool_blocks[0].name == "fetch"
+        assert tool_blocks[0].input == {"url": "http://example.com"}
+
+
+# ── Edge cases ───────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_empty_content_response(self, anthropic_proxy_server):
+        """Empty text response is handled gracefully."""
+        _, port = await anthropic_proxy_server(TextResponse(content=""))
+        client = _sdk_client(port)
+        response = await _sync_sdk_call(
+            client.messages.create,
+            model="claude-sonnet-4",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        assert response.type == "message"
+        assert response.content[0].text == ""
+
+    @pytest.mark.asyncio
+    async def test_multiple_messages_conversation(self, anthropic_proxy_server):
+        """Multi-turn message array is handled."""
+        _, port = await anthropic_proxy_server(TextResponse(content="Response"))
+        client = _sdk_client(port)
+        response = await _sync_sdk_call(
+            client.messages.create,
+            model="claude-sonnet-4",
+            max_tokens=1024,
+            messages=[
+                {"role": "user", "content": "First"},
+                {"role": "assistant", "content": "Reply"},
+                {"role": "user", "content": "Second"},
+            ],
+        )
+        assert response.content[0].text == "Response"
+
+    @pytest.mark.asyncio
+    async def test_serialized_mode(self, anthropic_proxy_server):
+        """Serialize mode processes requests through the queue."""
+        _, port = await anthropic_proxy_server(
+            TextResponse(content="serialized"),
+            serialize=True,
+        )
+        client = _sdk_client(port)
+        response = await _sync_sdk_call(
+            client.messages.create,
+            model="claude-sonnet-4",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        assert response.content[0].text == "serialized"

--- a/tests/unit/test_context_thresholds.py
+++ b/tests/unit/test_context_thresholds.py
@@ -172,6 +172,7 @@ class TestCheckThresholds:
 
     def test_importable_from_forge(self) -> None:
         from forge import default_context_warning
+
         assert callable(default_context_warning)
 
 
@@ -184,6 +185,7 @@ class TestInferenceInjection:
     @pytest.mark.asyncio
     async def test_warning_injected_into_api_messages(self) -> None:
         from unittest.mock import AsyncMock
+
         from forge.core.inference import run_inference
         from forge.core.workflow import ToolCall
         from forge.guardrails import ErrorTracker, ResponseValidator
@@ -205,7 +207,7 @@ class TestInferenceInjection:
         # Mock client — capture what api_messages it receives
         captured_messages = []
 
-        async def mock_send(api_messages, tools=None, sampling=None):
+        async def mock_send(api_messages, tools=None, sampling=None, max_tokens=None):
             captured_messages.extend(api_messages)
             return [ToolCall(tool="done", args={})]
 
@@ -227,13 +229,15 @@ class TestInferenceInjection:
 
         # The injected warning should be the last message (user role)
         warning_msgs = [m for m in captured_messages if "Context usage" in m.get("content", "")]
-        assert len(warning_msgs) > 0, \
+        assert len(warning_msgs) > 0, (
             f"Expected context warning in api_messages, got: {[m['content'][:50] for m in captured_messages]}"
+        )
         assert warning_msgs[0]["role"] == "user"
 
     @pytest.mark.asyncio
     async def test_no_injection_without_threshold_config(self) -> None:
         from unittest.mock import AsyncMock
+
         from forge.core.inference import run_inference
         from forge.core.workflow import ToolCall
         from forge.guardrails import ErrorTracker, ResponseValidator
@@ -248,7 +252,7 @@ class TestInferenceInjection:
 
         captured_messages = []
 
-        async def mock_send(api_messages, tools=None, sampling=None):
+        async def mock_send(api_messages, tools=None, sampling=None, max_tokens=None):
             captured_messages.extend(api_messages)
             return [ToolCall(tool="done", args={})]
 

--- a/tests/unit/test_decoders.py
+++ b/tests/unit/test_decoders.py
@@ -1,0 +1,381 @@
+"""Edge case tests for decoder functions (inbound message conversion).
+
+Tests for:
+- openai_to_messages() — OpenAI → forge Messages
+- anthropic_to_openai_messages() — Anthropic body → OpenAI messages
+- openai_to_anthropic_messages() — OpenAI messages → Anthropic body fields
+
+Focuses on edge cases and boundary conditions not covered in the
+main converter test files (test_proxy_convert.py, test_anthropic_convert.py).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from forge.core.messages import MessageRole, MessageType
+from forge.proxy.convert import (
+    anthropic_to_openai_messages,
+    openai_to_anthropic_messages,
+    openai_to_messages,
+)
+
+# ── openai_to_messages edge cases ──────────────────────────────
+
+
+class TestOpenaiToMessagesEdgeCases:
+    """Edge cases for openai_to_messages not covered in test_proxy_convert.py."""
+
+    def test_empty_list(self) -> None:
+        assert openai_to_messages([]) == []
+
+    def test_none_content_becomes_empty_string(self) -> None:
+        msgs = [{"role": "user", "content": None}]
+        result = openai_to_messages(msgs)
+        assert len(result) == 1
+        assert result[0].content == ""
+
+    def test_missing_content_key(self) -> None:
+        msgs = [{"role": "user"}]
+        result = openai_to_messages(msgs)
+        assert len(result) == 1
+        assert result[0].content == ""
+
+    def test_unknown_role_maps_to_user(self) -> None:
+        msgs = [{"role": "fake_role", "content": "data"}]
+        result = openai_to_messages(msgs)
+        assert result[0].role == MessageRole.USER
+        assert result[0].metadata.type == MessageType.USER_INPUT
+
+    def test_missing_role_defaults_to_user(self) -> None:
+        msgs = [{"content": "no role"}]
+        result = openai_to_messages(msgs)
+        assert result[0].role == MessageRole.USER
+
+    def test_list_content_with_mixed_types(self) -> None:
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "first"},
+                    "plain string",
+                    {"type": "text", "text": "second"},
+                ],
+            }
+        ]
+        result = openai_to_messages(msgs)
+        assert result[0].content == "first\nplain string\nsecond"
+
+    def test_list_content_with_non_text_blocks_ignored(self) -> None:
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "visible"},
+                    {"type": "image_url", "image_url": {"url": "data:..."}},
+                ],
+            }
+        ]
+        result = openai_to_messages(msgs)
+        # Only text blocks are extracted; image_url blocks contribute nothing
+        assert result[0].content == "visible"
+
+    def test_assistant_with_empty_tool_calls(self) -> None:
+        """Assistant with tool_calls=[] should be treated as text response."""
+        msgs = [{"role": "assistant", "content": "just text", "tool_calls": []}]
+        result = openai_to_messages(msgs)
+        assert len(result) == 1
+        assert result[0].metadata.type == MessageType.TEXT_RESPONSE
+
+    def test_assistant_with_tool_calls_and_reasoning(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "Let me think...",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "call_001",
+                        "function": {"name": "search", "arguments": '{"q":"x"}'},
+                    }
+                ],
+            }
+        ]
+        result = openai_to_messages(msgs)
+        assert len(result) == 1
+        assert result[0].metadata.type == MessageType.TOOL_CALL
+        assert result[0].content == "Let me think..."
+        assert len(result[0].tool_calls or []) == 1
+        assert result[0].tool_calls[0].name == "search"
+
+    def test_tool_message_without_tool_call_id(self) -> None:
+        msgs = [{"role": "tool", "content": "result"}]
+        result = openai_to_messages(msgs)
+        assert result[0].role == MessageRole.TOOL
+        assert result[0].metadata.type == MessageType.TOOL_RESULT
+        assert result[0].tool_call_id == ""
+
+    def test_multiple_system_messages(self) -> None:
+        """Multiple system messages are all preserved."""
+        msgs = [
+            {"role": "system", "content": "Rule 1"},
+            {"role": "system", "content": "Rule 2"},
+            {"role": "user", "content": "Hi"},
+        ]
+        result = openai_to_messages(msgs)
+        assert len(result) == 3
+        assert result[0].metadata.type == MessageType.SYSTEM_PROMPT
+        assert result[1].metadata.type == MessageType.SYSTEM_PROMPT
+        assert result[2].metadata.type == MessageType.USER_INPUT
+
+    def test_tool_message_with_name(self) -> None:
+        msgs = [{"role": "tool", "tool_call_id": "c1", "content": "ok", "name": "search"}]
+        result = openai_to_messages(msgs)
+        assert result[0].tool_name == "search"
+        assert result[0].tool_call_id == "c1"
+
+
+# ── anthropic_to_openai_messages edge cases ───────────────────
+
+
+class TestAnthropicToOpenAIMessagesEdgeCases:
+    """Edge cases for anthropic_to_openai_messages."""
+
+    def test_completely_empty_body(self) -> None:
+        assert anthropic_to_openai_messages({}) == []
+
+    def test_only_system_no_messages(self) -> None:
+        body: dict[str, Any] = {"system": "You are helpful."}
+        result = anthropic_to_openai_messages(body)
+        assert len(result) == 1
+        assert result[0] == {"role": "system", "content": "You are helpful."}
+
+    def test_user_content_as_empty_list(self) -> None:
+        """Empty content list produces no message (all block types filtered out)."""
+        body: dict[str, Any] = {"messages": [{"role": "user", "content": []}]}
+        result = anthropic_to_openai_messages(body)
+        assert result == []
+
+    def test_user_content_with_only_thinking_blocks(self) -> None:
+        body: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "thinking", "text": "Hmm..."}],
+                }
+            ],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert "<think>" in result[0]["content"]
+        assert "Hmm..." in result[0]["content"]
+
+    def test_assistant_with_thinking_only(self) -> None:
+        body: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "thinking", "text": "I think..."}],
+                }
+            ],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert "thinking" not in str(result[0].get("content", "").lower())
+        assert "<think>" in result[0]["content"]
+
+    def test_tool_result_with_empty_content(self) -> None:
+        body: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "t1", "content": ""}],
+                }
+            ],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert result[0]["content"] == ""
+        assert result[0]["tool_call_id"] == "t1"
+
+    def test_assistant_text_with_empty_tool_use(self) -> None:
+        """Assistant with text + empty tool_use block."""
+        body: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Done"},
+                        {"type": "tool_use", "id": "t1", "name": "submit", "input": {}},
+                    ],
+                }
+            ],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert result[0]["content"] == "Done"
+        assert len(result[0]["tool_calls"]) == 1
+        assert result[0]["tool_calls"][0]["function"]["name"] == "submit"
+
+    def test_missing_messages_key(self) -> None:
+        body: dict[str, Any] = {"system": "hi"}
+        result = anthropic_to_openai_messages(body)
+        assert len(result) == 1
+        assert result[0]["role"] == "system"
+
+    def test_string_content_vs_list_content(self) -> None:
+        """Same content as string vs list should produce same result."""
+        string_body: dict[str, Any] = {"messages": [{"role": "user", "content": "hello"}]}
+        list_body: dict[str, Any] = {"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]}
+        string_result = anthropic_to_openai_messages(string_body)
+        list_result = anthropic_to_openai_messages(list_body)
+        assert string_result == list_result
+
+    def test_tool_use_without_id_generates_one(self) -> None:
+        body: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "name": "f", "input": {}}],
+                }
+            ],
+        }
+        result = anthropic_to_openai_messages(body)
+        assert "id" in result[0]["tool_calls"][0]
+        assert result[0]["tool_calls"][0]["id"].startswith("call_")
+
+
+# ── openai_to_anthropic_messages edge cases ───────────────────
+
+
+class TestOpenaiToAnthropicMessagesEdgeCases:
+    """Edge cases for openai_to_anthropic_messages."""
+
+    def test_empty_messages_list(self) -> None:
+        result = openai_to_anthropic_messages([])
+        assert result == {"messages": []}
+
+    def test_system_only(self) -> None:
+        msgs = [{"role": "system", "content": "Be helpful."}]
+        result = openai_to_anthropic_messages(msgs)
+        assert result["system"] == "Be helpful."
+        assert result["messages"] == []
+
+    def test_assistant_with_empty_tool_calls(self) -> None:
+        """Assistant with empty tool_calls list: content becomes list of text blocks."""
+        msgs = [{"role": "assistant", "content": "hello", "tool_calls": []}]
+        result = openai_to_anthropic_messages(msgs)
+        # content becomes a list of text blocks since tool_calls is falsy
+        assert result["messages"][0]["content"] == [{"type": "text", "text": "hello"}]
+
+    def test_tool_with_missing_tool_call_id(self) -> None:
+        msgs = [{"role": "tool", "content": "result"}]
+        result = openai_to_anthropic_messages(msgs)
+        block = result["messages"][0]["content"][0]
+        assert block["tool_use_id"] == ""
+
+    def test_tool_with_is_error_false(self) -> None:
+        msgs = [{"role": "tool", "tool_call_id": "c1", "content": "ok", "is_error": False}]
+        result = openai_to_anthropic_messages(msgs)
+        block = result["messages"][0]["content"][0]
+        assert "is_error" not in block
+
+    def test_tool_with_is_error_true(self) -> None:
+        msgs = [{"role": "tool", "tool_call_id": "c1", "content": "fail", "is_error": True}]
+        result = openai_to_anthropic_messages(msgs)
+        block = result["messages"][0]["content"][0]
+        assert block["is_error"] is True
+
+    def test_assistant_with_text_and_tool_use(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "Checking...",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "call_001",
+                        "function": {"name": "search", "arguments": '{"q":"x"}'},
+                    }
+                ],
+            }
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        blocks = result["messages"][0]["content"]
+        assert len(blocks) == 2
+        assert blocks[0]["type"] == "text"
+        assert blocks[1]["type"] == "tool_use"
+
+    def test_user_content_as_list_with_thinking(self) -> None:
+        msgs = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Hi"}, {"type": "thinking", "text": "Hmm"}],
+            }
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        blocks = result["messages"][0]["content"]
+        assert len(blocks) == 2
+        assert blocks[0]["type"] == "text"
+        assert blocks[1]["type"] == "thinking"
+
+    def test_user_content_list_with_unknown_block_type(self) -> None:
+        msgs = [
+            {
+                "role": "user",
+                "content": [{"type": "unknown_type", "data": "x"}],
+            }
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        # Unknown block types should be passed through as-is
+        block = result["messages"][0]["content"][0]
+        assert block["type"] == "unknown_type"
+
+    def test_tool_arguments_as_empty_string(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "c1",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            }
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        assert result["messages"][0]["content"][0]["input"] == {}
+
+    def test_tool_arguments_missing(self) -> None:
+        """Missing arguments defaults to empty dict (parsed from '{}')."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "c1",
+                        "function": {"name": "f"},
+                    }
+                ],
+            }
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        # defaults to "{}" string → json.loads → {}
+        assert result["messages"][0]["content"][0]["input"] == {}
+
+    def test_arguments_already_dict_not_double_serialized(self) -> None:
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "c1",
+                        "function": {"name": "f", "arguments": {"key": "val"}},
+                    }
+                ],
+            }
+        ]
+        result = openai_to_anthropic_messages(msgs)
+        assert result["messages"][0]["content"][0]["input"] == {"key": "val"}

--- a/tests/unit/test_encoders.py
+++ b/tests/unit/test_encoders.py
@@ -1,0 +1,555 @@
+"""Edge case tests for encoder functions (outbound response conversion).
+
+Tests for:
+- tool_calls_to_openai(), text_response_to_openai() — forge → OpenAI
+- openai_to_anthropic_response(), openai_to_anthropic_sse() — OpenAI → Anthropic
+- anthropic_to_openai_response(), anthropic_to_openai_sse() — Anthropic → OpenAI
+
+Focuses on edge cases and boundary conditions not covered in
+test_proxy_convert.py and test_anthropic_convert.py.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from forge.core.workflow import ToolCall
+from forge.proxy.convert import (
+    anthropic_to_openai_response,
+    anthropic_to_openai_sse,
+    openai_to_anthropic_response,
+    openai_to_anthropic_sse,
+    text_response_to_openai,
+    text_to_sse_events,
+    tool_calls_to_openai,
+    tool_calls_to_sse_events,
+)
+
+# ── tool_calls_to_openai edge cases ───────────────────────────
+
+
+class TestToolCallsToOpenaiEdgeCases:
+    def test_single_tool_call(self) -> None:
+        result = tool_calls_to_openai([ToolCall(tool="search", args={"q": "test"})])
+        assert result["object"] == "chat.completion"
+        assert result["choices"][0]["finish_reason"] == "tool_calls"
+        assert len(result["choices"][0]["message"]["tool_calls"]) == 1
+
+    def test_multiple_tool_calls(self) -> None:
+        calls = [
+            ToolCall(tool="search", args={"q": "x"}),
+            ToolCall(tool="fetch", args={"url": "http://x"}),
+        ]
+        result = tool_calls_to_openai(calls)
+        assert len(result["choices"][0]["message"]["tool_calls"]) == 2
+
+    def test_tool_call_with_reasoning(self) -> None:
+        calls = [ToolCall(tool="search", args={"q": "x"}, reasoning="Let me check.")]
+        result = tool_calls_to_openai(calls)
+        assert result["choices"][0]["message"]["content"] == "Let me check."
+
+    def test_tool_call_with_empty_reasoning(self) -> None:
+        calls = [ToolCall(tool="search", args={"q": "x"}, reasoning=None)]
+        result = tool_calls_to_openai(calls)
+        assert result["choices"][0]["message"]["content"] is None
+
+    def test_tool_call_arguments_serialized_as_json(self) -> None:
+        calls = [ToolCall(tool="f", args={"nested": {"key": "val"}})]
+        result = tool_calls_to_openai(calls)
+        args = json.loads(result["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"])
+        assert args == {"nested": {"key": "val"}}
+
+    def test_usage_fields_present(self) -> None:
+        result = tool_calls_to_openai([ToolCall(tool="f", args={})])
+        assert "prompt_tokens" in result["usage"]
+        assert "completion_tokens" in result["usage"]
+        assert "total_tokens" in result["usage"]
+
+    def test_model_propagated(self) -> None:
+        result = tool_calls_to_openai([ToolCall(tool="f", args={})], model="my-model")
+        assert result["model"] == "my-model"
+
+    def test_id_generation(self) -> None:
+        result1 = tool_calls_to_openai([ToolCall(tool="f", args={})])
+        result2 = tool_calls_to_openai([ToolCall(tool="f", args={})])
+        # IDs should be unique across calls
+        assert result1["id"] != result2["id"]
+
+
+# ── text_response_to_openai edge cases ────────────────────────
+
+
+class TestTextResponseToOpenaiEdgeCases:
+    def test_empty_text(self) -> None:
+        result = text_response_to_openai("")
+        assert result["choices"][0]["message"]["content"] == ""
+        assert result["choices"][0]["finish_reason"] == "stop"
+
+    def test_long_text(self) -> None:
+        text = "x" * 10000
+        result = text_response_to_openai(text)
+        assert result["choices"][0]["message"]["content"] == text
+
+    def test_unicode_text(self) -> None:
+        result = text_response_to_openai("Hello 世界 🌍")
+        assert result["choices"][0]["message"]["content"] == "Hello 世界 🌍"
+
+    def test_multiline_text(self) -> None:
+        text = "line1\nline2\nline3"
+        result = text_response_to_openai(text)
+        assert result["choices"][0]["message"]["content"] == text
+
+    def test_model_propagated(self) -> None:
+        result = text_response_to_openai("hi", model="custom")
+        assert result["model"] == "custom"
+
+
+# ── tool_calls_to_sse_events edge cases ───────────────────────
+
+
+class TestToolCallsToSseEventsEdgeCases:
+    def test_single_tool_call_sse(self) -> None:
+        events = tool_calls_to_sse_events([ToolCall(tool="f", args={})])
+        assert events[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+    def test_multiple_tool_calls_sse(self) -> None:
+        calls = [ToolCall(tool="a", args={}), ToolCall(tool="b", args={})]
+        events = tool_calls_to_sse_events(calls)
+        # Should have one delta per tool call
+        tool_chunks = [e for e in events if e["choices"][0].get("delta", {}).get("tool_calls")]
+        assert len(tool_chunks) == 2
+
+    def test_reasoning_sent_first_in_sse(self) -> None:
+        calls = [ToolCall(tool="f", args={}, reasoning="Thinking...")]
+        events = tool_calls_to_sse_events(calls)
+        first = events[0]
+        assert first["choices"][0]["delta"]["content"] == "Thinking..."
+        assert first["choices"][0]["delta"]["role"] == "assistant"
+
+    def test_sse_model_propagated(self) -> None:
+        events = tool_calls_to_sse_events([ToolCall(tool="f", args={})], model="m")
+        for e in events:
+            assert e["model"] == "m"
+
+
+# ── text_to_sse_events edge cases ─────────────────────────────
+
+
+class TestTextToSseEventsEdgeCases:
+    def test_empty_text_sse(self) -> None:
+        events = text_to_sse_events("")
+        assert events[-1]["choices"][0]["finish_reason"] == "stop"
+
+    def test_chunked_text(self) -> None:
+        events = text_to_sse_events("abcdefgh", chunk_size=3)
+        # Should have multiple chunks + final
+        content_chunks = [e for e in events if e["choices"][0].get("delta", {}).get("content")]
+        assert len(content_chunks) > 1
+
+    def test_chunked_text_shorter_than_chunk_size(self) -> None:
+        events = text_to_sse_events("hi", chunk_size=10)
+        content_chunks = [e for e in events if e["choices"][0].get("delta", {}).get("content")]
+        assert len(content_chunks) == 1
+
+    def test_sse_first_chunk_has_role(self) -> None:
+        events = text_to_sse_events("hello")
+        first = events[0]
+        assert first["choices"][0]["delta"]["role"] == "assistant"
+
+
+# ── openai_to_anthropic_response edge cases ───────────────────
+
+
+class TestOpenaiToAnthropicResponseEdgeCases:
+    def test_content_filter_finish_reason(self) -> None:
+        """content_filter → stop_sequence mapping."""
+        openai_resp = {
+            "choices": [{"finish_reason": "content_filter"}],
+            "usage": {},
+        }
+        result = openai_to_anthropic_response(openai_resp, "model")
+        assert result["stop_reason"] == "stop_sequence"
+
+    def test_multiple_tool_calls(self) -> None:
+        openai_resp = {
+            "id": "chatcmpl-1",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "id": "call_001",
+                                "function": {"name": "f1", "arguments": '{"a":1}'},
+                            },
+                            {
+                                "type": "function",
+                                "id": "call_002",
+                                "function": {"name": "f2", "arguments": '{"b":2}'},
+                            },
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        result = openai_to_anthropic_response(openai_resp, "model")
+        assert len(result["content"]) == 2
+        assert result["content"][0]["type"] == "tool_use"
+        assert result["content"][0]["name"] == "f1"
+        assert result["content"][1]["name"] == "f2"
+
+    def test_reasoning_before_tool_use(self) -> None:
+        openai_resp = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Let me check the weather.",
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "id": "call_001",
+                                "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {},
+        }
+        result = openai_to_anthropic_response(openai_resp, "model")
+        assert result["content"][0] == {"type": "text", "text": "Let me check the weather."}
+        assert result["content"][1]["type"] == "tool_use"
+        assert result["content"][1]["name"] == "get_weather"
+
+    def test_no_choices_raises(self) -> None:
+        """Empty choices list → IndexError in current code."""
+        openai_resp = {"choices": [], "usage": {}}
+        with pytest.raises(IndexError):
+            openai_to_anthropic_response(openai_resp, "model")
+
+    def test_missing_usage_fields(self) -> None:
+        openai_resp = {"choices": [{"finish_reason": "stop"}]}
+        result = openai_to_anthropic_response(openai_resp, "model")
+        assert result["usage"]["input_tokens"] == 0
+        assert result["usage"]["output_tokens"] == 0
+
+    def test_id_propagated(self) -> None:
+        openai_resp = {
+            "id": "chatcmpl-custom",
+            "choices": [{"finish_reason": "stop"}],
+            "usage": {},
+        }
+        result = openai_to_anthropic_response(openai_resp, "model")
+        assert result["id"] == "chatcmpl-custom"
+
+    def test_arguments_as_dict_not_double_serialized(self) -> None:
+        openai_resp = {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "id": "c1",
+                                "function": {"name": "f", "arguments": {"key": "val"}},
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {},
+        }
+        result = openai_to_anthropic_response(openai_resp, "model")
+        assert result["content"][0]["input"] == {"key": "val"}
+
+
+# ── openai_to_anthropic_sse edge cases ────────────────────────
+
+
+class TestOpenaiToAnthropicSseEdgeCases:
+    def test_empty_events(self) -> None:
+        result = openai_to_anthropic_sse([], "model")
+        assert len(result) == 2  # message_start + message_stop
+        assert result[0]["type"] == "message_start"
+        assert result[-1]["type"] == "message_stop"
+
+    def test_text_stream_accumulates(self) -> None:
+        events = [
+            {"id": "c1", "choices": [{"delta": {"content": "A"}, "finish_reason": None}]},
+            {"id": "c1", "choices": [{"delta": {"content": "B"}, "finish_reason": None}]},
+            {"id": "c1", "choices": [{"delta": {"content": "C"}, "finish_reason": "stop"}]},
+        ]
+        result = openai_to_anthropic_sse(events, "model")
+        text_deltas = [e for e in result if e.get("delta", {}).get("type") == "text_delta"]
+        texts = [e["delta"]["text"] for e in text_deltas]
+        assert texts == ["A", "B", "C"]
+
+    def test_tool_call_accumulates_args(self) -> None:
+        """Tool call args accumulate and emit as single input_json_delta at final chunk."""
+        events = [
+            {
+                "id": "c1",
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {"index": 0, "id": "call_001", "type": "function", "function": {"name": "f"}}
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "c1",
+                "choices": [
+                    {
+                        "delta": {"tool_calls": [{"index": 0, "function": {"arguments": '{"a":'}}]},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "c1",
+                "choices": [
+                    {
+                        "delta": {"tool_calls": [{"index": 0, "function": {"arguments": "1}"}}]},
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            },
+        ]
+        result = openai_to_anthropic_sse(events, "model")
+        input_deltas = [e for e in result if e.get("delta", {}).get("type") == "input_json_delta"]
+        # Args accumulate → single delta at final chunk with full accumulated args
+        assert len(input_deltas) == 1
+        assert input_deltas[0]["delta"]["partial_json"] == '{"a":1}'
+
+    def test_content_filter_in_finish_reason(self) -> None:
+        events = [
+            {"id": "c1", "choices": [{"delta": {"content": "x"}, "finish_reason": "content_filter"}]},
+        ]
+        result = openai_to_anthropic_sse(events, "model")
+        message_stops = [e for e in result if e.get("type") == "message_stop"]
+        # The content_filter maps to stop_sequence
+        assert any(e.get("stop_reason") == "stop_sequence" for e in message_stops)
+
+    def test_multiple_tool_calls_in_stream(self) -> None:
+        events = [
+            {
+                "id": "c1",
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [{"index": 0, "id": "c1", "type": "function", "function": {"name": "f1"}}]
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "c1",
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [{"index": 1, "id": "c2", "type": "function", "function": {"name": "f2"}}]
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {"id": "c1", "choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+        ]
+        result = openai_to_anthropic_sse(events, "model")
+        tool_starts = [e for e in result if e.get("content_block", {}).get("type") == "tool_use"]
+        assert len(tool_starts) == 2
+
+    def test_wrapped_with_id_and_model(self) -> None:
+        events = [{"id": "my-id", "choices": [{"delta": {"content": "x"}, "finish_reason": "stop"}]}]
+        result = openai_to_anthropic_sse(events, "my-model")
+        for ev in result:
+            if ev.get("type") not in ("message_stop",):
+                assert ev.get("id") == "my-id"
+                assert ev.get("model") == "my-model"
+
+
+# ── anthropic_to_openai_response edge cases ───────────────────
+
+
+class TestAnthropicToOpenaiResponseEdgeCases:
+    def test_stop_sequence_stop_reason(self) -> None:
+        resp = {"content": [{"type": "text", "text": "x"}], "stop_reason": "stop_sequence", "usage": {}}
+        result = anthropic_to_openai_response(resp, "model")
+        assert result["choices"][0]["finish_reason"] == "stop"
+
+    def test_multiple_tool_use_blocks(self) -> None:
+        resp = {
+            "content": [
+                {"type": "tool_use", "id": "t1", "name": "f1", "input": {"a": 1}},
+                {"type": "tool_use", "id": "t2", "name": "f2", "input": {"b": 2}},
+            ],
+            "stop_reason": "tool_use",
+            "usage": {},
+        }
+        result = anthropic_to_openai_response(resp, "model")
+        tc = result["choices"][0]["message"]["tool_calls"]
+        assert len(tc) == 2
+        assert tc[0]["function"]["name"] == "f1"
+        assert tc[1]["function"]["name"] == "f2"
+
+    def test_text_and_tool_together(self) -> None:
+        resp = {
+            "content": [
+                {"type": "text", "text": "Let me check."},
+                {"type": "tool_use", "id": "t1", "name": "search", "input": {"q": "x"}},
+            ],
+            "stop_reason": "tool_use",
+            "usage": {},
+        }
+        result = anthropic_to_openai_response(resp, "model")
+        msg = result["choices"][0]["message"]
+        assert msg["content"] == "Let me check."
+        assert len(msg["tool_calls"]) == 1
+
+    def test_thinking_wrapped_in_tags(self) -> None:
+        resp = {
+            "content": [{"type": "thinking", "text": "I think..."}],
+            "stop_reason": "end_turn",
+            "usage": {},
+        }
+        result = anthropic_to_openai_response(resp, "model")
+        assert result["choices"][0]["message"]["content"] == "<think>I think...</think>"
+
+    def test_total_tokens_computed(self) -> None:
+        resp = {
+            "content": [{"type": "text", "text": "hi"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        result = anthropic_to_openai_response(resp, "model")
+        assert result["usage"]["total_tokens"] == 15
+
+    def test_missing_usage_defaults_to_zero(self) -> None:
+        resp = {"content": [], "stop_reason": "end_turn"}
+        result = anthropic_to_openai_response(resp, "model")
+        assert result["usage"]["prompt_tokens"] == 0
+        assert result["usage"]["completion_tokens"] == 0
+        assert result["usage"]["total_tokens"] == 0
+
+    def test_id_propagated(self) -> None:
+        resp = {"content": [], "stop_reason": "end_turn", "id": "msg-custom", "usage": {}}
+        result = anthropic_to_openai_response(resp, "model")
+        assert result["id"] == "msg-custom"
+
+    def test_arguments_serialized_as_json_string(self) -> None:
+        resp = {
+            "content": [{"type": "tool_use", "id": "t1", "name": "f", "input": {"nested": {"k": "v"}}}],
+            "stop_reason": "tool_use",
+            "usage": {},
+        }
+        result = anthropic_to_openai_response(resp, "model")
+        args = json.loads(result["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"])
+        assert args == {"nested": {"k": "v"}}
+
+
+# ── anthropic_to_openai_sse edge cases ────────────────────────
+
+
+class TestAnthropicToOpenaiSseEdgeCases:
+    def test_empty_events(self) -> None:
+        result = anthropic_to_openai_sse([], "model")
+        assert result == []
+
+    def test_text_stream_generates_chunks(self) -> None:
+        events = [
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop", "stop_reason": "end_turn"},
+        ]
+        result = anthropic_to_openai_sse(events, "model")
+        content_chunks = [e for e in result if e["choices"][0].get("delta", {}).get("content")]
+        assert len(content_chunks) == 1
+        assert content_chunks[0]["choices"][0]["delta"]["content"] == "Hello"
+
+    def test_tool_stream_generates_chunks(self) -> None:
+        events = [
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "t1", "name": "f"}},
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": '{"a":1}'},
+            },
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop", "stop_reason": "tool_use"},
+        ]
+        result = anthropic_to_openai_sse(events, "model")
+        tool_chunks = [e for e in result if "tool_calls" in e.get("choices", [{}])[0].get("delta", {})]
+        assert len(tool_chunks) >= 1
+        assert tool_chunks[0]["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"] == '{"a":1}'
+
+    def test_stop_reason_max_tokens_maps_to_length(self) -> None:
+        events = [
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "x"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop", "stop_reason": "max_tokens"},
+        ]
+        result = anthropic_to_openai_sse(events, "model")
+        assert result[-1]["choices"][0]["finish_reason"] == "length"
+
+    def test_stop_reason_stop_sequence_maps_to_stop(self) -> None:
+        events = [
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "x"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop", "stop_reason": "stop_sequence"},
+        ]
+        result = anthropic_to_openai_sse(events, "model")
+        assert result[-1]["choices"][0]["finish_reason"] == "stop"
+
+    def test_fallback_single_chunk_for_text_only(self) -> None:
+        """Events with text content but no proper delta events get a fallback."""
+        events = [
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hello"}},
+            {"type": "message_stop", "stop_reason": "end_turn"},
+        ]
+        result = anthropic_to_openai_sse(events, "model")
+        # Should have content chunks + final chunk
+        assert len(result) >= 2
+
+    def test_model_propagated_in_chunks(self) -> None:
+        events = [
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "x"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop", "stop_reason": "end_turn"},
+        ]
+        result = anthropic_to_openai_sse(events, "my-model")
+        for e in result:
+            assert e["model"] == "my-model"
+
+    def test_multiple_content_blocks(self) -> None:
+        events = [
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "A"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "content_block_start", "index": 1, "content_block": {"type": "tool_use", "id": "t1", "name": "f"}},
+            {"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": "{}"}},
+            {"type": "content_block_stop", "index": 1},
+            {"type": "message_stop", "stop_reason": "tool_use"},
+        ]
+        result = anthropic_to_openai_sse(events, "model")
+        content_chunks = [e for e in result if e["choices"][0].get("delta", {}).get("content")]
+        tool_chunks = [e for e in result if "tool_calls" in e.get("choices", [{}])[0].get("delta", {})]
+        assert len(content_chunks) == 1
+        assert len(tool_chunks) >= 1

--- a/tests/unit/test_eval_budget.py
+++ b/tests/unit/test_eval_budget.py
@@ -3,16 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import Any
-
-import pytest
 
 from forge.clients.base import ChunkType, StreamChunk
 from forge.context.strategies import TieredCompact
-from forge.core.workflow import LLMResponse, ToolCall, ToolSpec, TextResponse
-
-from tests.eval.eval_runner import EvalConfig, RunResult, run_scenario
-from tests.eval.scenarios import compaction_chain_p1, basic_2step
+from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
+from tests.eval.eval_runner import EvalConfig, run_scenario
+from tests.eval.scenarios import basic_2step, compaction_chain_p1
 
 
 class _MockClient:
@@ -29,6 +25,7 @@ class _MockClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
+        **kwargs,
     ) -> LLMResponse:
         if self._idx < len(self._calls):
             tc = self._calls[self._idx]
@@ -41,6 +38,7 @@ class _MockClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
+        **kwargs,
     ) -> AsyncIterator[StreamChunk]:
         resp = await self.send(messages, tools)
         yield StreamChunk(type=ChunkType.FINAL, response=resp)
@@ -58,18 +56,23 @@ class TestBudgetOverride:
         assert compaction_chain_p1.budget_tokens == 3600
 
         # Build a client that completes the 10-step chain
-        client = _MockClient([
-            ToolCall(tool="patient_lookup", args={"patient_name": "Margaret Chen"}),
-            ToolCall(tool="pull_records", args={"mrn": "MRN-84201"}),
-            ToolCall(tool="order_labs", args={"encounter_id": "ENC-20250305"}),
-            ToolCall(tool="review_imaging", args={"lab_id": "LAB-7718"}),
-            ToolCall(tool="request_referral", args={"imaging_id": "IMG-3304"}),
-            ToolCall(tool="check_pharmacy", args={"referral_id": "REF-5521"}),
-            ToolCall(tool="verify_insurance", args={"patient_mrn": "MRN-84201"}),
-            ToolCall(tool="request_prior_auth", args={"plan_id": "PLAN-BC-4490", "referral_id": "REF-5521"}),
-            ToolCall(tool="schedule_appointment", args={"auth_id": "AUTH-9917", "referral_id": "REF-5521"}),
-            ToolCall(tool="submit_treatment_plan", args={"summary": "MRN-84201 HbA1c 9.2% cortical thinning Patel metformin"}),
-        ])
+        client = _MockClient(
+            [
+                ToolCall(tool="patient_lookup", args={"patient_name": "Margaret Chen"}),
+                ToolCall(tool="pull_records", args={"mrn": "MRN-84201"}),
+                ToolCall(tool="order_labs", args={"encounter_id": "ENC-20250305"}),
+                ToolCall(tool="review_imaging", args={"lab_id": "LAB-7718"}),
+                ToolCall(tool="request_referral", args={"imaging_id": "IMG-3304"}),
+                ToolCall(tool="check_pharmacy", args={"referral_id": "REF-5521"}),
+                ToolCall(tool="verify_insurance", args={"patient_mrn": "MRN-84201"}),
+                ToolCall(tool="request_prior_auth", args={"plan_id": "PLAN-BC-4490", "referral_id": "REF-5521"}),
+                ToolCall(tool="schedule_appointment", args={"auth_id": "AUTH-9917", "referral_id": "REF-5521"}),
+                ToolCall(
+                    tool="submit_treatment_plan",
+                    args={"summary": "MRN-84201 HbA1c 9.2% cortical thinning Patel metformin"},
+                ),
+            ]
+        )
 
         config = EvalConfig(
             runs_per_scenario=1,
@@ -85,10 +88,12 @@ class TestBudgetOverride:
         """Without budget_override, scenario.budget_tokens is used."""
         assert basic_2step.budget_tokens == 8192
 
-        client = _MockClient([
-            ToolCall(tool="get_country_info", args={"country": "France"}),
-            ToolCall(tool="summarize", args={"content": "test"}),
-        ])
+        client = _MockClient(
+            [
+                ToolCall(tool="get_country_info", args={"country": "France"}),
+                ToolCall(tool="summarize", args={"content": "test"}),
+            ]
+        )
 
         config = EvalConfig(
             runs_per_scenario=1,
@@ -100,18 +105,23 @@ class TestBudgetOverride:
 
     async def test_tight_budget_triggers_compaction(self) -> None:
         """A very tight budget with long responses should trigger compaction."""
-        client = _MockClient([
-            ToolCall(tool="patient_lookup", args={"patient_name": "Margaret Chen"}),
-            ToolCall(tool="pull_records", args={"mrn": "MRN-84201"}),
-            ToolCall(tool="order_labs", args={"encounter_id": "ENC-20250305"}),
-            ToolCall(tool="review_imaging", args={"lab_id": "LAB-7718"}),
-            ToolCall(tool="request_referral", args={"imaging_id": "IMG-3304"}),
-            ToolCall(tool="check_pharmacy", args={"referral_id": "REF-5521"}),
-            ToolCall(tool="verify_insurance", args={"patient_mrn": "MRN-84201"}),
-            ToolCall(tool="request_prior_auth", args={"plan_id": "PLAN-BC-4490", "referral_id": "REF-5521"}),
-            ToolCall(tool="schedule_appointment", args={"auth_id": "AUTH-9917", "referral_id": "REF-5521"}),
-            ToolCall(tool="submit_treatment_plan", args={"summary": "MRN-84201 HbA1c 9.2% cortical thinning Patel metformin"}),
-        ])
+        client = _MockClient(
+            [
+                ToolCall(tool="patient_lookup", args={"patient_name": "Margaret Chen"}),
+                ToolCall(tool="pull_records", args={"mrn": "MRN-84201"}),
+                ToolCall(tool="order_labs", args={"encounter_id": "ENC-20250305"}),
+                ToolCall(tool="review_imaging", args={"lab_id": "LAB-7718"}),
+                ToolCall(tool="request_referral", args={"imaging_id": "IMG-3304"}),
+                ToolCall(tool="check_pharmacy", args={"referral_id": "REF-5521"}),
+                ToolCall(tool="verify_insurance", args={"patient_mrn": "MRN-84201"}),
+                ToolCall(tool="request_prior_auth", args={"plan_id": "PLAN-BC-4490", "referral_id": "REF-5521"}),
+                ToolCall(tool="schedule_appointment", args={"auth_id": "AUTH-9917", "referral_id": "REF-5521"}),
+                ToolCall(
+                    tool="submit_treatment_plan",
+                    args={"summary": "MRN-84201 HbA1c 9.2% cortical thinning Patel metformin"},
+                ),
+            ]
+        )
 
         config = EvalConfig(
             runs_per_scenario=1,

--- a/tests/unit/test_guardrails_backends.py
+++ b/tests/unit/test_guardrails_backends.py
@@ -1,0 +1,316 @@
+"""Guardrails format-agnostic tests.
+
+Verifies that Forge guardrails (ResponseValidator, ErrorTracker,
+StepEnforcer, Guardrails) work correctly regardless of encoder/decoder
+combo. Guardrails operate on forge internal types (TextResponse, ToolCall)
+and must work with any backend format.
+"""
+
+from __future__ import annotations
+
+from forge.core.workflow import TextResponse, ToolCall
+from forge.guardrails import ErrorTracker, Guardrails, ResponseValidator, StepEnforcer
+
+# ── ResponseValidator works with all backends ─────────────────
+
+
+class TestResponseValidatorAllBackends:
+    """ResponseValidator validates forge types, not wire formats."""
+
+    def test_validates_tool_calls_from_any_backend(self):
+        """Valid tool calls pass regardless of backend format."""
+        v = ResponseValidator(tool_names=["search", "answer"])
+        calls = [ToolCall(tool="search", args={"q": "test"})]
+        result = v.validate(calls)
+        assert result.needs_retry is False
+        assert result.tool_calls == calls
+
+    def test_unknown_tool_detected_from_any_backend(self):
+        """Unknown tool detection works regardless of backend."""
+        v = ResponseValidator(tool_names=["search"])
+        calls = [ToolCall(tool="unknown_tool", args={})]
+        result = v.validate(calls)
+        assert result.needs_retry is True
+        assert result.nudge.kind == "unknown_tool"
+
+    def test_rescue_works_from_any_backend(self):
+        """Rescue parsing works regardless of backend format."""
+        v = ResponseValidator(
+            tool_names=["search", "answer"],
+            rescue_enabled=True,
+        )
+        text = '{"tool": "search", "args": {"q": "rescued"}}'
+        result = v.validate(TextResponse(content=text))
+        assert result.needs_retry is False
+        assert result.tool_calls[0].tool == "search"
+        assert result.tool_calls[0].args == {"q": "rescued"}
+
+    def test_retry_nudge_for_text_from_any_backend(self):
+        """Text response triggers retry regardless of backend."""
+        v = ResponseValidator(
+            tool_names=["search", "answer"],
+            rescue_enabled=False,
+        )
+        result = v.validate(TextResponse(content="I don't know"))
+        assert result.needs_retry is True
+        assert result.nudge.kind == "retry"
+
+
+# ── ErrorTracker works with all backends ─────────────────────
+
+
+class TestErrorTrackerAllBackends:
+    """ErrorTracker tracks errors independently of wire format."""
+
+    def test_retries_increment(self):
+        et = ErrorTracker(max_retries=3)
+        et.record_retry()
+        et.record_retry()
+        assert et.consecutive_retries == 2
+        assert et.retries_exhausted is False
+        et.record_retry()
+        assert et.retries_exhausted is False  # 3 > 3 = False
+        et.record_retry()
+        assert et.retries_exhausted is True  # 4 > 3 = True
+
+    def test_retries_reset_on_success(self):
+        et = ErrorTracker(max_retries=3)
+        et.record_retry()
+        et.record_retry()
+        et.reset_retries()
+        assert et.consecutive_retries == 0
+        assert et.retries_exhausted is False
+
+    def test_tool_errors_increment(self):
+        et = ErrorTracker(max_tool_errors=2)
+        et.record_result(success=False, is_soft_error=False)
+        et.record_result(success=False, is_soft_error=False)
+        assert et.consecutive_tool_errors == 2
+        assert et.tool_errors_exhausted is False  # 2 > 2 = False
+        et.record_result(success=False, is_soft_error=False)
+        assert et.tool_errors_exhausted is True  # 3 > 2 = True
+
+    def test_soft_errors_do_not_increment(self):
+        et = ErrorTracker(max_tool_errors=2)
+        et.record_result(success=False, is_soft_error=True)
+        assert et.consecutive_tool_errors == 0
+
+    def test_success_does_not_reset(self):
+        """Individual success doesn't reset — only clean batch does."""
+        et = ErrorTracker(max_tool_errors=2)
+        et.record_result(success=False)
+        et.record_result(success=True)
+        assert et.consecutive_tool_errors == 1
+
+    def test_reset_errors_on_clean_batch(self):
+        et = ErrorTracker(max_tool_errors=2)
+        et.record_result(success=False)
+        et.record_result(success=False)
+        et.record_result(success=False)
+        assert et.tool_errors_exhausted is True  # 3 > 2
+        et.reset_errors()
+        assert et.consecutive_tool_errors == 0
+        assert et.tool_errors_exhausted is False
+
+
+# ── StepEnforcer works with all backends ─────────────────────
+
+
+class TestStepEnforcerAllBackends:
+    """StepEnforcer enforces steps regardless of wire format."""
+
+    def test_blocks_premature_terminal(self):
+        se = StepEnforcer(
+            required_steps=["search"],
+            terminal_tools=frozenset(["answer"]),
+        )
+        result = se.check([ToolCall(tool="answer", args={})])
+        assert result.needs_nudge is True
+
+    def test_allows_terminal_after_steps(self):
+        se = StepEnforcer(
+            required_steps=["search"],
+            terminal_tools=frozenset(["answer"]),
+        )
+        se.record("search")
+        result = se.check([ToolCall(tool="answer", args={})])
+        assert result.needs_nudge is False
+
+    def test_prerequisites_blocked(self):
+        se = StepEnforcer(
+            required_steps=[],
+            terminal_tools=frozenset(["respond"]),
+            tool_prerequisites={"edit_file": ["read_file"]},
+        )
+        result = se.check_prerequisites([ToolCall(tool="edit_file", args={})])
+        assert result.needs_nudge is True
+
+    def test_prerequisites_passed(self):
+        se = StepEnforcer(
+            required_steps=[],
+            terminal_tools=frozenset(["respond"]),
+            tool_prerequisites={"edit_file": ["read_file"]},
+        )
+        se.record("read_file")
+        result = se.check_prerequisites([ToolCall(tool="edit_file", args={})])
+        assert result.needs_nudge is False
+
+
+# ── Guardrails facade works with all backends ────────────────
+
+
+class TestGuardrailsFacadeAllBackends:
+    """Guardrails facade produces correct actions regardless of backend."""
+
+    def make(self, **overrides):
+        defaults = dict(
+            tool_names=["search", "lookup", "answer"],
+            required_steps=["search", "lookup"],
+            terminal_tool="answer",
+        )
+        defaults.update(overrides)
+        return Guardrails(**defaults)
+
+    def test_valid_tool_execute(self):
+        g = self.make()
+        result = g.check([ToolCall(tool="search", args={"q": "x"})])
+        assert result.action == "execute"
+
+    def test_text_retry(self):
+        g = self.make(rescue_enabled=False)
+        result = g.check(TextResponse(content="bare text"))
+        assert result.action == "retry"
+
+    def test_premature_terminal_blocked(self):
+        g = self.make()
+        result = g.check([ToolCall(tool="answer", args={})])
+        assert result.action == "step_blocked"
+
+    def test_terminal_allowed_after_steps(self):
+        g = self.make()
+        g.check([ToolCall(tool="search", args={})])
+        g.record(["search"])
+        g.check([ToolCall(tool="lookup", args={})])
+        g.record(["lookup"])
+        result = g.check([ToolCall(tool="answer", args={})])
+        assert result.action == "execute"
+
+    def test_record_terminal_returns_done(self):
+        g = self.make()
+        g.check([ToolCall(tool="search", args={})])
+        g.record(["search"])
+        g.check([ToolCall(tool="lookup", args={})])
+        g.record(["lookup"])
+        g.check([ToolCall(tool="answer", args={})])
+        assert g.record(["answer"]) is True
+
+    def test_record_non_terminal_returns_not_done(self):
+        g = self.make()
+        g.check([ToolCall(tool="search", args={})])
+        assert g.record(["search"]) is False
+
+
+# ── Multi-turn agent loop with guardrails ────────────────────
+
+
+class TestMultiTurnWithGuardrails:
+    """Simulate a multi-turn agent loop with guardrails.
+
+    This tests the full agentic loop pattern used by WorkflowRunner
+    and the proxy handler, verifying guardrails work correctly
+    regardless of encoder/decoder combo.
+    """
+
+    def test_two_step_tool_call_loop(self):
+        """search → lookup → answer (with all guardrails)."""
+        g = Guardrails(
+            tool_names=["search", "lookup", "answer"],
+            required_steps=["search", "lookup"],
+            terminal_tool="answer",
+        )
+
+        # Turn 1: model calls search
+        r1 = g.check([ToolCall(tool="search", args={"q": "weather"})])
+        assert r1.action == "execute"
+        g.record(["search"])
+
+        # Turn 2: model calls lookup
+        r2 = g.check([ToolCall(tool="lookup", args={"source": "api"})])
+        assert r2.action == "execute"
+        g.record(["lookup"])
+
+        # Turn 3: model tries answer — should be allowed
+        r3 = g.check([ToolCall(tool="answer", args={"text": "sunny"})])
+        assert r3.action == "execute"
+        assert g.record(["answer"]) is True
+
+    def test_premature_answer_then_retry(self):
+        """Model tries answer too early, gets blocked, then complies."""
+        g = Guardrails(
+            tool_names=["search", "answer"],
+            required_steps=["search"],
+            terminal_tool="answer",
+        )
+
+        # Premature
+        r1 = g.check([ToolCall(tool="answer", args={"text": "hmm"})])
+        assert r1.action == "step_blocked"
+
+        # Now do the required step
+        r2 = g.check([ToolCall(tool="search", args={"q": "x"})])
+        assert r2.action == "execute"
+        g.record(["search"])
+
+        # Now answer is allowed
+        r3 = g.check([ToolCall(tool="answer", args={"text": "result"})])
+        assert r3.action == "execute"
+
+    def test_error_tracker_with_tool_failures(self):
+        """ErrorTracker correctly tracks tool execution errors."""
+        et = ErrorTracker(max_retries=3, max_tool_errors=2)
+
+        # Simulate: valid tool → execution error → valid tool → done
+        et.record_result(success=False, is_soft_error=False)
+        assert et.tool_errors_exhausted is False
+
+        et.record_result(success=True)
+        # Not reset yet
+
+        et.reset_errors()
+        assert et.consecutive_tool_errors == 0
+
+    def test_retry_tracker_with_format_agnostic_responses(self):
+        """ErrorTracker works regardless of whether backend returns
+        TextResponse (OpenAI) or tool_use (Anthropic) internally."""
+        et = ErrorTracker(max_retries=2)
+
+        # Simulate repeated validation failures (format-agnostic)
+        et.record_retry()
+        et.record_retry()
+        assert et.retries_exhausted is False  # 2 > 2 = False
+        et.record_retry()
+        assert et.retries_exhausted is True  # 3 > 2 = True
+
+        # Reset on success
+        et.reset_retries()
+        assert et.retries_exhausted is False
+
+    def test_step_tracker_with_arg_matched_prereqs(self):
+        """StepEnforcer arg-matched prerequisites work correctly."""
+        se = StepEnforcer(
+            required_steps=[],
+            terminal_tools=frozenset(["respond"]),
+            tool_prerequisites={
+                "edit_file": [{"tool": "read_file", "match_arg": "path"}],
+            },
+        )
+
+        # Read different file — doesn't satisfy
+        se.record("read_file", {"path": "other.py"})
+        result = se.check_prerequisites([ToolCall(tool="edit_file", args={"path": "foo.py"})])
+        assert result.needs_nudge is True
+
+        # Read the right file — satisfies
+        se.record("read_file", {"path": "foo.py"})
+        result = se.check_prerequisites([ToolCall(tool="edit_file", args={"path": "foo.py"})])
+        assert result.needs_nudge is False

--- a/tests/unit/test_handler_combos.py
+++ b/tests/unit/test_handler_combos.py
@@ -1,0 +1,439 @@
+"""Full handler path tests for encoder/decoder combinations.
+
+Tests the complete handler pipeline (decoder → guardrails → encoder)
+for each encoder/decoder combo by mocking backend responses.
+
+| Decoder | Encoder | Endpoint | anthropic_backend |
+|---------|---------|----------|-------------------|
+| OpenAI  | OpenAI  | /v1/chat/completions | False |
+| Anthropic | Anthropic | /v1/messages | True |
+| Anthropic | OpenAI | /v1/messages | False |
+| OpenAI  | Anthropic | /v1/chat/completions | True |
+
+Existing tests in test_anthropic_handler.py cover the anthropic_backend=True
+path. This file focuses on the Anthropic→OpenAI combo (anthropic_backend=False
+with handle_messages) and cross-verification that all combos produce the
+correct output format.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from forge.context.manager import ContextManager
+from forge.context.strategies import NoCompact
+from forge.core.workflow import TextResponse, ToolCall
+from forge.proxy.handler import handle_chat_completions, handle_messages
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+def _mock_client(response):
+    client = AsyncMock()
+    client.api_format = "ollama"
+    client.send = AsyncMock(return_value=response)
+    return client
+
+
+def _ctx():
+    return ContextManager(strategy=NoCompact(), budget_tokens=8192)
+
+
+def _anthropic_body(messages=None, tools=None, stream=False, model="claude-sonnet-4"):
+    """Build a minimal Anthropic-format request body."""
+    b = {"messages": messages or [{"role": "user", "content": "hi"}], "model": model}
+    if tools is not None:
+        b["tools"] = tools
+    if stream:
+        b["stream"] = True
+    return b
+
+
+def _openai_body(messages=None, tools=None, stream=False, model="forge"):
+    """Build a minimal OpenAI-format request body."""
+    b = {"messages": messages or [{"role": "user", "content": "hi"}], "model": model}
+    if tools is not None:
+        b["tools"] = tools
+    if stream:
+        b["stream"] = True
+    return b
+
+
+# ── Anthropic → OpenAI (handle_messages with anthropic_backend=False) ──
+
+
+class TestAnthropicToOpenAI:
+    """handle_messages with anthropic_backend=False: Anthropic input → OpenAI output."""
+
+    @pytest.mark.asyncio
+    async def test_text_response(self):
+        """Anthropic request → OpenAI text response."""
+        client = _mock_client(TextResponse(content="Hello!"))
+        body = _anthropic_body()
+        result = await handle_messages(
+            body=body,
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert result["object"] == "chat.completion"
+        assert result["choices"][0]["message"]["content"] == "Hello!"
+        assert result["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_response(self):
+        """Anthropic request → OpenAI tool call response."""
+        client = _mock_client([ToolCall(tool="search", args={"q": "test"})])
+        body = _anthropic_body(
+            tools=[
+                {
+                    "name": "search",
+                    "description": "Search",
+                    "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}},
+                }
+            ],
+        )
+        result = await handle_messages(
+            body=body,
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert result["object"] == "chat.completion"
+        tc = result["choices"][0]["message"]["tool_calls"]
+        assert len(tc) == 1
+        assert tc[0]["function"]["name"] == "search"
+        assert result["choices"][0]["finish_reason"] == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_streaming_text(self):
+        """Anthropic streaming request → OpenAI SSE text events."""
+        client = _mock_client(TextResponse(content="Hi"))
+        body = _anthropic_body(stream=True)
+        result = await handle_messages(
+            body=body,
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert isinstance(result, list)
+        assert result[-1]["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_call(self):
+        """Anthropic streaming request → OpenAI SSE tool call events."""
+        client = _mock_client([ToolCall(tool="fetch", args={"url": "http://x"})])
+        body = _anthropic_body(
+            tools=[
+                {
+                    "name": "fetch",
+                    "description": "Fetch",
+                    "input_schema": {"type": "object", "properties": {"url": {"type": "string"}}},
+                }
+            ],
+            stream=True,
+        )
+        result = await handle_messages(
+            body=body,
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert isinstance(result, list)
+        assert result[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_system_message_passed_through(self):
+        """System message in Anthropic body is converted and passed to backend."""
+        client = _mock_client(TextResponse(content="Got it"))
+        body = _anthropic_body(messages=[{"role": "user", "content": "hi"}])
+        body["system"] = "You are a helpful bot."
+        result = await handle_messages(
+            body=body,
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert result["choices"][0]["message"]["content"] == "Got it"
+
+
+# ── OpenAI → OpenAI (handle_chat_completions with anthropic_backend=False) ──
+
+
+class TestOpenaiToOpenAI:
+    """handle_chat_completions with anthropic_backend=False: OpenAI in/out (regression)."""
+
+    @pytest.mark.asyncio
+    async def test_text_response(self):
+        client = _mock_client(TextResponse(content="Hello!"))
+        result = await handle_chat_completions(
+            _openai_body(),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert result["object"] == "chat.completion"
+        assert result["choices"][0]["message"]["content"] == "Hello!"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_response(self):
+        client = _mock_client([ToolCall(tool="search", args={"q": "x"})])
+        result = await handle_chat_completions(
+            _openai_body(
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "search", "description": "S", "parameters": {}},
+                    }
+                ]
+            ),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert result["choices"][0]["finish_reason"] == "tool_calls"
+        assert result["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "search"
+
+    @pytest.mark.asyncio
+    async def test_streaming_text(self):
+        client = _mock_client(TextResponse(content="Hi"))
+        result = await handle_chat_completions(
+            _openai_body(stream=True),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert isinstance(result, list)
+        assert result[-1]["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_call(self):
+        client = _mock_client([ToolCall(tool="f", args={})])
+        result = await handle_chat_completions(
+            _openai_body(
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "f", "description": "S", "parameters": {}},
+                    }
+                ],
+                stream=True,
+            ),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert isinstance(result, list)
+        assert result[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+
+# ── OpenAI → Anthropic (handle_chat_completions with anthropic_backend=True) ──
+
+
+class TestOpenaiToAnthropic:
+    """handle_chat_completions with anthropic_backend=True: OpenAI in → Anthropic out."""
+
+    @pytest.mark.asyncio
+    async def test_text_response(self):
+        client = _mock_client(TextResponse(content="Hello!"))
+        result = await handle_chat_completions(
+            _openai_body(),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=True,
+        )
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["stop_reason"] == "end_turn"
+        assert result["content"][0] == {"type": "text", "text": "Hello!"}
+
+    @pytest.mark.asyncio
+    async def test_tool_call_response(self):
+        client = _mock_client([ToolCall(tool="search", args={"q": "x"})])
+        result = await handle_chat_completions(
+            _openai_body(
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "search", "description": "S", "parameters": {}},
+                    }
+                ]
+            ),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=True,
+        )
+        assert result["type"] == "message"
+        assert result["stop_reason"] == "tool_use"
+        assert result["content"][0]["type"] == "tool_use"
+        assert result["content"][0]["name"] == "search"
+
+    @pytest.mark.asyncio
+    async def test_streaming_text(self):
+        client = _mock_client(TextResponse(content="Hi"))
+        result = await handle_chat_completions(
+            _openai_body(stream=True),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=True,
+        )
+        assert isinstance(result, list)
+        assert result[0]["type"] == "message_start"
+        assert result[-1]["type"] == "message_stop"
+        text_deltas = [e for e in result if e.get("delta", {}).get("type") == "text_delta"]
+        assert len(text_deltas) >= 1
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_call(self):
+        client = _mock_client([ToolCall(tool="f", args={"x": 1})])
+        result = await handle_chat_completions(
+            _openai_body(
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "f", "description": "S", "parameters": {}},
+                    }
+                ],
+                stream=True,
+            ),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=True,
+        )
+        assert isinstance(result, list)
+        tool_starts = [e for e in result if e.get("content_block", {}).get("type") == "tool_use"]
+        assert len(tool_starts) >= 1
+        input_deltas = [e for e in result if e.get("delta", {}).get("type") == "input_json_delta"]
+        assert len(input_deltas) >= 1
+        assert result[-1]["type"] == "message_stop"
+
+
+# ── Anthropic → Anthropic (handle_messages with anthropic_backend=True) ──
+
+
+class TestAnthropicToAnthropic:
+    """handle_messages with anthropic_backend=True: Anthropic in/out (regression)."""
+
+    @pytest.mark.asyncio
+    async def test_text_response(self):
+        client = _mock_client(TextResponse(content="Hello!"))
+        body = _anthropic_body()
+        result = await handle_messages(
+            body=body,
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=True,
+        )
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["content"][0] == {"type": "text", "text": "Hello!"}
+
+    @pytest.mark.asyncio
+    async def test_tool_call_response(self):
+        client = _mock_client([ToolCall(tool="search", args={"q": "x"})])
+        body = _anthropic_body(
+            tools=[
+                {
+                    "name": "search",
+                    "description": "Search",
+                    "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}},
+                }
+            ]
+        )
+        result = await handle_messages(
+            body=body,
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=True,
+        )
+        assert result["stop_reason"] == "tool_use"
+        assert result["content"][0]["type"] == "tool_use"
+        assert result["content"][0]["name"] == "search"
+
+    @pytest.mark.asyncio
+    async def test_streaming(self):
+        client = _mock_client(TextResponse(content="Hi"))
+        body = _anthropic_body(stream=True)
+        result = await handle_messages(
+            body=body,
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=True,
+        )
+        assert isinstance(result, list)
+        assert result[0]["type"] == "message_start"
+        assert result[-1]["type"] == "message_stop"
+
+
+# ── Cross-combo verification: same backend response, different output formats ──
+
+
+class TestFormatConsistency:
+    """Same backend response should produce correctly formatted output for each combo."""
+
+    @pytest.mark.asyncio
+    async def test_text_response_format_differs_by_backend(self):
+        """Text response should be OpenAI format when anthropic_backend=False,
+        Anthropic format when anthropic_backend=True."""
+        client = _mock_client(TextResponse(content="Hello!"))
+
+        openai_result = await handle_chat_completions(
+            _openai_body(),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert "object" in openai_result
+        assert "choices" in openai_result
+        assert "type" not in openai_result
+
+        client.reset_mock()
+        anthropic_result = await handle_chat_completions(
+            _openai_body(),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=True,
+        )
+        assert "type" in anthropic_result
+        assert anthropic_result["type"] == "message"
+        assert "choices" not in anthropic_result
+
+    @pytest.mark.asyncio
+    async def test_tool_call_format_differs_by_backend(self):
+        """Tool call response should differ by backend format."""
+        client = _mock_client([ToolCall(tool="search", args={"q": "x"})])
+
+        openai_result = await handle_chat_completions(
+            _openai_body(
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "search", "description": "S", "parameters": {}},
+                    }
+                ]
+            ),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=False,
+        )
+        assert openai_result["choices"][0]["finish_reason"] == "tool_calls"
+        assert "tool_calls" in openai_result["choices"][0]["message"]
+
+        client.reset_mock()
+        anthropic_result = await handle_chat_completions(
+            _openai_body(
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "search", "description": "S", "parameters": {}},
+                    }
+                ]
+            ),
+            client=client,
+            context_manager=_ctx(),
+            anthropic_backend=True,
+        )
+        assert anthropic_result["stop_reason"] == "tool_use"
+        assert anthropic_result["content"][0]["type"] == "tool_use"

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -108,7 +108,16 @@ async def _sse_request(port, body):
         writer.write(request)
         await writer.drain()
 
-        response_data = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+        # Read until connection closes (chunked encoding ends with 0\r\n\r\n)
+        response_data = bytearray()
+        while True:
+            chunk = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+            if not chunk:
+                break
+            response_data.extend(chunk)
+            # Chunked transfer ends with "0\r\n\r\n"
+            if b"0\r\n\r\n" in response_data:
+                break
         response_str = response_data.decode("utf-8", errors="replace")
 
         # Extract SSE data lines from chunked transfer encoding

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -4,16 +4,15 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator
-from unittest.mock import MagicMock
 
 import pytest
+from pydantic import BaseModel
 
-from forge.clients.base import ChunkType, LLMClient, StreamChunk
+from forge.clients.base import ChunkType, StreamChunk
 from forge.context.manager import ContextManager
 from forge.context.strategies import NoCompact
 from forge.core.messages import Message, MessageMeta, MessageRole, MessageType, ToolCallInfo
 from forge.core.runner import WorkflowRunner
-from pydantic import BaseModel
 from forge.core.workflow import (
     LLMResponse,
     TextResponse,
@@ -22,7 +21,16 @@ from forge.core.workflow import (
     ToolSpec,
     Workflow,
 )
-from forge.errors import MaxIterationsError, PrerequisiteError, StepEnforcementError, StreamError, ToolCallError, ToolExecutionError, ToolResolutionError, WorkflowCancelledError
+from forge.errors import (
+    MaxIterationsError,
+    PrerequisiteError,
+    StepEnforcementError,
+    StreamError,
+    ToolCallError,
+    ToolExecutionError,
+    ToolResolutionError,
+    WorkflowCancelledError,
+)
 
 
 class EmptyParams(BaseModel):
@@ -58,6 +66,7 @@ class MockClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
+        **kwargs,
     ) -> LLMResponse:
         self.send_calls.append((messages, tools))
         return self._next()
@@ -139,10 +148,12 @@ class TestHappyPath:
     @pytest.mark.asyncio
     async def test_simple_workflow(self):
         """One required step + terminal tool → returns terminal result."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(_make_workflow(), "do something", prompt_vars={"role": "tester"})
         assert result == "submit_result"
@@ -156,11 +167,13 @@ class TestHappyPath:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["step_a", "step_b"])
-        client = MockClient([
-            ToolCall(tool="step_a", args={}),
-            ToolCall(tool="step_b", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="step_a", args={}),
+                ToolCall(tool="step_b", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -179,10 +192,12 @@ class TestHappyPath:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={"key": "value", "count": 42}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={"key": "value", "count": 42}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert received_args == {"key": "value", "count": 42}
@@ -195,11 +210,13 @@ class TestRetryLogic:
     @pytest.mark.asyncio
     async def test_text_response_triggers_retry(self):
         """TextResponse triggers retry nudge, then ToolCall succeeds."""
-        client = MockClient([
-            TextResponse(content="I don't know"),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="I don't know"),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -207,12 +224,14 @@ class TestRetryLogic:
     @pytest.mark.asyncio
     async def test_retries_exhausted_raises_tool_call_error(self):
         """All retries exhausted → ToolCallError with last raw response."""
-        client = MockClient([
-            TextResponse(content="nope1"),
-            TextResponse(content="nope2"),
-            TextResponse(content="nope3"),
-            TextResponse(content="final_nope"),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="nope1"),
+                TextResponse(content="nope2"),
+                TextResponse(content="nope3"),
+                TextResponse(content="final_nope"),
+            ]
+        )
         runner = _make_runner(client, max_retries_per_step=3)
         with pytest.raises(ToolCallError) as exc_info:
             await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
@@ -227,18 +246,20 @@ class TestRetryLogic:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["step_a", "step_b"])
-        client = MockClient([
-            # 2 retries then success
-            TextResponse(content="fail1"),
-            TextResponse(content="fail2"),
-            ToolCall(tool="step_a", args={}),
-            # 2 more retries then success — counter reset by previous ToolCall
-            TextResponse(content="fail3"),
-            TextResponse(content="fail4"),
-            ToolCall(tool="step_b", args={}),
-            # Terminal
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                # 2 retries then success
+                TextResponse(content="fail1"),
+                TextResponse(content="fail2"),
+                ToolCall(tool="step_a", args={}),
+                # 2 more retries then success — counter reset by previous ToolCall
+                TextResponse(content="fail3"),
+                TextResponse(content="fail4"),
+                ToolCall(tool="step_b", args={}),
+                # Terminal
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client, max_retries_per_step=3)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -246,12 +267,14 @@ class TestRetryLogic:
     @pytest.mark.asyncio
     async def test_retries_consume_iterations(self):
         """Each TextResponse retry consumes an iteration from max_iterations."""
-        client = MockClient([
-            TextResponse(content="fail1"),  # iteration 0
-            TextResponse(content="fail2"),  # iteration 1
-            ToolCall(tool="fetch", args={}),  # iteration 2
-            ToolCall(tool="submit", args={}),  # iteration 3 — would exceed max_iterations=3
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="fail1"),  # iteration 0
+                TextResponse(content="fail2"),  # iteration 1
+                ToolCall(tool="fetch", args={}),  # iteration 2
+                ToolCall(tool="submit", args={}),  # iteration 3 — would exceed max_iterations=3
+            ]
+        )
         runner = _make_runner(client, max_iterations=3, max_retries_per_step=3)
         # 2 retries + 1 fetch = 3 iterations used, no room for submit
         with pytest.raises(MaxIterationsError) as exc_info:
@@ -261,11 +284,13 @@ class TestRetryLogic:
     @pytest.mark.asyncio
     async def test_max_iterations_bounds_total_llm_calls(self):
         """max_iterations is the hard ceiling on total LLM calls including retries."""
-        client = MockClient([
-            TextResponse(content="nope"),  # iteration 0
-            TextResponse(content="nope"),  # iteration 1
-            TextResponse(content="nope"),  # iteration 2
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="nope"),  # iteration 0
+                TextResponse(content="nope"),  # iteration 1
+                TextResponse(content="nope"),  # iteration 2
+            ]
+        )
         # max_retries_per_step=5 (high), but max_iterations=3 (low) — hits iterations first
         runner = _make_runner(client, max_iterations=3, max_retries_per_step=5)
         with pytest.raises(MaxIterationsError):
@@ -292,11 +317,13 @@ class TestStepEnforcement:
             "submit": _make_tool("submit", fn=counting_submit),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="submit", args={}),   # premature
-            ToolCall(tool="fetch", args={}),     # do the required step
-            ToolCall(tool="submit", args={}),    # now satisfied
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="submit", args={}),  # premature
+                ToolCall(tool="fetch", args={}),  # do the required step
+                ToolCall(tool="submit", args={}),  # now satisfied
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert result == "submitted"
@@ -306,15 +333,17 @@ class TestStepEnforcement:
     @pytest.mark.asyncio
     async def test_premature_terminal_resets_retry_counter(self):
         """Premature terminal (valid ToolCall) resets consecutive_retries."""
-        client = MockClient([
-            TextResponse(content="garbage"),      # retry 1
-            TextResponse(content="garbage"),      # retry 2
-            ToolCall(tool="submit", args={}),     # premature terminal — resets counter
-            TextResponse(content="garbage"),      # retry 1 (reset)
-            TextResponse(content="garbage"),      # retry 2
-            ToolCall(tool="fetch", args={}),      # success
-            ToolCall(tool="submit", args={}),     # terminal, satisfied
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="garbage"),  # retry 1
+                TextResponse(content="garbage"),  # retry 2
+                ToolCall(tool="submit", args={}),  # premature terminal — resets counter
+                TextResponse(content="garbage"),  # retry 1 (reset)
+                TextResponse(content="garbage"),  # retry 2
+                ToolCall(tool="fetch", args={}),  # success
+                ToolCall(tool="submit", args={}),  # terminal, satisfied
+            ]
+        )
         # max_retries_per_step=3 — without reset, retries 1+2+1+2 = would exceed
         runner = _make_runner(client, max_retries_per_step=3)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
@@ -323,11 +352,13 @@ class TestStepEnforcement:
     @pytest.mark.asyncio
     async def test_step_nudge_allows_recovery(self):
         """After nudge, model completes required step, then terminal succeeds."""
-        client = MockClient([
-            ToolCall(tool="submit", args={}),   # nudged
-            ToolCall(tool="fetch", args={}),     # required step
-            ToolCall(tool="submit", args={}),    # now OK
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="submit", args={}),  # nudged
+                ToolCall(tool="fetch", args={}),  # required step
+                ToolCall(tool="submit", args={}),  # now OK
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -335,13 +366,15 @@ class TestStepEnforcement:
     @pytest.mark.asyncio
     async def test_escalating_nudge_tiers(self):
         """3 premature terminal calls get tier 1, 2, 3 nudge messages."""
-        client = MockClient([
-            ToolCall(tool="submit", args={}),   # tier 1
-            ToolCall(tool="submit", args={}),   # tier 2
-            ToolCall(tool="submit", args={}),   # tier 3
-            ToolCall(tool="fetch", args={}),     # required step
-            ToolCall(tool="submit", args={}),    # now OK
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="submit", args={}),  # tier 1
+                ToolCall(tool="submit", args={}),  # tier 2
+                ToolCall(tool="submit", args={}),  # tier 3
+                ToolCall(tool="fetch", args={}),  # required step
+                ToolCall(tool="submit", args={}),  # now OK
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         original_compact = ctx.maybe_compact
         captured_messages: list[list[Message]] = []
@@ -374,12 +407,14 @@ class TestStepEnforcement:
     @pytest.mark.asyncio
     async def test_premature_terminal_exhausted_raises_step_enforcement_error(self):
         """4th premature terminal call raises StepEnforcementError."""
-        client = MockClient([
-            ToolCall(tool="submit", args={}),   # tier 1
-            ToolCall(tool="submit", args={}),   # tier 2
-            ToolCall(tool="submit", args={}),   # tier 3
-            ToolCall(tool="submit", args={}),   # raises
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="submit", args={}),  # tier 1
+                ToolCall(tool="submit", args={}),  # tier 2
+                ToolCall(tool="submit", args={}),  # tier 3
+                ToolCall(tool="submit", args={}),  # raises
+            ]
+        )
         runner = _make_runner(client)
         with pytest.raises(StepEnforcementError) as exc_info:
             await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
@@ -390,18 +425,20 @@ class TestStepEnforcement:
     @pytest.mark.asyncio
     async def test_premature_terminal_counter_resets_on_progress(self):
         """Successful tool call resets the premature terminal counter."""
-        client = MockClient([
-            ToolCall(tool="submit", args={}),   # premature 1
-            ToolCall(tool="submit", args={}),   # premature 2
-            ToolCall(tool="submit", args={}),   # premature 3
-            # If counter didn't reset, the next premature call would be attempt 4 → raise
-            ToolCall(tool="fetch", args={}),     # success — resets counter
-            ToolCall(tool="submit", args={}),   # premature 1 (reset)
-            ToolCall(tool="submit", args={}),   # premature 2 (reset)
-            ToolCall(tool="submit", args={}),   # premature 3 (reset)
-            # Still alive after 3 more because counter was reset
-            ToolCall(tool="submit", args={}),    # now satisfied (fetch was done)
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="submit", args={}),  # premature 1
+                ToolCall(tool="submit", args={}),  # premature 2
+                ToolCall(tool="submit", args={}),  # premature 3
+                # If counter didn't reset, the next premature call would be attempt 4 → raise
+                ToolCall(tool="fetch", args={}),  # success — resets counter
+                ToolCall(tool="submit", args={}),  # premature 1 (reset)
+                ToolCall(tool="submit", args={}),  # premature 2 (reset)
+                ToolCall(tool="submit", args={}),  # premature 3 (reset)
+                # Still alive after 3 more because counter was reset
+                ToolCall(tool="submit", args={}),  # now satisfied (fetch was done)
+            ]
+        )
         # Need enough iterations for all 8 calls
         runner = _make_runner(client, max_iterations=10)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
@@ -415,11 +452,13 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_unknown_tool_nudges_then_recovers(self):
         """Unknown tool name → nudge, model corrects → workflow completes."""
-        client = MockClient([
-            ToolCall(tool="get_pricing", args={}),  # wrong name
-            ToolCall(tool="fetch", args={}),          # corrected
-            ToolCall(tool="submit", args={}),         # terminal
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="get_pricing", args={}),  # wrong name
+                ToolCall(tool="fetch", args={}),  # corrected
+                ToolCall(tool="submit", args={}),  # terminal
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -427,11 +466,13 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_unknown_tool_nudge_lists_available_tools(self):
         """Nudge message for unknown tool contains available tool names."""
-        client = MockClient([
-            ToolCall(tool="nonexistent", args={}),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="nonexistent", args={}),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -446,11 +487,13 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_unknown_tool_consumes_iteration(self):
         """Unknown tool nudge consumes an iteration from max_iterations."""
-        client = MockClient([
-            ToolCall(tool="bad_name", args={}),   # iteration 0 (nudge)
-            ToolCall(tool="fetch", args={}),        # iteration 1
-            ToolCall(tool="submit", args={}),       # iteration 2 — exceeds max_iterations=2
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="bad_name", args={}),  # iteration 0 (nudge)
+                ToolCall(tool="fetch", args={}),  # iteration 1
+                ToolCall(tool="submit", args={}),  # iteration 2 — exceeds max_iterations=2
+            ]
+        )
         runner = _make_runner(client, max_iterations=2)
         with pytest.raises(MaxIterationsError):
             await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
@@ -458,12 +501,14 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_unknown_tool_exhausts_retries(self):
         """Repeated unknown tool names exhaust max_retries_per_step → ToolCallError."""
-        client = MockClient([
-            ToolCall(tool="bad1", args={}),
-            ToolCall(tool="bad2", args={}),
-            ToolCall(tool="bad3", args={}),
-            ToolCall(tool="bad4", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="bad1", args={}),
+                ToolCall(tool="bad2", args={}),
+                ToolCall(tool="bad3", args={}),
+                ToolCall(tool="bad4", args={}),
+            ]
+        )
         runner = _make_runner(client, max_retries_per_step=3)
         with pytest.raises(ToolCallError, match="Retries exhausted"):
             await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
@@ -471,12 +516,14 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_unknown_tool_and_text_response_share_retry_counter(self):
         """TextResponse and unknown tool retries accumulate on the same counter."""
-        client = MockClient([
-            TextResponse(content="garbage"),         # retry 1
-            ToolCall(tool="nonexistent", args={}),   # retry 2
-            TextResponse(content="more garbage"),    # retry 3
-            ToolCall(tool="still_wrong", args={}),   # retry 4 → exceeds max_retries=3
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="garbage"),  # retry 1
+                ToolCall(tool="nonexistent", args={}),  # retry 2
+                TextResponse(content="more garbage"),  # retry 3
+                ToolCall(tool="still_wrong", args={}),  # retry 4 → exceeds max_retries=3
+            ]
+        )
         runner = _make_runner(client, max_retries_per_step=3)
         with pytest.raises(ToolCallError, match="Retries exhausted"):
             await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
@@ -498,11 +545,13 @@ class TestErrorHandling:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={"count": "five"}),   # will raise
-            ToolCall(tool="fetch", args={"count": 5}),        # corrected
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={"count": "five"}),  # will raise
+                ToolCall(tool="fetch", args={"count": 5}),  # corrected
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -520,11 +569,13 @@ class TestErrorHandling:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),   # error 1
-            ToolCall(tool="fetch", args={}),   # error 2
-            ToolCall(tool="fetch", args={}),   # error 3 → exceeds max_tool_errors=2
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),  # error 1
+                ToolCall(tool="fetch", args={}),  # error 2
+                ToolCall(tool="fetch", args={}),  # error 3 → exceeds max_tool_errors=2
+            ]
+        )
         runner = _make_runner(client, max_tool_errors=2)
         with pytest.raises(ToolExecutionError):
             await runner.run(wf, "go", prompt_vars={"role": "agent"})
@@ -548,11 +599,13 @@ class TestErrorHandling:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),  # error 1
-            ToolCall(tool="fetch", args={}),  # error 2
-            ToolCall(tool="fetch", args={}),  # error 3 → exceeds max_tool_errors=2
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),  # error 1
+                ToolCall(tool="fetch", args={}),  # error 2
+                ToolCall(tool="fetch", args={}),  # error 3 → exceeds max_tool_errors=2
+            ]
+        )
         runner = _make_runner(client, max_tool_errors=2)
         with pytest.raises(ToolExecutionError) as exc_info:
             await runner.run(wf, "go", prompt_vars={"role": "agent"})
@@ -576,13 +629,15 @@ class TestErrorHandling:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),  # error 1 (call_count=1)
-            ToolCall(tool="fetch", args={}),  # success  (call_count=2) → resets counter
-            ToolCall(tool="fetch", args={}),  # error 1 again (call_count=3) → counter reset
-            ToolCall(tool="fetch", args={}),  # success  (call_count=4)
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),  # error 1 (call_count=1)
+                ToolCall(tool="fetch", args={}),  # success  (call_count=2) → resets counter
+                ToolCall(tool="fetch", args={}),  # error 1 again (call_count=3) → counter reset
+                ToolCall(tool="fetch", args={}),  # success  (call_count=4)
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         # max_tool_errors=1 — without reset, second error would raise
         runner = _make_runner(client, max_tool_errors=1)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
@@ -605,11 +660,13 @@ class TestErrorHandling:
             "submit": _make_tool("submit", fn=flaky_submit),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={"bad": True}),   # terminal raises
-            ToolCall(tool="submit", args={}),               # terminal succeeds
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={"bad": True}),  # terminal raises
+                ToolCall(tool="submit", args={}),  # terminal succeeds
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert result == "submitted"
@@ -631,12 +688,14 @@ class TestErrorHandling:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),    # fails — should NOT satisfy required step
-            ToolCall(tool="submit", args={}),   # premature — fetch not satisfied yet
-            ToolCall(tool="fetch", args={}),    # succeeds — now satisfied
-            ToolCall(tool="submit", args={}),   # terminal — OK
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),  # fails — should NOT satisfy required step
+                ToolCall(tool="submit", args={}),  # premature — fetch not satisfied yet
+                ToolCall(tool="fetch", args={}),  # succeeds — now satisfied
+                ToolCall(tool="submit", args={}),  # terminal — OK
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -655,11 +714,13 @@ class TestErrorHandling:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),  # iteration 0 (error)
-            ToolCall(tool="fetch", args={}),  # iteration 1 (error)
-            ToolCall(tool="fetch", args={}),  # iteration 2 — exceeds max_iterations=2
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),  # iteration 0 (error)
+                ToolCall(tool="fetch", args={}),  # iteration 1 (error)
+                ToolCall(tool="fetch", args={}),  # iteration 2 — exceeds max_iterations=2
+            ]
+        )
         runner = _make_runner(client, max_iterations=2, max_tool_errors=5)
         with pytest.raises(MaxIterationsError):
             await runner.run(wf, "go", prompt_vars={"role": "agent"})
@@ -667,9 +728,7 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_max_iterations_exceeded(self):
         """Non-terminal ToolCalls exhaust max_iterations → MaxIterationsError."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}) for _ in range(5)
-        ])
+        client = MockClient([ToolCall(tool="fetch", args={}) for _ in range(5)])
         runner = _make_runner(client, max_iterations=3)
         with pytest.raises(MaxIterationsError) as exc_info:
             await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
@@ -684,10 +743,12 @@ class TestContextManagement:
     @pytest.mark.asyncio
     async def test_compaction_called_each_iteration(self):
         """maybe_compact called once per iteration with correct args."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         original_compact = ctx.maybe_compact
         compact_calls = []
@@ -708,10 +769,12 @@ class TestContextManagement:
     @pytest.mark.asyncio
     async def test_messages_grow_correctly(self):
         """After each tool call, messages contain correct types in order."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -732,10 +795,12 @@ class TestStreaming:
     @pytest.mark.asyncio
     async def test_stream_mode_uses_send_stream(self):
         """With stream=True, runner calls send_stream() instead of send()."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client, stream=True)
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         assert len(client.send_stream_calls) == 2
@@ -749,10 +814,12 @@ class TestStreaming:
         async def collect(chunk: StreamChunk) -> None:
             received_chunks.append(chunk)
 
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client, stream=True, on_chunk=collect)
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -764,10 +831,12 @@ class TestStreaming:
     @pytest.mark.asyncio
     async def test_stream_extracts_final_response(self):
         """Streaming extracts ToolCall from FINAL chunk and acts on it."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={"x": 1}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={"x": 1}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client, stream=True)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -801,6 +870,7 @@ class TestAsyncToolSupport:
     @pytest.mark.asyncio
     async def test_async_tool_callable(self):
         """Async tool callable is awaited correctly."""
+
         async def async_fetch(**kwargs):
             return "async_result"
 
@@ -809,10 +879,12 @@ class TestAsyncToolSupport:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -820,6 +892,7 @@ class TestAsyncToolSupport:
     @pytest.mark.asyncio
     async def test_sync_tool_callable(self):
         """Sync tool callable is called correctly."""
+
         def sync_fetch(**kwargs):
             return "sync_result"
 
@@ -828,10 +901,12 @@ class TestAsyncToolSupport:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -844,10 +919,12 @@ class TestMessageStructure:
     @pytest.mark.asyncio
     async def test_initial_messages_correct(self):
         """Initial messages: system prompt + user input with correct metadata."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(_make_workflow(), "do something", prompt_vars={"role": "tester"})
 
@@ -862,10 +939,12 @@ class TestMessageStructure:
     @pytest.mark.asyncio
     async def test_tool_call_message_format(self):
         """Tool call message contains tool name and args, result is stringified."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={"key": "val"}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={"key": "val"}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -882,11 +961,13 @@ class TestMessageStructure:
     @pytest.mark.asyncio
     async def test_text_response_emits_assistant_before_retry_nudge(self):
         """TextResponse content is recorded as ASSISTANT/TEXT_RESPONSE before the retry nudge."""
-        client = MockClient([
-            TextResponse(content="I'm not sure what to do"),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="I'm not sure what to do"),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -903,11 +984,13 @@ class TestMessageStructure:
         """Unknown tool call is recorded as ASSISTANT(tc) + TOOL(error) — the
         corrective signal rides the canonical tool-result channel rather than a
         trailing user nudge."""
-        client = MockClient([
-            ToolCall(tool="nonexistent", args={"x": 1}),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="nonexistent", args={"x": 1}),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -923,11 +1006,13 @@ class TestMessageStructure:
     @pytest.mark.asyncio
     async def test_step_nudge_emits_assistant_before_nudge(self):
         """Premature terminal tool call is recorded as ASSISTANT before the step nudge."""
-        client = MockClient([
-            ToolCall(tool="submit", args={}),   # premature
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="submit", args={}),  # premature
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -943,11 +1028,13 @@ class TestMessageStructure:
     @pytest.mark.asyncio
     async def test_retry_nudge_message_metadata(self):
         """Retry nudge has MessageType.RETRY_NUDGE metadata."""
-        client = MockClient([
-            TextResponse(content="bad output"),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="bad output"),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         original_compact = ctx.maybe_compact
         captured_messages: list[list[Message]] = []
@@ -970,11 +1057,13 @@ class TestMessageStructure:
     @pytest.mark.asyncio
     async def test_step_nudge_message_metadata(self):
         """Step nudge has MessageType.STEP_NUDGE metadata."""
-        client = MockClient([
-            ToolCall(tool="submit", args={}),   # premature
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="submit", args={}),  # premature
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         original_compact = ctx.maybe_compact
         captured_messages: list[list[Message]] = []
@@ -1002,10 +1091,12 @@ class TestRescueToolCalls:
     @pytest.mark.asyncio
     async def test_rescue_json_from_text_response(self):
         """TextResponse with valid JSON tool call is rescued — no retry nudge."""
-        client = MockClient([
-            TextResponse(content='{"tool": "fetch", "args": {"key": "val"}}'),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content='{"tool": "fetch", "args": {"key": "val"}}'),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -1015,10 +1106,12 @@ class TestRescueToolCalls:
     @pytest.mark.asyncio
     async def test_rescue_rehearsal_syntax(self):
         """TextResponse with rehearsal syntax is rescued."""
-        client = MockClient([
-            TextResponse(content='fetch[ARGS]{"key": "val"}'),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content='fetch[ARGS]{"key": "val"}'),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -1027,31 +1120,36 @@ class TestRescueToolCalls:
     @pytest.mark.asyncio
     async def test_rescue_resets_retry_counter(self):
         """Rescued tool call resets consecutive_retries like a normal ToolCall."""
-        client = MockClient([
-            TextResponse(content="plain garbage"),            # retry 1
-            TextResponse(content="more garbage"),             # retry 2
-            TextResponse(content='{"tool": "fetch", "args": {}}'),  # rescued → resets
-            TextResponse(content="garbage again"),            # retry 1 (reset)
-            TextResponse(content="still garbage"),            # retry 2
-            TextResponse(content='{"tool": "fetch", "args": {}}'),  # rescued → resets
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="plain garbage"),  # retry 1
+                TextResponse(content="more garbage"),  # retry 2
+                TextResponse(content='{"tool": "fetch", "args": {}}'),  # rescued → resets
+                TextResponse(content="garbage again"),  # retry 1 (reset)
+                TextResponse(content="still garbage"),  # retry 2
+                TextResponse(content='{"tool": "fetch", "args": {}}'),  # rescued → resets
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         # max_retries=3 — without reset from rescue, retries would exhaust
         runner = _make_runner(client, max_retries_per_step=3, max_iterations=10)
         result = await runner.run(
             _make_workflow(required_steps=[]),
-            "go", prompt_vars={"role": "agent"},
+            "go",
+            prompt_vars={"role": "agent"},
         )
         assert result == "submit_result"
 
     @pytest.mark.asyncio
     async def test_rescue_unknown_tool_falls_through(self):
         """Rescued ToolCall with unknown tool name goes to the unknown tool nudge path."""
-        client = MockClient([
-            TextResponse(content='{"tool": "nonexistent", "args": {}}'),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content='{"tool": "nonexistent", "args": {}}'),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         # rescue_tool_call returns None for unknown tools → normal retry nudge
@@ -1071,10 +1169,12 @@ class TestRescueToolCalls:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            TextResponse(content='{"tool": "fetch", "args": {"count": 42}}'),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content='{"tool": "fetch", "args": {"count": 42}}'),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert received_args == {"count": 42}
@@ -1082,10 +1182,12 @@ class TestRescueToolCalls:
     @pytest.mark.asyncio
     async def test_rescue_satisfies_required_step(self):
         """Rescued tool call satisfies a required step."""
-        client = MockClient([
-            TextResponse(content='{"tool": "fetch", "args": {}}'),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content='{"tool": "fetch", "args": {}}'),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         # submit succeeds because rescued fetch satisfied the required step
@@ -1094,11 +1196,13 @@ class TestRescueToolCalls:
     @pytest.mark.asyncio
     async def test_non_rescuable_text_still_nudges(self):
         """Plain text that can't be rescued still triggers retry nudge."""
-        client = MockClient([
-            TextResponse(content="Let me think about this..."),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="Let me think about this..."),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -1113,10 +1217,12 @@ class TestReasoningCapture:
     @pytest.mark.asyncio
     async def test_reasoning_message_appended_before_tool_call(self):
         """ToolCall with reasoning → REASONING message before TOOL_CALL in history."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}, reasoning="I need to fetch the data first."),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}, reasoning="I need to fetch the data first."),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         original_compact = ctx.maybe_compact
         captured_messages: list[list[Message]] = []
@@ -1147,10 +1253,12 @@ class TestReasoningCapture:
     @pytest.mark.asyncio
     async def test_no_reasoning_message_when_reasoning_is_none(self):
         """ToolCall without reasoning → no REASONING message in history."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         original_compact = ctx.maybe_compact
         captured_messages: list[list[Message]] = []
@@ -1186,11 +1294,13 @@ class TestReasoningCapture:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}, reasoning="Let me try fetching."),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}, reasoning="Let me try fetching."),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         original_compact = ctx.maybe_compact
         captured_messages: list[list[Message]] = []
@@ -1233,11 +1343,13 @@ class TestReasoningCapture:
             "submit": _make_tool("submit", fn=flaky_submit),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}, reasoning="Time to submit the result."),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}, reasoning="Time to submit the result."),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         original_compact = ctx.maybe_compact
         captured_messages: list[list[Message]] = []
@@ -1266,10 +1378,12 @@ class TestReasoningCapture:
     @pytest.mark.asyncio
     async def test_reasoning_folded_into_tool_call_on_wire(self):
         """Reasoning is folded into the tool_call message's content on the wire."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}, reasoning="Thinking about this..."),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}, reasoning="Thinking about this..."),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -1284,11 +1398,13 @@ class TestReasoningCapture:
     @pytest.mark.asyncio
     async def test_text_response_not_folded_into_tool_call(self):
         """TEXT_RESPONSE is not folded into the next tool_call's content (unlike REASONING)."""
-        client = MockClient([
-            TextResponse(content="Let me think about this..."),
-            ToolCall(tool="fetch", args={}, reasoning="Now I know what to do"),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="Let me think about this..."),
+                ToolCall(tool="fetch", args={}, reasoning="Now I know what to do"),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -1309,13 +1425,17 @@ class TestOnMessageCallback:
     async def test_on_message_receives_all_messages(self):
         """on_message fires for every message: system, user, tool_call, tool_result, terminal."""
         collected: list[Message] = []
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx, on_message=collected.append,
+            client=client,
+            context_manager=ctx,
+            on_message=collected.append,
         )
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -1332,10 +1452,12 @@ class TestOnMessageCallback:
     @pytest.mark.asyncio
     async def test_on_message_none_is_safe(self):
         """on_message=None (default) does not cause errors."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)  # on_message not set
         result = await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -1344,14 +1466,18 @@ class TestOnMessageCallback:
     async def test_on_message_captures_retry_nudge(self):
         """on_message fires for retry nudge messages."""
         collected: list[Message] = []
-        client = MockClient([
-            TextResponse(content="bad"),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="bad"),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx, on_message=collected.append,
+            client=client,
+            context_manager=ctx,
+            on_message=collected.append,
         )
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -1362,14 +1488,18 @@ class TestOnMessageCallback:
     async def test_on_message_captures_step_nudge(self):
         """on_message fires for step nudge messages."""
         collected: list[Message] = []
-        client = MockClient([
-            ToolCall(tool="submit", args={}),   # premature
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="submit", args={}),  # premature
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx, on_message=collected.append,
+            client=client,
+            context_manager=ctx,
+            on_message=collected.append,
         )
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -1389,15 +1519,19 @@ class TestOnMessageCallback:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),   # error
-            ToolCall(tool="fetch", args={}),   # error
-            ToolCall(tool="fetch", args={}),   # exceeds max_tool_errors
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),  # error
+                ToolCall(tool="fetch", args={}),  # error
+                ToolCall(tool="fetch", args={}),  # exceeds max_tool_errors
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx,
-            max_tool_errors=2, on_message=collected.append,
+            client=client,
+            context_manager=ctx,
+            max_tool_errors=2,
+            on_message=collected.append,
         )
         with pytest.raises(ToolExecutionError):
             await runner.run(wf, "go", prompt_vars={"role": "agent"})
@@ -1409,13 +1543,17 @@ class TestOnMessageCallback:
     async def test_on_message_captures_reasoning(self):
         """on_message fires for reasoning messages."""
         collected: list[Message] = []
-        client = MockClient([
-            ToolCall(tool="fetch", args={}, reasoning="Thinking..."),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}, reasoning="Thinking..."),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx, on_message=collected.append,
+            client=client,
+            context_manager=ctx,
+            on_message=collected.append,
         )
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -1428,13 +1566,17 @@ class TestOnMessageCallback:
     async def test_on_message_captures_rescued_tool_call(self):
         """Rescued tool call emits TOOL_CALL + TOOL_RESULT, no TEXT_RESPONSE or RETRY_NUDGE."""
         collected: list[Message] = []
-        client = MockClient([
-            TextResponse(content='{"tool": "fetch", "args": {"key": "val"}}'),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content='{"tool": "fetch", "args": {"key": "val"}}'),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx, on_message=collected.append,
+            client=client,
+            context_manager=ctx,
+            on_message=collected.append,
         )
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -1448,14 +1590,18 @@ class TestOnMessageCallback:
     async def test_on_message_with_streaming(self):
         """on_message works correctly when stream=True."""
         collected: list[Message] = []
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx,
-            stream=True, on_message=collected.append,
+            client=client,
+            context_manager=ctx,
+            stream=True,
+            on_message=collected.append,
         )
         await runner.run(_make_workflow(), "go", prompt_vars={"role": "agent"})
 
@@ -1480,12 +1626,15 @@ class TestInitialMessages:
     async def test_initial_messages_skips_system_and_user_init(self):
         """When initial_messages is provided, no system/user messages are emitted."""
         collected: list[Message] = []
-        client = MockClient([
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx,
+            client=client,
+            context_manager=ctx,
             on_message=collected.append,
         )
 
@@ -1510,19 +1659,30 @@ class TestInitialMessages:
     @pytest.mark.asyncio
     async def test_initial_messages_included_in_api_call(self):
         """Seed messages are sent to the LLM (visible in the API messages)."""
-        client = MockClient([
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(client=client, context_manager=ctx)
 
         seed = [
             Message(MessageRole.SYSTEM, "You are a tester.", MessageMeta(MessageType.SYSTEM_PROMPT)),
             Message(MessageRole.USER, "first question", MessageMeta(MessageType.USER_INPUT)),
-            Message(MessageRole.ASSISTANT, "", MessageMeta(MessageType.TOOL_CALL),
-                    tool_calls=[ToolCallInfo(name="fetch", args={}, call_id="c0")]),
-            Message(MessageRole.TOOL, "fetch_result", MessageMeta(MessageType.TOOL_RESULT),
-                    tool_name="fetch", tool_call_id="c0"),
+            Message(
+                MessageRole.ASSISTANT,
+                "",
+                MessageMeta(MessageType.TOOL_CALL),
+                tool_calls=[ToolCallInfo(name="fetch", args={}, call_id="c0")],
+            ),
+            Message(
+                MessageRole.TOOL,
+                "fetch_result",
+                MessageMeta(MessageType.TOOL_RESULT),
+                tool_name="fetch",
+                tool_call_id="c0",
+            ),
             Message(MessageRole.USER, "follow-up", MessageMeta(MessageType.USER_INPUT)),
         ]
 
@@ -1540,13 +1700,16 @@ class TestInitialMessages:
     async def test_none_initial_messages_is_default(self):
         """Passing initial_messages=None behaves identically to not passing it."""
         collected: list[Message] = []
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx,
+            client=client,
+            context_manager=ctx,
             on_message=collected.append,
         )
 
@@ -1580,11 +1743,13 @@ class TestToolResolutionError:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={"query": "capital of France"}),
-            ToolCall(tool="fetch", args={"query": "france"}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={"query": "capital of France"}),
+                ToolCall(tool="fetch", args={"query": "france"}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -1602,11 +1767,13 @@ class TestToolResolutionError:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="fetch", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="fetch", args={}),
+            ]
+        )
         runner = _make_runner(client, max_iterations=3)
         with pytest.raises(MaxIterationsError):
             await runner.run(wf, "go", prompt_vars={"role": "agent"})
@@ -1629,9 +1796,7 @@ class TestToolResolutionError:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}) for _ in range(5)
-        ])
+        client = MockClient([ToolCall(tool="fetch", args={}) for _ in range(5)])
         # max_tool_errors=1 — a single hard error would raise ToolExecutionError.
         # But 5 consecutive ToolResolutionErrors should NOT trigger it.
         runner = _make_runner(client, max_iterations=5, max_tool_errors=1)
@@ -1657,12 +1822,14 @@ class TestToolResolutionError:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),    # ToolResolutionError — step NOT recorded
-            ToolCall(tool="submit", args={}),   # premature — fetch not satisfied
-            ToolCall(tool="fetch", args={}),    # succeeds — step recorded
-            ToolCall(tool="submit", args={}),   # now OK
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),  # ToolResolutionError — step NOT recorded
+                ToolCall(tool="submit", args={}),  # premature — fetch not satisfied
+                ToolCall(tool="fetch", args={}),  # succeeds — step recorded
+                ToolCall(tool="submit", args={}),  # now OK
+            ]
+        )
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
         assert result == "submit_result"
@@ -1680,9 +1847,7 @@ class TestToolResolutionError:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}) for _ in range(4)
-        ])
+        client = MockClient([ToolCall(tool="fetch", args={}) for _ in range(4)])
         runner = _make_runner(client, max_iterations=3)
         with pytest.raises(MaxIterationsError) as exc_info:
             await runner.run(wf, "go", prompt_vars={"role": "agent"})
@@ -1707,12 +1872,14 @@ class TestToolResolutionError:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),   # ToolResolutionError (no increment)
-            ToolCall(tool="fetch", args={}),   # ValueError (increment to 1)
-            ToolCall(tool="fetch", args={}),   # succeeds
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),  # ToolResolutionError (no increment)
+                ToolCall(tool="fetch", args={}),  # ValueError (increment to 1)
+                ToolCall(tool="fetch", args={}),  # succeeds
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         # max_tool_errors=1 — the one hard error hits 1, which is <=, not >
         runner = _make_runner(client, max_tool_errors=1)
         result = await runner.run(wf, "go", prompt_vars={"role": "agent"})
@@ -1731,14 +1898,18 @@ class TestToolResolutionError:
             "submit": _make_tool("submit"),
         }
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="fetch", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="fetch", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx,
-            max_iterations=2, on_message=collected.append,
+            client=client,
+            context_manager=ctx,
+            max_iterations=2,
+            on_message=collected.append,
         )
         with pytest.raises(MaxIterationsError):
             await runner.run(wf, "go", prompt_vars={"role": "agent"})
@@ -1751,6 +1922,7 @@ class TestToolResolutionError:
     async def test_resolution_error_is_not_forge_error(self):
         """ToolResolutionError is a plain Exception, not a ForgeError."""
         from forge.errors import ForgeError
+
         err = ToolResolutionError("test")
         assert isinstance(err, Exception)
         assert not isinstance(err, ForgeError)
@@ -1774,16 +1946,18 @@ class TestPrerequisiteEnforcement:
             ),
             "submit": _make_tool("submit"),
         }
-        client = MockClient([
-            # 1: model tries edit_file first → blocked
-            ToolCall(tool="edit_file", args={"path": "foo.py"}),
-            # 2: model corrects, calls read_file
-            ToolCall(tool="read_file", args={"path": "foo.py"}),
-            # 3: model calls edit_file again → now allowed
-            ToolCall(tool="edit_file", args={"path": "foo.py"}),
-            # 4: terminal
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                # 1: model tries edit_file first → blocked
+                ToolCall(tool="edit_file", args={"path": "foo.py"}),
+                # 2: model corrects, calls read_file
+                ToolCall(tool="read_file", args={"path": "foo.py"}),
+                # 3: model calls edit_file again → now allowed
+                ToolCall(tool="edit_file", args={"path": "foo.py"}),
+                # 4: terminal
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow(tools=tools, required_steps=[], terminal_tool="submit")
         runner = _make_runner(client)
         result = await runner.run(wf, "fix foo.py", prompt_vars={"role": "dev"})
@@ -1802,12 +1976,14 @@ class TestPrerequisiteEnforcement:
             ),
             "submit": _make_tool("submit"),
         }
-        client = MockClient([
-            ToolCall(tool="edit_file", args={}),
-            ToolCall(tool="read_file", args={}),
-            ToolCall(tool="edit_file", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="edit_file", args={}),
+                ToolCall(tool="read_file", args={}),
+                ToolCall(tool="edit_file", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow(tools=tools, required_steps=[], terminal_tool="submit")
         runner = _make_runner(client)
         runner.on_message = collected.append
@@ -1829,12 +2005,14 @@ class TestPrerequisiteEnforcement:
             ),
             "submit": _make_tool("submit"),
         }
-        client = MockClient([
-            ToolCall(tool="edit_file", args={}),
-            ToolCall(tool="edit_file", args={}),
-            ToolCall(tool="edit_file", args={}),
-            ToolCall(tool="edit_file", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="edit_file", args={}),
+                ToolCall(tool="edit_file", args={}),
+                ToolCall(tool="edit_file", args={}),
+                ToolCall(tool="edit_file", args={}),
+            ]
+        )
         wf = _make_workflow(tools=tools, required_steps=[], terminal_tool="submit")
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(client=client, context_manager=ctx, max_iterations=10)
@@ -1844,10 +2022,12 @@ class TestPrerequisiteEnforcement:
     @pytest.mark.asyncio
     async def test_no_prereqs_no_interference(self):
         """Workflows without prerequisites behave identically to before."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow()
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "dev"})
@@ -1866,15 +2046,17 @@ class TestPrerequisiteEnforcement:
             ),
             "submit": _make_tool("submit"),
         }
-        client = MockClient([
-            # Read a.py, then try to edit b.py → blocked (arg mismatch)
-            ToolCall(tool="read_file", args={"path": "a.py"}),
-            ToolCall(tool="edit_file", args={"path": "b.py"}),
-            # Read b.py, then edit b.py → allowed
-            ToolCall(tool="read_file", args={"path": "b.py"}),
-            ToolCall(tool="edit_file", args={"path": "b.py"}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                # Read a.py, then try to edit b.py → blocked (arg mismatch)
+                ToolCall(tool="read_file", args={"path": "a.py"}),
+                ToolCall(tool="edit_file", args={"path": "b.py"}),
+                # Read b.py, then edit b.py → allowed
+                ToolCall(tool="read_file", args={"path": "b.py"}),
+                ToolCall(tool="edit_file", args={"path": "b.py"}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow(tools=tools, required_steps=[], terminal_tool="submit")
         runner = _make_runner(client)
         runner.on_message = collected.append
@@ -1899,12 +2081,15 @@ class TestMultipleTerminalTools:
             "set_ac": _make_tool("set_ac", fn=lambda **kw: "ac_on"),
             "no_action": _make_tool("no_action", fn=lambda **kw: "skipped"),
         }
-        client = MockClient([
-            ToolCall(tool="gather", args={}),
-            ToolCall(tool="set_ac", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="gather", args={}),
+                ToolCall(tool="set_ac", args={}),
+            ]
+        )
         wf = _make_workflow(
-            tools=tools, required_steps=["gather"],
+            tools=tools,
+            required_steps=["gather"],
             terminal_tool=["set_ac", "no_action"],
         )
         runner = _make_runner(client)
@@ -1919,12 +2104,15 @@ class TestMultipleTerminalTools:
             "set_ac": _make_tool("set_ac", fn=lambda **kw: "ac_on"),
             "no_action": _make_tool("no_action", fn=lambda **kw: "skipped"),
         }
-        client = MockClient([
-            ToolCall(tool="gather", args={}),
-            ToolCall(tool="no_action", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="gather", args={}),
+                ToolCall(tool="no_action", args={}),
+            ]
+        )
         wf = _make_workflow(
-            tools=tools, required_steps=["gather"],
+            tools=tools,
+            required_steps=["gather"],
             terminal_tool=["set_ac", "no_action"],
         )
         runner = _make_runner(client)
@@ -1940,14 +2128,17 @@ class TestMultipleTerminalTools:
             "set_ac": _make_tool("set_ac"),
             "no_action": _make_tool("no_action"),
         }
-        client = MockClient([
-            ToolCall(tool="set_ac", args={}),       # premature
-            ToolCall(tool="no_action", args={}),     # also premature
-            ToolCall(tool="gather", args={}),         # required step
-            ToolCall(tool="set_ac", args={}),         # now allowed
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="set_ac", args={}),  # premature
+                ToolCall(tool="no_action", args={}),  # also premature
+                ToolCall(tool="gather", args={}),  # required step
+                ToolCall(tool="set_ac", args={}),  # now allowed
+            ]
+        )
         wf = _make_workflow(
-            tools=tools, required_steps=["gather"],
+            tools=tools,
+            required_steps=["gather"],
             terminal_tool=["set_ac", "no_action"],
         )
         runner = _make_runner(client)
@@ -1967,10 +2158,12 @@ class TestCancellation:
     @pytest.mark.asyncio
     async def test_cancel_before_start(self):
         """Cancel event set before run() starts raises immediately."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow()
         runner = _make_runner(client)
         cancel = asyncio.Event()
@@ -1995,10 +2188,12 @@ class TestCancellation:
             "fetch": _make_tool("fetch", fn=cancel_after_fetch),
             "submit": _make_tool("submit"),
         }
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
         runner = _make_runner(client)
 
@@ -2021,10 +2216,12 @@ class TestCancellation:
             "fetch": _make_tool("fetch", fn=cancel_after_fetch),
             "submit": _make_tool("submit"),
         }
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow(tools=tools, required_steps=["fetch"])
         runner = _make_runner(client)
 
@@ -2042,10 +2239,12 @@ class TestCancellation:
     @pytest.mark.asyncio
     async def test_no_cancel_event_runs_normally(self):
         """None cancel_event has no effect."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow()
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "dev"}, cancel_event=None)
@@ -2055,10 +2254,12 @@ class TestCancellation:
     async def test_unset_cancel_event_runs_normally(self):
         """Cancel event that is never set doesn't interfere."""
         cancel = asyncio.Event()  # never set
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow()
         runner = _make_runner(client)
         result = await runner.run(wf, "go", prompt_vars={"role": "dev"}, cancel_event=cancel)
@@ -2075,11 +2276,13 @@ class TestCustomRetryNudge:
     async def test_custom_nudge_string(self):
         """String retry_nudge is used as static message."""
         collected = []
-        client = MockClient([
-            TextResponse(content="bare text"),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="bare text"),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow()
         runner = _make_runner(client)
         runner.on_message = collected.append
@@ -2094,15 +2297,18 @@ class TestCustomRetryNudge:
     async def test_custom_nudge_callable(self):
         """Callable retry_nudge receives raw response."""
         collected = []
-        client = MockClient([
-            TextResponse(content="my response"),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="my response"),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow()
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx,
+            client=client,
+            context_manager=ctx,
             retry_nudge=lambda raw: f"Please use a tool. You said: {raw[:10]}",
         )
         runner.on_message = collected.append
@@ -2128,11 +2334,13 @@ class TestCustomRetryNudge:
     async def test_none_retry_nudge_uses_default(self):
         """None retry_nudge falls back to default."""
         collected = []
-        client = MockClient([
-            TextResponse(content="bare text"),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="bare text"),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf = _make_workflow()
         runner = _make_runner(client)
         runner.on_message = collected.append

--- a/tests/unit/test_slot_worker.py
+++ b/tests/unit/test_slot_worker.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
-from unittest.mock import AsyncMock
 
 import pytest
+from pydantic import BaseModel
 
 from forge.context.manager import ContextManager
 from forge.context.strategies import NoCompact
-from forge.core.messages import MessageType
 from forge.core.runner import WorkflowRunner
 from forge.core.slot_worker import SlotWorker
 from forge.core.workflow import (
@@ -21,7 +19,6 @@ from forge.core.workflow import (
     Workflow,
 )
 from forge.errors import WorkflowCancelledError
-from pydantic import BaseModel
 
 
 class EmptyParams(BaseModel):
@@ -61,14 +58,14 @@ class MockClient:
         self.responses = list(responses)
         self._call_index = 0
 
-    async def send(self, messages, tools=None, sampling=None):
+    async def send(self, messages, tools=None, sampling=None, **kwargs):
         resp = self.responses[self._call_index]
         self._call_index += 1
         if isinstance(resp, ToolCall):
             return [resp]
         return resp
 
-    async def send_stream(self, messages, tools=None, sampling=None):
+    async def send_stream(self, messages, tools=None, sampling=None, **kwargs):
         raise NotImplementedError
 
     async def get_context_length(self):
@@ -85,18 +82,21 @@ def _make_worker(client: MockClient) -> SlotWorker:
 
 
 class TestBasicOperation:
-
     @pytest.mark.asyncio
     async def test_submit_returns_result(self):
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         worker = _make_worker(client)
         await worker.start()
         try:
             result = await worker.submit(
-                _make_workflow(), "go", prompt_vars={"role": "dev"},
+                _make_workflow(),
+                "go",
+                prompt_vars={"role": "dev"},
             )
             assert result == "submit_result"
         finally:
@@ -111,20 +111,25 @@ class TestBasicOperation:
             def fn(**kw):
                 order.append(tag)
                 return f"{tag}_done"
-            client = MockClient([
-                ToolCall(tool="fetch", args={}),
-                ToolCall(tool="submit", args={}),
-            ])
+
+            client = MockClient(
+                [
+                    ToolCall(tool="fetch", args={}),
+                    ToolCall(tool="submit", args={}),
+                ]
+            )
             return client, fn
 
         # We need a single client that can handle multiple sequential workflows.
         # Use a client with enough responses for 2 sequential workflows.
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
 
         def track_first(**kw):
             order.append("first")
@@ -135,15 +140,19 @@ class TestBasicOperation:
             return "second_result"
 
         wf1 = Workflow(
-            name="wf1", description="first",
+            name="wf1",
+            description="first",
             tools={"fetch": _make_tool("fetch"), "submit": _make_tool("submit", fn=track_first)},
-            required_steps=["fetch"], terminal_tool="submit",
+            required_steps=["fetch"],
+            terminal_tool="submit",
             system_prompt_template="You are a {role}.",
         )
         wf2 = Workflow(
-            name="wf2", description="second",
+            name="wf2",
+            description="second",
             tools={"fetch": _make_tool("fetch"), "submit": _make_tool("submit", fn=track_second)},
-            required_steps=["fetch"], terminal_tool="submit",
+            required_steps=["fetch"],
+            terminal_tool="submit",
             system_prompt_template="You are a {role}.",
         )
 
@@ -180,7 +189,6 @@ class TestBasicOperation:
 
 
 class TestPriority:
-
     @pytest.mark.asyncio
     async def test_higher_priority_runs_first_when_queued(self):
         """When multiple tasks are queued, lower int runs first."""
@@ -203,29 +211,35 @@ class TestPriority:
             return "low_result"
 
         # First workflow blocks, then two more queue up
-        client = MockClient([
-            # First workflow (blocker)
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-            # High priority (should run second)
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-            # Low priority (should run third)
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                # First workflow (blocker)
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+                # High priority (should run second)
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+                # Low priority (should run third)
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
 
         wf_blocker = _make_workflow()
         wf_high = Workflow(
-            name="high", description="high",
+            name="high",
+            description="high",
             tools={"fetch": _make_tool("fetch"), "submit": _make_tool("submit", fn=track_high)},
-            required_steps=["fetch"], terminal_tool="submit",
+            required_steps=["fetch"],
+            terminal_tool="submit",
             system_prompt_template="You are a {role}.",
         )
         wf_low = Workflow(
-            name="low", description="low",
+            name="low",
+            description="low",
             tools={"fetch": _make_tool("fetch"), "submit": _make_tool("submit", fn=track_low)},
-            required_steps=["fetch"], terminal_tool="submit",
+            required_steps=["fetch"],
+            terminal_tool="submit",
             system_prompt_template="You are a {role}.",
         )
 
@@ -237,12 +251,8 @@ class TestPriority:
 
             # Now queue low (priority=10) then high (priority=1)
             # High should run before low despite being submitted second
-            task_low = asyncio.create_task(
-                worker.submit(wf_low, "low", priority=10, prompt_vars={"role": "dev"})
-            )
-            task_high = asyncio.create_task(
-                worker.submit(wf_high, "high", priority=1, prompt_vars={"role": "dev"})
-            )
+            task_low = asyncio.create_task(worker.submit(wf_low, "low", priority=10, prompt_vars={"role": "dev"}))
+            task_high = asyncio.create_task(worker.submit(wf_high, "high", priority=1, prompt_vars={"role": "dev"}))
 
             r_high = await task_high
             r_low = await task_low
@@ -256,16 +266,20 @@ class TestPriority:
     @pytest.mark.asyncio
     async def test_default_priority_is_zero(self):
         """Default priority is 0 (equal for all tasks)."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         worker = _make_worker(client)
         await worker.start()
         try:
             # Submit without explicit priority
             result = await worker.submit(
-                _make_workflow(), "go", prompt_vars={"role": "dev"},
+                _make_workflow(),
+                "go",
+                prompt_vars={"role": "dev"},
             )
             assert result == "submit_result"
         finally:
@@ -276,7 +290,6 @@ class TestPriority:
 
 
 class TestPreemption:
-
     @pytest.mark.asyncio
     async def test_cancel_current(self):
         """cancel_current() cancels the running workflow."""
@@ -286,11 +299,14 @@ class TestPreemption:
             await gate.wait()
             return "fetch_result"
 
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+            ]
+        )
         wf = Workflow(
-            name="slow", description="slow",
+            name="slow",
+            description="slow",
             tools={
                 "fetch": ToolDef(
                     spec=ToolSpec(name="fetch", description="fetch", parameters=EmptyParams),
@@ -298,16 +314,15 @@ class TestPreemption:
                 ),
                 "submit": _make_tool("submit"),
             },
-            required_steps=["fetch"], terminal_tool="submit",
+            required_steps=["fetch"],
+            terminal_tool="submit",
             system_prompt_template="You are a {role}.",
         )
 
         worker = _make_worker(client)
         await worker.start()
         try:
-            task = asyncio.create_task(
-                worker.submit(wf, "go", prompt_vars={"role": "dev"})
-            )
+            task = asyncio.create_task(worker.submit(wf, "go", prompt_vars={"role": "dev"}))
             await asyncio.sleep(0.05)  # let the worker start
             worker.cancel_current()
             gate.set()  # unblock the tool so the runner can check cancel
@@ -327,13 +342,16 @@ class TestPreemption:
             return "fetch_result"
 
         # Slow workflow on slot (priority 10)
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),  # slow task
-            ToolCall(tool="fetch", args={}),  # high-priority task
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),  # slow task
+                ToolCall(tool="fetch", args={}),  # high-priority task
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         wf_slow = Workflow(
-            name="slow", description="slow",
+            name="slow",
+            description="slow",
             tools={
                 "fetch": ToolDef(
                     spec=ToolSpec(name="fetch", description="fetch", parameters=EmptyParams),
@@ -341,7 +359,8 @@ class TestPreemption:
                 ),
                 "submit": _make_tool("submit"),
             },
-            required_steps=["fetch"], terminal_tool="submit",
+            required_steps=["fetch"],
+            terminal_tool="submit",
             system_prompt_template="You are a {role}.",
         )
         wf_fast = _make_workflow()
@@ -349,15 +368,11 @@ class TestPreemption:
         worker = _make_worker(client)
         await worker.start()
         try:
-            slow_task = asyncio.create_task(
-                worker.submit(wf_slow, "slow", priority=10, prompt_vars={"role": "dev"})
-            )
+            slow_task = asyncio.create_task(worker.submit(wf_slow, "slow", priority=10, prompt_vars={"role": "dev"}))
             await asyncio.sleep(0.05)  # let slow task start running
 
             # Submit higher priority — should auto-cancel the slow task
-            fast_task = asyncio.create_task(
-                worker.submit(wf_fast, "fast", priority=1, prompt_vars={"role": "dev"})
-            )
+            fast_task = asyncio.create_task(worker.submit(wf_fast, "fast", priority=1, prompt_vars={"role": "dev"}))
             gate.set()  # unblock so cancel can propagate
 
             result = await fast_task
@@ -371,20 +386,28 @@ class TestPreemption:
     @pytest.mark.asyncio
     async def test_no_preempt_equal_priority(self):
         """Equal priority does not trigger preemption."""
-        client = MockClient([
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         worker = _make_worker(client)
         await worker.start()
         try:
             r1 = await worker.submit(
-                _make_workflow(), "first", priority=5, prompt_vars={"role": "dev"},
+                _make_workflow(),
+                "first",
+                priority=5,
+                prompt_vars={"role": "dev"},
             )
             r2 = await worker.submit(
-                _make_workflow(), "second", priority=5, prompt_vars={"role": "dev"},
+                _make_workflow(),
+                "second",
+                priority=5,
+                prompt_vars={"role": "dev"},
             )
             assert r1 == "submit_result"
             assert r2 == "submit_result"
@@ -396,29 +419,33 @@ class TestPreemption:
 
 
 class TestErrorHandling:
-
     @pytest.mark.asyncio
     async def test_exception_propagates_to_caller(self):
         """Exceptions from the runner propagate to the submit() caller."""
-        from forge.errors import MaxIterationsError
 
-        client = MockClient([
-            TextResponse(content="bare text"),
-            TextResponse(content="bare text again"),
-            TextResponse(content="bare text third"),
-            TextResponse(content="bare text fourth"),
-        ])
+        client = MockClient(
+            [
+                TextResponse(content="bare text"),
+                TextResponse(content="bare text again"),
+                TextResponse(content="bare text third"),
+                TextResponse(content="bare text fourth"),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx,
-            max_iterations=3, rescue_enabled=False,
+            client=client,
+            context_manager=ctx,
+            max_iterations=3,
+            rescue_enabled=False,
         )
         worker = SlotWorker(runner)
         await worker.start()
         try:
             with pytest.raises(Exception):
                 await worker.submit(
-                    _make_workflow(), "go", prompt_vars={"role": "dev"},
+                    _make_workflow(),
+                    "go",
+                    prompt_vars={"role": "dev"},
                 )
         finally:
             await worker.stop()
@@ -426,20 +453,24 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_worker_continues_after_error(self):
         """Worker processes next task after a failed one."""
-        client = MockClient([
-            # First workflow: will fail (not enough responses to complete)
-            TextResponse(content="fail"),
-            TextResponse(content="fail"),
-            TextResponse(content="fail"),
-            TextResponse(content="fail"),
-            # Second workflow: succeeds
-            ToolCall(tool="fetch", args={}),
-            ToolCall(tool="submit", args={}),
-        ])
+        client = MockClient(
+            [
+                # First workflow: will fail (not enough responses to complete)
+                TextResponse(content="fail"),
+                TextResponse(content="fail"),
+                TextResponse(content="fail"),
+                TextResponse(content="fail"),
+                # Second workflow: succeeds
+                ToolCall(tool="fetch", args={}),
+                ToolCall(tool="submit", args={}),
+            ]
+        )
         ctx = ContextManager(strategy=NoCompact(), budget_tokens=100_000)
         runner = WorkflowRunner(
-            client=client, context_manager=ctx,
-            max_iterations=3, rescue_enabled=False,
+            client=client,
+            context_manager=ctx,
+            max_iterations=3,
+            rescue_enabled=False,
         )
         worker = SlotWorker(runner)
         await worker.start()
@@ -447,11 +478,15 @@ class TestErrorHandling:
             # First task fails
             with pytest.raises(Exception):
                 await worker.submit(
-                    _make_workflow(), "fail", prompt_vars={"role": "dev"},
+                    _make_workflow(),
+                    "fail",
+                    prompt_vars={"role": "dev"},
                 )
             # Second task succeeds
             result = await worker.submit(
-                _make_workflow(), "succeed", prompt_vars={"role": "dev"},
+                _make_workflow(),
+                "succeed",
+                prompt_vars={"role": "dev"},
             )
             assert result == "submit_result"
         finally:


### PR DESCRIPTION
  Summary

  Adds Anthropic as a first-class backend alongside Ollama and Llamafile. The proxy now supports both OpenAI-compatible (/v1/chat/completions) and Anthropic-native (/v1/messages) endpoints, with full format
  conversion, streaming, and guardrails.

  What changed

  - New AnthropicClient (src/forge/clients/anthropic.py) — full adapter using the official anthropic SDK with message format conversion, streaming, and base_url support
  - Anthropic proxy endpoint (POST /v1/messages) — accepts Anthropic-format requests, converts to forge's internal pipeline, and returns Anthropic-format responses
  - Message format converters (src/forge/proxy/convert.py) — bidirectional encoder/decoder functions for OpenAI ↔ Anthropic format (messages, tool calls, SSE events)
  - Handler support (src/forge/proxy/handler.py) — handle_messages() delegates to handle_chat_completions() with format conversion; max_tokens passthrough to inference pipeline
  - Test coverage — 7 new test suites (encoders, decoders, guardrails backends, handler combos, Anthropic client, Anthropic convert, Anthropic handler, Anthropic proxy integration)
  - PII pre-commit hook (scripts/check_pii.py) — scans staged changes for personal paths, SSH keys, AWS credentials, and other sensitive patterns
  - Test resilience — mock clients now accept **kwargs so they're future-proof against inference pipeline signature changes

  How to use

  # Start proxy with Anthropic backend
  ANTHROPIC_API_KEY="sk-..." python -m forge.proxy \
    --backend anthropic \
    --model claude-sonnet-4-6 \
    --port 8081

  # Point your client at the proxy
  curl http://localhost:8081/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"Hello"}]}'

  # Or use the Anthropic-native endpoint
  curl http://localhost:8081/v1/messages \
    -H "Content-Type: application/json" \
    -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"Hello"}]}'

  Test plan

  - All 1075 unit tests pass
  - Start proxy with --backend anthropic and send a chat completion request
  - Start proxy with --backend anthropic and send an Anthropic messages request
  - Start proxy with llama.cpp backend: ANTHROPIC_API_KEY="-" --backend anthropic --backend-url http://localhost:8080 --model qwen3.6-27b
  - Test streaming with both endpoints
  - Test tool calling through the proxy
