### PR TITLE
Proxy hardening (v0.7.1): Anthropic Messages API / Claude Code, --mode, token usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ eval_vram*.jsonl
 ablation_progress.log
 ablation_run.log
 llama.log
+scripts/*.log
 
 # OS
 Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to forge are documented here.
 
+## [0.7.1] — 2026-05-24
+
+Proxy hardening: forge now works with Claude Code. First PyPI release to include the Docker, model-pass-through, and token-usage work that landed on `main` after v0.7.0.
+
+### Added
+- **Anthropic Messages API on the proxy (`POST /v1/messages`).** Point Claude Code — or any Anthropic-protocol client — at a forge-guarded model. Two downstream shapes: **Path 2** (default, `--backend-protocol openai`) translates Anthropic ↔ OpenAI for local llama.cpp / Ollama and emits Anthropic SSE back; **Path 1** (`--backend-protocol anthropic`, external mode) forwards to an Anthropic-shape downstream (LiteLLM, the Anthropic API, a self-hosted proxy), passing unknown fields through verbatim. Adds a `base_url` kwarg on `AnthropicClient`. See the new "Using forge with Claude Code" section in the User Guide.
+- **`--mode {native,prompt}` proxy flag** — run prompt-injected function-calling through the proxy for OpenAI-compatible backends that lack a native tool-calling template, not just native FC. Closes #53.
+- **Real token-usage reporting through the proxy** — responses carry actual prompt/completion counts (previously hardcoded zeros), in both OpenAI (`usage.prompt_tokens/...`) and Anthropic (`usage.input_tokens/output_tokens`) shapes, streaming and non-streaming. #81 (thanks @mhajder).
+- **Per-request model-name pass-through for external backends** — the proxy honors the inbound `model` against external OpenAI-compatible backends. #80 (thanks @mhajder).
+- **Dockerfile** for running the proxy as a container. #79 (thanks @mhajder).
+
+### Changed
+- **`last_usage` unified on slot-keyed `{slot_id: TokenUsage}` across all clients.** `AnthropicClient` previously stored a flat `{input_tokens, output_tokens}` dict; it now uses the slot-0 convention `LlamafileClient` / `OllamaClient` already follow, so usage extraction has one contract.
+- **Inbound `model` rides the proxy's passthrough/extras channel** rather than the sampling map — a cleaner replacement for the #80 mechanism that keeps `model` out of `sampling`.
+
+### Fixed
+- **Proxy no longer hard-imports the optional `anthropic` SDK at load.** A plain `forge-guardrails` install (without the `[anthropic]` extra) can now start the proxy for local / OpenAI-shape backends; the SDK is imported lazily and only required for `--backend-protocol anthropic`.
+- **Proxy router tolerates query strings.** Requests like Claude Code's `POST /v1/messages?beta=true` route correctly instead of returning 404.
+- **`eval_runner` token accounting for local backends** — was silently counting zero tokens because it read the flat `last_usage` keys; now reads the slot-keyed `TokenUsage` (fixed by the unification above).
+
+### Known limitations
+- **`cache_control` is not preserved on Path 2.** OpenAI Chat Completions has no analog, so prompt-cache hints are dropped when the downstream is a local OpenAI-shape backend. Path 1 (Anthropic-shape downstream) preserves `cache_control` on clean turns. See ADR-015.
+- **Prompt-mode multi-turn tool convergence is model-dependent.** Some models reliably consume prompt-injected tool results across turns; others re-call the same tool. Native FC is the more robust default for heavy multi-turn tool use (e.g. Claude Code).
+
 ## [0.7.0] — 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Forge takes an 8B local model from single digits to 84% across forge's 26-scenar
 
 **Three ways to use it:**
 
-- **Proxy server** — Drop-in OpenAI-compatible proxy (`python -m forge.proxy`) that sits between any client (opencode, Continue, aider, etc.) and a local model server. Applies guardrails transparently — the client thinks it's talking to a smarter model. Most popular entry point.
+- **Proxy server** — Drop-in proxy (`python -m forge.proxy`) speaking both the OpenAI chat-completions and Anthropic Messages (`/v1/messages`) APIs, sitting between any client and a local model server. Point OpenAI-compatible tools (opencode, Continue, aider) **or Claude Code** at it and forge applies guardrails transparently — the client thinks it's talking to a smarter model. Most popular entry point.
 
 - **WorkflowRunner** — Define tools, pick a backend, run structured agent loops. Forge manages the full lifecycle: system prompts, tool execution, context compaction, and guardrails. **SlotWorker** adds priority-queued access to a shared inference slot with auto-preemption — for multi-agent architectures where specialist workflows share a GPU slot. Best when you're building on forge directly.
 
@@ -126,9 +126,9 @@ For multi-step workflows, multi-turn conversations, and backend auto-management,
 
 ## Proxy Server
 
-Drop-in OpenAI-compatible proxy that sits between any client and a local model server. Point your client at the proxy (e.g. `http://localhost:8081/v1`) and forge applies its guardrails transparently — the client thinks it's talking to a smarter model.
+Drop-in proxy that sits between any client and a local model server, speaking both the OpenAI chat-completions API and the Anthropic Messages API (`/v1/messages`). Point your client at the proxy (e.g. `http://localhost:8081/v1`) and forge applies its guardrails transparently — the client thinks it's talking to a smarter model.
 
-This is the path for **using forge with an existing harness** (opencode, Continue, aider, Cline, anything that speaks the OpenAI chat-completions schema). No Python rewrite.
+This is the path for **using forge with an existing harness** (opencode, Continue, aider, Cline, anything that speaks the OpenAI chat-completions schema — or Claude Code, which speaks the Anthropic Messages API). No Python rewrite.
 
 ```bash
 # External mode — you manage the backend, forge proxies it
@@ -139,6 +139,8 @@ python -m forge.proxy --backend llamaserver --gguf path/to/model.gguf --port 808
 ```
 
 Then configure your client to use `http://localhost:8081/v1` as the API base URL.
+
+**Claude Code:** the proxy also serves the Anthropic Messages API on `POST /v1/messages`, so you can point Claude Code at a forge-guarded local model — set `ANTHROPIC_BASE_URL=http://localhost:8081` and `ANTHROPIC_AUTH_TOKEN=anything` for the `claude` process. See [Using forge with Claude Code](docs/USER_GUIDE.md#using-forge-with-claude-code) for the full setup (native-vs-prompt FC, Anthropic-shape downstreams, `cache_control`).
 
 **Backend compatibility:**
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -46,7 +46,7 @@ result = await runner.run(workflow, "What's the weather in Paris?")
 
 ### Mode 2: Proxy Server (drop-in, zero code changes)
 
-Forge sits between any OpenAI-compatible client and your model server, intercepting requests and applying guardrails transparently. The client doesn't know forge is there.
+Forge sits between any client and your model server, intercepting requests and applying guardrails transparently. It speaks both the OpenAI chat-completions API and the Anthropic Messages API (`/v1/messages`), so OpenAI-compatible tools and Claude Code both work. The client doesn't know forge is there.
 
 ```bash
 # External mode — you manage the backend
@@ -63,9 +63,32 @@ from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8081/v1")
 ```
 
-**Best for:** Adding guardrails to existing tools without modifying them. Works with any tool that speaks the OpenAI-compatible API — no per-client wrappers needed.
+**Best for:** Adding guardrails to existing tools without modifying them. Works with any tool that speaks the OpenAI-compatible API, plus Claude Code via the Anthropic Messages API — no per-client wrappers needed.
 
 **Reliability note:** The proxy automatically injects a synthetic `respond` tool when tools are present in the request. The model calls `respond(message="...")` instead of producing bare text, keeping it in tool-calling mode where forge's full guardrail stack applies. The `respond` call is stripped from the outbound response — the client sees a normal text response and never knows the tool exists. This is essential for small local models (~8B), which cannot be trusted to choose correctly between text and tool calls — eval testing showed that trusting the model's text intent dropped workflow completion from 100% to as low as 4%. Guiding the model to a tool is a must. See [ADR-013](decisions/013-text-response-intent.md) for the full analysis.
+
+#### Using forge with Claude Code
+
+Claude Code speaks the Anthropic Messages API, which the proxy serves on `POST /v1/messages` — so you can point Claude Code at a forge-guarded local model. Start the proxy against any backend, then set two environment variables for the Claude Code process:
+
+```bash
+# Start the proxy (managed mode against a local GGUF; native FC by default)
+python -m forge.proxy --backend llamaserver --gguf path/to/model.gguf --port 8081
+
+# Point Claude Code at it — scope these to the claude process only
+ANTHROPIC_BASE_URL=http://localhost:8081 \
+ANTHROPIC_AUTH_TOKEN=forge \
+claude
+```
+
+`ANTHROPIC_AUTH_TOKEN` can be any non-empty string — forge ignores it. The model name Claude Code sends is also ignored; forge serves whatever backend the proxy was started with.
+
+**Function-calling mode.** `--mode native` (default) uses the backend's chat-template tool-calling and is the smoother default for Claude Code's heavy multi-turn tool use. `--mode prompt` injects the tool surface into the prompt for backends without a tool-calling template; whether a model stays coherent across multi-turn tool results in prompt mode varies by model, so prefer native when the backend supports it.
+
+**Downstream protocol.**
+
+- **Local model (default, `--backend-protocol openai`)** — forge translates Claude Code's Anthropic requests to OpenAI for llama.cpp / Ollama and converts the reply back to Anthropic SSE. Anthropic-only fields with no OpenAI analog (`cache_control`, `thinking`, `document` blocks) are dropped at that boundary; see [ADR-015](decisions/015-cache-control-preservation-path1.md).
+- **Anthropic-shape downstream (`--backend-protocol anthropic`, external mode)** — forge forwards to an Anthropic Messages endpoint (e.g. LiteLLM or the Anthropic API), passing unknown fields through verbatim and preserving `cache_control` on clean turns. This path uses the Anthropic SDK: `pip install forge-guardrails[anthropic]`.
 
 #### Proxy design boundaries
 

--- a/docs/decisions/015-cache-control-preservation-path1.md
+++ b/docs/decisions/015-cache-control-preservation-path1.md
@@ -1,0 +1,56 @@
+# ADR-015: `cache_control` preservation in the Anthropic proxy (path 1)
+
+**Status:** accepted (v0.7.1)
+
+## Context
+
+forge's proxy accepts Anthropic Messages API requests on `/v1/messages` and runs forge guardrails over the inference loop. Two paths exist:
+
+- **Path 2** (default): inbound Anthropic → translate to OpenAI shape → run against an OpenAI-compatible backend (llama.cpp, vLLM, Ollama, etc.).
+- **Path 1** (`--backend-protocol anthropic`): inbound Anthropic → run against an Anthropic-shape downstream (LiteLLM `/v1/messages`, the real Anthropic API, a self-hosted Anthropic proxy).
+
+Anthropic's prompt caching is opt-in per content block: callers tag a block (typically the last block of a stable system prompt or tool definition) with `cache_control: {type: "ephemeral"}`. Anthropic hashes the prefix up to that block and reuses the cached prefix at ~10% of base input cost. Claude Code uses this aggressively to keep large stable contexts cheap across turns.
+
+`cache_control` lives **inside content blocks** (e.g. on a `text` block within a `system` field or message). The forge internal type `forge.Message` does not represent per-block metadata. As the inbound request flows through forge:
+
+1. The proxy parses the Anthropic body to `forge.Message` objects (no `cache_control` field exists to populate).
+2. The runner serializes `forge.Message` back to OpenAI dicts internally (`api_format="openai"`) for client consumption.
+3. `AnthropicClient._convert_messages` rebuilds Anthropic-shape blocks from the OpenAI dicts — `cache_control` is gone.
+
+On path 2 this loss is intrinsic: OpenAI Chat Completions has no `cache_control` analog. On path 1 the loss is incidental to forge's deconstruct/rebuild architecture — both ends of the wire speak Anthropic, but forge in the middle doesn't preserve the field.
+
+## Decision
+
+For path 1 only, the proxy passes the **original inbound Anthropic body** through to `AnthropicClient` as a separate kwarg. When forge has not mutated the message list during the inference call, the client bypasses `_convert_messages` and sends the inbound body verbatim — preserving `cache_control` (and every other block-level Anthropic field).
+
+The runner clears the verbatim opt-in on any forge-side mutation:
+
+- `ContextManager.maybe_compact()` modifying the message list
+- A context-threshold warning being injected
+- A retry being triggered (rescue parse, unknown tool, step enforcement, etc.)
+
+On those calls, the client falls back to the existing `_convert_messages` rebuild path. The next clean turn (next CC request) resumes verbatim emit.
+
+## Consequences
+
+| Scenario | Behavior |
+|---|---|
+| Clean turn, no forge mutation | Verbatim emit. `cache_control` preserved. Anthropic cache hit when prefix matches. |
+| Forge retry (append-style mutation) | Rebuild on the retry call. Cache miss on **that call**. Anthropic's stored cache entry persists; next clean turn hits again. |
+| Forge compaction (early-message removal) | Rebuild on calls after compaction. Cache miss on those calls. |
+| Path 2 (OpenAI-shape downstream) | `cache_control` lost at the protocol boundary. Documented loss; no downstream support exists. |
+
+Cost shape: a single CC turn that triggers a forge retry pays full price for that one retry call (no cache lookup), bounded per-call rather than per-session. Anthropic's content-hash cache on the server side is unaffected.
+
+## Why not modify `forge.Message`
+
+The architecturally complete answer is a per-block annotations field on `forge.Message` so block-level metadata round-trips through forge's internal serialization. That would touch a core primitive type for a benefit limited to one client and one path. Deferred until a concrete user case justifies it.
+
+## Out of scope
+
+- **LiteLLM → on-prem-OpenAI-shape models behind LiteLLM.** Those downstreams don't speak Anthropic's prompt-cache protocol regardless of what forge preserves. The path 1 cache-preservation work is moot for them. forge faithfully passes `cache_control` through to LiteLLM, which then strips it when translating to the on-prem model's protocol.
+- **Path 2 `cache_control` preservation via OpenAI prompt-caching analogs** (some vendors have proprietary equivalents). Not currently in scope.
+
+## How to verify
+
+Per-call cache-hit ratio is observable in Anthropic's response `usage` field (`cache_read_input_tokens` vs `input_tokens`). A live integration test pointing CC at a v0.7.1 forge proxy → real Anthropic API would surface the working/non-working split between clean turns and forge-mutation turns.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forge-guardrails"
-version = "0.7.0"
+version = "0.7.1"
 description = "A reliability layer for self-hosted LLM tool-calling. Guardrails, context management, and backend adapters for multi-step agentic workflows."
 requires-python = ">=3.12"
 license = "MIT"

--- a/scripts/integration_test_proxy.py
+++ b/scripts/integration_test_proxy.py
@@ -81,15 +81,23 @@ def _setup_logging() -> None:
 
 # ── Real-backend helpers ──────────────────────────────────────────────
 
-def _spawn_llama_server(gguf: Path, port: int) -> subprocess.Popen:
+def _spawn_llama_server(
+    gguf: Path, port: int, mode: str = "native", extra_flags: list[str] | None = None,
+) -> subprocess.Popen:
     """Launch llama-server with forge's canonical flags (matches ServerManager)."""
     cmd = [
         LLAMA_SERVER_BIN,
         "-m", str(gguf),
         "-ngl", "999",
         "--port", str(port),
-        "--jinja",
     ]
+    # Native FC needs the chat template's tool-calling (--jinja). Prompt mode
+    # injects the tool surface into the prompt and parses text, so it omits
+    # --jinja — matching ServerManager's mode-conditional behavior.
+    if mode == "native":
+        cmd.append("--jinja")
+    if extra_flags:
+        cmd.extend(extra_flags)
     print(f"[external] launching: {' '.join(cmd)}")
     return subprocess.Popen(
         cmd,
@@ -262,11 +270,85 @@ async def _run_test_anthropic_tool_stream(proxy_base: str) -> None:
         print(f"     [WARN] no tool_use content block in stream — model returned text only")
 
 
+async def _run_test_anthropic_tool_multiturn(proxy_base: str) -> None:
+    """Test 5: Anthropic multi-turn — model must consume a tool_result and answer.
+
+    Turn 1: ask, expect a get_weather tool_use.
+    Turn 2: feed the tool_result back, expect a TEXT answer (end_turn) — NOT a
+    re-call of the same tool. A re-call is the "re-read loop" that real Claude
+    Code surfaced: the model ignores the tool_result and calls the tool again.
+    This is the path the single-turn T3/T4 never exercised.
+    """
+    print("  -- T5 Anthropic multi-turn tool_result (Path 2, convergence)")
+    user_msg = {
+        "role": "user",
+        "content": (
+            "What's the weather in Paris? Use the get_weather tool, then "
+            "tell me the result."
+        ),
+    }
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        # Turn 1 — expect a tool call.
+        r1 = await client.post(
+            f"{proxy_base}/v1/messages",
+            json={
+                "model": "test", "max_tokens": 512,
+                "messages": [user_msg],
+                "tools": [GET_WEATHER_TOOL_ANTHROPIC],
+                "stream": False,
+            },
+        )
+        assert r1.status_code == 200, f"T5 turn1 status={r1.status_code} {r1.text[:200]}"
+        d1 = r1.json()
+        tool_uses = [b for b in d1["content"] if b.get("type") == "tool_use"]
+        assert tool_uses, f"T5 turn1 produced no tool_use: {d1['content']}"
+        tu = tool_uses[0]
+        print(f"     turn1 tool_use: {tu['name']} id={tu['id']} input={tu.get('input')}")
+
+        # Turn 2 — echo the assistant turn back verbatim, append a tool_result.
+        assistant_msg = {"role": "assistant", "content": d1["content"]}
+        tool_result_msg = {
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": tu["id"],
+                "content": "Paris: 18°C, sunny, light wind from the west.",
+            }],
+        }
+        r2 = await client.post(
+            f"{proxy_base}/v1/messages",
+            json={
+                "model": "test", "max_tokens": 512,
+                "messages": [user_msg, assistant_msg, tool_result_msg],
+                "tools": [GET_WEATHER_TOOL_ANTHROPIC],
+                "stream": False,
+            },
+        )
+        assert r2.status_code == 200, f"T5 turn2 status={r2.status_code} {r2.text[:200]}"
+        d2 = r2.json()
+        t2_tools = [b for b in d2["content"] if b.get("type") == "tool_use"]
+        t2_text = [b for b in d2["content"] if b.get("type") == "text"]
+        print(f"     turn2 blocks: tool_use={len(t2_tools)} text={len(t2_text)} "
+              f"stop_reason={d2.get('stop_reason')}")
+        if t2_text:
+            print(f"     turn2 text={t2_text[0]['text'][:160]!r}")
+        # Convergence: after the tool_result, the model must answer, not re-call.
+        assert not t2_tools, (
+            f"T5 LOOP REPRODUCED — model re-called {[b['name'] for b in t2_tools]} "
+            f"instead of answering from the tool_result"
+        )
+        assert t2_text and d2.get("stop_reason") == "end_turn", (
+            f"T5 expected a text answer with stop_reason=end_turn, "
+            f"got stop_reason={d2.get('stop_reason')} content={d2['content']}"
+        )
+
+
 TESTS = [
     ("T1 OpenAI text", _run_test_openai_text),
     ("T2 Anthropic text", _run_test_anthropic_text),
     ("T3 Anthropic tool non-stream", _run_test_anthropic_tool_nonstream),
     ("T4 Anthropic tool stream", _run_test_anthropic_tool_stream),
+    ("T5 Anthropic multi-turn tool_result", _run_test_anthropic_tool_multiturn),
 ]
 
 
@@ -289,11 +371,13 @@ async def _run_all_tests(proxy_base: str) -> list[tuple[str, str, str]]:
 
 # ── Phase 1: External mode ───────────────────────────────────────────
 
-async def phase_external(gguf: Path) -> list[tuple[str, str, str]]:
-    print(f"\n===== Phase 1: external mode =====")
+async def phase_external(
+    gguf: Path, mode: str = "native", extra_flags: list[str] | None = None,
+) -> list[tuple[str, str, str]]:
+    print(f"\n===== Phase 1: external mode (fc={mode}) =====")
     print(f"      llama-server on :{EXTERNAL_BACKEND_PORT}, proxy on :{EXTERNAL_PROXY_PORT}")
 
-    llama_proc = _spawn_llama_server(gguf, EXTERNAL_BACKEND_PORT)
+    llama_proc = _spawn_llama_server(gguf, EXTERNAL_BACKEND_PORT, mode, extra_flags)
     try:
         await _wait_llama_ready(EXTERNAL_BACKEND_PORT)
         print(f"[external] llama-server ready")
@@ -302,7 +386,7 @@ async def phase_external(gguf: Path) -> list[tuple[str, str, str]]:
         proxy = ProxyServer(
             backend_url=f"http://127.0.0.1:{EXTERNAL_BACKEND_PORT}",
             port=EXTERNAL_PROXY_PORT,
-            mode="native",
+            mode=mode,
             backend_protocol="openai",
         )
         proxy.start()
@@ -322,8 +406,10 @@ async def phase_external(gguf: Path) -> list[tuple[str, str, str]]:
 
 # ── Phase 2: Managed mode ────────────────────────────────────────────
 
-async def phase_managed(gguf: Path) -> list[tuple[str, str, str]]:
-    print(f"\n===== Phase 2: managed mode =====")
+async def phase_managed(
+    gguf: Path, mode: str = "native", extra_flags: list[str] | None = None,
+) -> list[tuple[str, str, str]]:
+    print(f"\n===== Phase 2: managed mode (fc={mode}) =====")
     print(f"      forge owns llama-server on :{MANAGED_BACKEND_PORT}, proxy on :{MANAGED_PROXY_PORT}")
 
     from forge.proxy import ProxyServer
@@ -335,7 +421,8 @@ async def phase_managed(gguf: Path) -> list[tuple[str, str, str]]:
         backend_port=MANAGED_BACKEND_PORT,
         port=MANAGED_PROXY_PORT,
         budget_mode=BudgetMode.BACKEND,
-        mode="native",
+        mode=mode,
+        extra_flags=extra_flags,
     )
     proxy.start()
     print(f"[managed] proxy ready at {proxy.url}")
@@ -357,6 +444,17 @@ def _print_summary(phase: str, results: list[tuple[str, str, str]]) -> None:
 async def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--gguf", default=DEFAULT_GGUF, help="GGUF model path")
+    parser.add_argument(
+        "--server-flags", default=None,
+        help="Extra llama-server flags as a single string, e.g. "
+             "'--no-mmap -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 -c 32768'. "
+             "Threaded into external spawn and managed ServerManager.",
+    )
+    parser.add_argument(
+        "--mode", choices=["native", "prompt"], default="native",
+        help="Function-calling mode for the proxy + backend (default: native). "
+             "'prompt' exercises forge's prompt-injection FC path.",
+    )
     parser.add_argument("--skip-external", action="store_true")
     parser.add_argument("--skip-managed", action="store_true")
     args = parser.parse_args()
@@ -366,19 +464,24 @@ async def main() -> int:
         print(f"[FATAL] GGUF not found: {gguf}")
         return 2
 
+    extra_flags = args.server_flags.split() if args.server_flags else None
+
     _setup_logging()
     print(f"GGUF: {gguf}")
+    print(f"FC mode: {args.mode}")
+    if extra_flags:
+        print(f"Extra server flags: {extra_flags}")
     print(f"Forge proxy log: {LOG_FILE}")
 
     summaries: list[tuple[str, list[tuple[str, str, str]]]] = []
 
     if not args.skip_external:
-        ext = await phase_external(gguf)
+        ext = await phase_external(gguf, args.mode, extra_flags)
         _print_summary("external", ext)
         summaries.append(("external", ext))
 
     if not args.skip_managed:
-        man = await phase_managed(gguf)
+        man = await phase_managed(gguf, args.mode, extra_flags)
         _print_summary("managed", man)
         summaries.append(("managed", man))
 

--- a/scripts/integration_test_proxy.py
+++ b/scripts/integration_test_proxy.py
@@ -1,0 +1,397 @@
+"""Integration tests for the proxy against a real llama.cpp backend.
+
+Two phases, sequential, each owning its own backend lifecycle:
+
+1. External mode — script launches ``llama-server`` via subprocess, the
+   proxy points at it via ``backend_url``. Matches what users do per the
+   BACKEND_SETUP docs (CC user from issue, TI evaluation path).
+2. Managed mode — the proxy owns the llama-server via ServerManager.
+   Matches ``python -m forge.proxy --backend llamaserver --gguf X``.
+
+Same four tests run in each phase:
+
+- OpenAI text completion (regression coverage)
+- Anthropic text completion, no tools (Path 2 text round trip)
+- Anthropic tool call, non-streaming (Path 2 tool injection + emit)
+- Anthropic tool call, streaming (Path 2 SSE event sequence on the wire)
+
+Path 1 (Anthropic-shape downstream) is not covered here — that needs a
+real Anthropic API or LiteLLM container.  See test_path1_anthropic_passthrough
+in smoke_test_proxy.py for the wire-shape coverage of that path.
+
+Usage:
+    python scripts/integration_test_proxy.py [--gguf PATH]
+
+A proxy log is written to scripts/integration_test_proxy.log alongside
+this script — inspect it on failure for forge-side detail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+# AnthropicClient is imported via forge.proxy even though external+managed
+# modes here use LlamafileClient — set a dummy key so the SDK import doesn't
+# choke on missing env in some setups.
+os.environ.setdefault("ANTHROPIC_API_KEY", "dummy-for-integration")
+
+
+DEFAULT_GGUF = "/home/antoine/models/Ministral-3-14B-Instruct-2512-Q4_K_M.gguf"
+LLAMA_SERVER_BIN = "llama-server"
+
+# Distinct port pairs per phase so a stale process from one phase doesn't
+# poison the other.
+EXTERNAL_BACKEND_PORT = 18086
+EXTERNAL_PROXY_PORT = 18087
+MANAGED_BACKEND_PORT = 18088
+MANAGED_PROXY_PORT = 18089
+
+LOG_FILE = Path(__file__).parent / "integration_test_proxy.log"
+
+# Reasoning models can spend tens of seconds thinking before emitting tool
+# calls. Cold first inference is the slowest; subsequent calls are faster.
+REQUEST_TIMEOUT = 240.0
+
+
+# ── Logging ───────────────────────────────────────────────────────────
+
+def _setup_logging() -> None:
+    """Pipe forge logs to a file so failure post-mortem has detail."""
+    if LOG_FILE.exists():
+        LOG_FILE.unlink()
+    handler = logging.FileHandler(LOG_FILE)
+    handler.setFormatter(logging.Formatter(
+        "%(asctime)s [%(name)s] %(levelname)s: %(message)s"
+    ))
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+
+
+# ── Real-backend helpers ──────────────────────────────────────────────
+
+def _spawn_llama_server(gguf: Path, port: int) -> subprocess.Popen:
+    """Launch llama-server with forge's canonical flags (matches ServerManager)."""
+    cmd = [
+        LLAMA_SERVER_BIN,
+        "-m", str(gguf),
+        "-ngl", "999",
+        "--port", str(port),
+        "--jinja",
+    ]
+    print(f"[external] launching: {' '.join(cmd)}")
+    return subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+async def _wait_llama_ready(port: int, timeout: float = 180.0) -> None:
+    """Poll /props until llama-server responds; matches ServerManager's check."""
+    deadline = time.monotonic() + timeout
+    url = f"http://127.0.0.1:{port}/props"
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        while time.monotonic() < deadline:
+            try:
+                r = await client.get(url)
+                if r.status_code == 200:
+                    return
+            except (httpx.ConnectError, httpx.ReadTimeout, httpx.RemoteProtocolError):
+                pass
+            await asyncio.sleep(1.0)
+    raise RuntimeError(f"llama-server on :{port} did not become healthy in {timeout}s")
+
+
+# ── Test case definitions ────────────────────────────────────────────
+
+GET_WEATHER_TOOL_OPENAI = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string", "description": "City name"}},
+            "required": ["city"],
+        },
+    },
+}
+
+GET_WEATHER_TOOL_ANTHROPIC = {
+    "name": "get_weather",
+    "description": "Get the current weather for a city.",
+    "input_schema": {
+        "type": "object",
+        "properties": {"city": {"type": "string", "description": "City name"}},
+        "required": ["city"],
+    },
+}
+
+
+async def _run_test_openai_text(proxy_base: str) -> None:
+    """Test 1: OpenAI inbound, text only (regression coverage)."""
+    print("  -- T1 OpenAI text completion (regression)")
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        r = await client.post(
+            f"{proxy_base}/v1/chat/completions",
+            json={
+                "model": "test",
+                "messages": [{"role": "user", "content": "Reply with exactly the single word: OK"}],
+                "stream": False,
+            },
+        )
+    assert r.status_code == 200, f"T1 status={r.status_code} body={r.text[:300]}"
+    data = r.json()
+    assert "choices" in data, f"T1 missing 'choices': {data}"
+    msg = data["choices"][0]["message"]
+    print(f"     content={msg.get('content', '')[:80]!r}")
+    assert msg["role"] == "assistant"
+
+
+async def _run_test_anthropic_text(proxy_base: str) -> None:
+    """Test 2: Anthropic inbound, text only — Path 2 round trip."""
+    print("  -- T2 Anthropic text completion (Path 2, no tools)")
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        r = await client.post(
+            f"{proxy_base}/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 256,
+                "messages": [{"role": "user", "content": "Reply with exactly the single word: OK"}],
+                "stream": False,
+            },
+        )
+    assert r.status_code == 200, f"T2 status={r.status_code} body={r.text[:300]}"
+    data = r.json()
+    assert data.get("type") == "message", f"T2 wrong type: {data}"
+    assert data["role"] == "assistant"
+    assert data["id"].startswith("msg_"), f"T2 bad id: {data['id']}"
+    text_blocks = [b for b in data["content"] if b.get("type") == "text"]
+    assert text_blocks, f"T2 no text blocks: {data['content']}"
+    print(f"     text={text_blocks[0]['text'][:80]!r}")
+    print(f"     stop_reason={data.get('stop_reason')}")
+
+
+async def _run_test_anthropic_tool_nonstream(proxy_base: str) -> None:
+    """Test 3: Anthropic inbound with tools, non-streaming — Path 2."""
+    print("  -- T3 Anthropic tool call, non-streaming (Path 2)")
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        r = await client.post(
+            f"{proxy_base}/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 512,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": (
+                            "Use the get_weather tool to check the weather in "
+                            "Paris. Call the tool, do not answer in text."
+                        ),
+                    },
+                ],
+                "tools": [GET_WEATHER_TOOL_ANTHROPIC],
+                "stream": False,
+            },
+        )
+    assert r.status_code == 200, f"T3 status={r.status_code} body={r.text[:300]}"
+    data = r.json()
+    assert data.get("type") == "message", f"T3 wrong type: {data}"
+    tool_uses = [b for b in data["content"] if b.get("type") == "tool_use"]
+    text_blocks = [b for b in data["content"] if b.get("type") == "text"]
+    print(f"     content blocks: tool_use={len(tool_uses)} text={len(text_blocks)}")
+    if not tool_uses:
+        # Forge's handler.py falls back to text if the model refuses to call
+        # the tool after retries — that's not a wire bug. Note loudly.
+        print(f"     [WARN] no tool_use blocks — model returned text: "
+              f"{(text_blocks[0]['text'][:200] if text_blocks else '')!r}")
+        return
+    block = tool_uses[0]
+    assert block["name"] == "get_weather", f"T3 wrong tool: {block['name']}"
+    assert block["id"].startswith("toolu_"), f"T3 bad toolu id: {block['id']}"
+    assert isinstance(block.get("input"), dict), f"T3 input not dict: {block.get('input')}"
+    print(f"     tool_use: name={block['name']} id={block['id']} input={block['input']}")
+    assert data.get("stop_reason") == "tool_use", f"T3 stop_reason={data.get('stop_reason')}"
+
+
+async def _run_test_anthropic_tool_stream(proxy_base: str) -> None:
+    """Test 4: Anthropic inbound with tools, streaming — Path 2 SSE on the wire."""
+    print("  -- T4 Anthropic tool call, streaming (Path 2 SSE)")
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        r = await client.post(
+            f"{proxy_base}/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 512,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": (
+                            "Use the get_weather tool to check the weather in "
+                            "Paris. Call the tool, do not answer in text."
+                        ),
+                    },
+                ],
+                "tools": [GET_WEATHER_TOOL_ANTHROPIC],
+                "stream": True,
+            },
+        )
+    assert r.status_code == 200, f"T4 status={r.status_code}"
+    sse_text = r.text
+    assert "[DONE]" not in sse_text, "T4 Anthropic SSE must NOT emit [DONE]"
+    event_lines = [l for l in sse_text.splitlines() if l.startswith("event: ")]
+    event_types = [l.removeprefix("event: ").strip() for l in event_lines]
+    print(f"     events: {event_types}")
+    assert event_types, f"T4 no event: lines, body={sse_text[:300]!r}"
+    assert event_types[0] == "message_start", f"T4 first event={event_types[0]}"
+    assert event_types[-1] == "message_stop", f"T4 last event={event_types[-1]}"
+    has_tool_use = any('"tool_use"' in l for l in sse_text.splitlines() if l.startswith("data: "))
+    if not has_tool_use:
+        print(f"     [WARN] no tool_use content block in stream — model returned text only")
+
+
+TESTS = [
+    ("T1 OpenAI text", _run_test_openai_text),
+    ("T2 Anthropic text", _run_test_anthropic_text),
+    ("T3 Anthropic tool non-stream", _run_test_anthropic_tool_nonstream),
+    ("T4 Anthropic tool stream", _run_test_anthropic_tool_stream),
+]
+
+
+async def _run_all_tests(proxy_base: str) -> list[tuple[str, str, str]]:
+    """Run the full battery against a proxy. Returns [(name, status, detail)]."""
+    results: list[tuple[str, str, str]] = []
+    for name, fn in TESTS:
+        try:
+            t0 = time.monotonic()
+            await fn(proxy_base)
+            results.append((name, "PASS", f"{time.monotonic() - t0:.1f}s"))
+        except AssertionError as exc:
+            results.append((name, "FAIL", str(exc)[:200]))
+            print(f"     [FAIL] {exc}")
+        except Exception as exc:
+            results.append((name, "ERROR", f"{type(exc).__name__}: {exc}"[:200]))
+            print(f"     [ERROR] {type(exc).__name__}: {exc}")
+    return results
+
+
+# ── Phase 1: External mode ───────────────────────────────────────────
+
+async def phase_external(gguf: Path) -> list[tuple[str, str, str]]:
+    print(f"\n===== Phase 1: external mode =====")
+    print(f"      llama-server on :{EXTERNAL_BACKEND_PORT}, proxy on :{EXTERNAL_PROXY_PORT}")
+
+    llama_proc = _spawn_llama_server(gguf, EXTERNAL_BACKEND_PORT)
+    try:
+        await _wait_llama_ready(EXTERNAL_BACKEND_PORT)
+        print(f"[external] llama-server ready")
+
+        from forge.proxy import ProxyServer
+        proxy = ProxyServer(
+            backend_url=f"http://127.0.0.1:{EXTERNAL_BACKEND_PORT}",
+            port=EXTERNAL_PROXY_PORT,
+            mode="native",
+            backend_protocol="openai",
+        )
+        proxy.start()
+        print(f"[external] proxy ready at {proxy.url}")
+        try:
+            return await _run_all_tests(proxy.url)
+        finally:
+            proxy.stop()
+    finally:
+        llama_proc.terminate()
+        try:
+            llama_proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            llama_proc.kill()
+        print("[external] llama-server stopped")
+
+
+# ── Phase 2: Managed mode ────────────────────────────────────────────
+
+async def phase_managed(gguf: Path) -> list[tuple[str, str, str]]:
+    print(f"\n===== Phase 2: managed mode =====")
+    print(f"      forge owns llama-server on :{MANAGED_BACKEND_PORT}, proxy on :{MANAGED_PROXY_PORT}")
+
+    from forge.proxy import ProxyServer
+    from forge.server import BudgetMode
+
+    proxy = ProxyServer(
+        backend="llamaserver",
+        gguf=str(gguf),
+        backend_port=MANAGED_BACKEND_PORT,
+        port=MANAGED_PROXY_PORT,
+        budget_mode=BudgetMode.BACKEND,
+        mode="native",
+    )
+    proxy.start()
+    print(f"[managed] proxy ready at {proxy.url}")
+    try:
+        return await _run_all_tests(proxy.url)
+    finally:
+        proxy.stop()
+        print("[managed] proxy + managed llama-server stopped")
+
+
+# ── Entry point ──────────────────────────────────────────────────────
+
+def _print_summary(phase: str, results: list[tuple[str, str, str]]) -> None:
+    print(f"\n  [{phase} summary]")
+    for name, status, detail in results:
+        print(f"     {status:5s}  {name:34s}  {detail}")
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gguf", default=DEFAULT_GGUF, help="GGUF model path")
+    parser.add_argument("--skip-external", action="store_true")
+    parser.add_argument("--skip-managed", action="store_true")
+    args = parser.parse_args()
+
+    gguf = Path(args.gguf)
+    if not gguf.exists():
+        print(f"[FATAL] GGUF not found: {gguf}")
+        return 2
+
+    _setup_logging()
+    print(f"GGUF: {gguf}")
+    print(f"Forge proxy log: {LOG_FILE}")
+
+    summaries: list[tuple[str, list[tuple[str, str, str]]]] = []
+
+    if not args.skip_external:
+        ext = await phase_external(gguf)
+        _print_summary("external", ext)
+        summaries.append(("external", ext))
+
+    if not args.skip_managed:
+        man = await phase_managed(gguf)
+        _print_summary("managed", man)
+        summaries.append(("managed", man))
+
+    print("\n===== Final =====")
+    any_fail = False
+    for phase, results in summaries:
+        passed = sum(1 for _, s, _ in results if s == "PASS")
+        total = len(results)
+        if any(s != "PASS" for _, s, _ in results):
+            any_fail = True
+        print(f"  {phase}: {passed}/{total} passed")
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/smoke_test_proxy.py
+++ b/scripts/smoke_test_proxy.py
@@ -1,5 +1,19 @@
-"""Smoke test for the proxy — starts proxy in external mode against a
-mock backend, sends one request, verifies the response.
+"""Smoke tests for the proxy.
+
+Three scenarios, each with its own mock backend + proxy on distinct ports:
+
+1. ``test_openai()`` — OpenAI inbound → OpenAI backend.  Original smoke
+   coverage; proves the existing OpenAI path didn't regress.
+
+2. ``test_path2_anthropic_to_openai()`` — Anthropic inbound (``/v1/messages``)
+   → OpenAI backend.  Exercises Anthropic→OpenAI translation on inbound,
+   OpenAI→Anthropic emission on outbound, and the Anthropic SSE wire
+   format (``event:`` lines, no ``[DONE]`` terminator).
+
+3. ``test_path1_anthropic_passthrough()`` — Anthropic inbound → Anthropic
+   backend.  Mock records the request body it received from forge's
+   AnthropicClient and the test asserts ``cache_control`` survived
+   end-to-end (the ADR-015 passthrough invariant).
 
 Usage: python scripts/smoke_test_proxy.py
 """
@@ -8,71 +22,26 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
+from typing import Any
 
 import httpx
 
-
-async def mock_backend(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-    """Minimal mock that returns a tool call response."""
-    # Read request
-    request_line = await reader.readline()
-    headers: dict[str, str] = {}
-    while True:
-        line = await reader.readline()
-        decoded = line.decode().strip()
-        if not decoded:
-            break
-        if ":" in decoded:
-            k, v = decoded.split(":", 1)
-            headers[k.strip().lower()] = v.strip()
-
-    content_length = int(headers.get("content-length", "0"))
-    if content_length > 0:
-        body = await reader.readexactly(content_length)
-
-    # Return a tool call response
-    response_body = json.dumps({
-        "id": "chatcmpl-mock",
-        "object": "chat.completion",
-        "model": "mock",
-        "choices": [{
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": [{
-                    "id": "call_mock1",
-                    "type": "function",
-                    "function": {
-                        "name": "get_weather",
-                        "arguments": '{"city": "Paris"}',
-                    },
-                }],
-            },
-            "finish_reason": "tool_calls",
-        }],
-        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-    })
-
-    response = (
-        f"HTTP/1.1 200 OK\r\n"
-        f"Content-Type: application/json\r\n"
-        f"Content-Length: {len(response_body)}\r\n"
-        f"\r\n"
-        f"{response_body}"
-    )
-    writer.write(response.encode())
-    await writer.drain()
-    writer.close()
-    await writer.wait_closed()
+# The Anthropic SDK requires an API key at construction time even when
+# ``base_url`` retargets it at a local mock.  Set a dummy value before
+# any forge import so AnthropicClient doesn't trip on missing env.
+os.environ.setdefault("ANTHROPIC_API_KEY", "dummy-for-smoke")
 
 
-async def mock_backend_with_health(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-    """Mock that handles both /props (for context length) and /v1/chat/completions."""
+# ── HTTP helpers ──────────────────────────────────────────────────────
+
+async def _read_request(
+    reader: asyncio.StreamReader,
+) -> tuple[str, dict[str, str], bytes]:
+    """Read an HTTP request: returns (path, headers, body)."""
     request_line = await reader.readline()
     path = request_line.decode().split(" ")[1] if request_line else ""
-
     headers: dict[str, str] = {}
     while True:
         line = await reader.readline()
@@ -82,10 +51,30 @@ async def mock_backend_with_health(reader: asyncio.StreamReader, writer: asyncio
         if ":" in decoded:
             k, v = decoded.split(":", 1)
             headers[k.strip().lower()] = v.strip()
-
     content_length = int(headers.get("content-length", "0"))
+    body = b""
     if content_length > 0:
-        await reader.readexactly(content_length)
+        body = await reader.readexactly(content_length)
+    return path, headers, body
+
+
+def _write_json_response(body: str) -> bytes:
+    return (
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: application/json\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        "\r\n"
+        f"{body}"
+    ).encode()
+
+
+# ── Mock backends ─────────────────────────────────────────────────────
+
+async def openai_mock_backend(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter,
+) -> None:
+    """OpenAI-shape mock — /props for context length + /v1/chat/completions."""
+    path, _headers, _body = await _read_request(reader)
 
     if "/props" in path:
         body = json.dumps({"default_generation_settings": {"n_ctx": 8192}})
@@ -113,126 +102,352 @@ async def mock_backend_with_health(reader: asyncio.StreamReader, writer: asyncio
             "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
         })
 
-    response = (
-        f"HTTP/1.1 200 OK\r\n"
-        f"Content-Type: application/json\r\n"
-        f"Content-Length: {len(body)}\r\n"
-        f"\r\n"
-        f"{body}"
-    )
-    writer.write(response.encode())
+    writer.write(_write_json_response(body))
     await writer.drain()
     writer.close()
     await writer.wait_closed()
 
 
-async def main() -> None:
-    # Start mock backend on port 18080
-    mock_server = await asyncio.start_server(mock_backend_with_health, "127.0.0.1", 18080)
-    print("[mock] Backend running on :18080")
+# Captured request bodies from the Anthropic mock, used by path-1 assertions.
+_anthropic_mock_seen: list[dict[str, Any]] = []
 
-    # Start proxy
+
+async def anthropic_mock_backend(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter,
+) -> None:
+    """Anthropic-shape mock — records inbound bodies, returns a tool_use message.
+
+    The Anthropic SDK (used by forge's AnthropicClient in path 1) calls
+    ``POST {base_url}/v1/messages``.  Response must look like an Anthropic
+    Message object or the SDK will fail to parse.
+    """
+    path, _headers, body_bytes = await _read_request(reader)
+
+    if body_bytes:
+        try:
+            _anthropic_mock_seen.append(json.loads(body_bytes))
+        except json.JSONDecodeError:
+            _anthropic_mock_seen.append({"_raw": body_bytes.decode(errors="replace")})
+
+    if "/v1/messages" in path:
+        body = json.dumps({
+            "id": "msg_anthropic_mock_0001",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-mock",
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_mock_0001",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+            }],
+            "stop_reason": "tool_use",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 12, "output_tokens": 6},
+        })
+    else:
+        body = json.dumps({"error": {"type": "not_found", "message": path}})
+
+    writer.write(_write_json_response(body))
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
+
+
+# ── Proxy lifecycle helper ────────────────────────────────────────────
+
+def _start_proxy(**kwargs: Any) -> Any:
+    """Construct + start a ProxyServer, return it (blocks until ready)."""
     from forge.proxy import ProxyServer
+    proxy = ProxyServer(**kwargs)
+    proxy.start()
+    return proxy
 
-    proxy = ProxyServer(
+
+# ── Test 1: OpenAI end-to-end (regression coverage) ──────────────────
+
+async def test_openai() -> None:
+    print("\n=== test_openai (OpenAI inbound → OpenAI backend) ===")
+    mock = await asyncio.start_server(openai_mock_backend, "127.0.0.1", 18080)
+    proxy = _start_proxy(
         backend_url="http://127.0.0.1:18080",
         port=18081,
         budget_tokens=8192,
     )
+    print("[setup] mock=:18080 proxy=:18081")
 
-    # Run proxy start in a thread (it blocks until ready)
-    import threading
-    proxy_thread = threading.Thread(target=proxy.start, daemon=True)
-    proxy_thread.start()
-    proxy_thread.join(timeout=10)
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            health = await client.get("http://127.0.0.1:18081/health")
+            assert health.status_code == 200, f"health: {health.status_code}"
 
-    if not proxy._started:
-        print("[FAIL] Proxy didn't start")
-        sys.exit(1)
+            resp = await client.post(
+                "http://127.0.0.1:18081/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [
+                        {"role": "system", "content": "You are a weather assistant."},
+                        {"role": "user", "content": "What's the weather in Paris?"},
+                    ],
+                    "tools": [{
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather for a city",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        },
+                    }],
+                    "stream": False,
+                },
+            )
+            assert resp.status_code == 200, resp.status_code
+            data = resp.json()
+            choice = data["choices"][0]
+            assert choice["finish_reason"] == "tool_calls"
+            tc = choice["message"]["tool_calls"][0]
+            assert tc["function"]["name"] == "get_weather"
+            args = json.loads(tc["function"]["arguments"])
+            assert args["city"] == "Paris"
+            print("[ok] non-streaming tool call")
 
-    print("[proxy] Running on :18081")
+            resp_stream = await client.post(
+                "http://127.0.0.1:18081/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "Weather in Paris?"}],
+                    "tools": [{
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        },
+                    }],
+                    "stream": True,
+                },
+            )
+            body = resp_stream.text
+            assert any("[DONE]" in l for l in body.split("\n")), "openai SSE missing [DONE]"
+            print("[ok] streaming with [DONE] terminator")
 
-    # Send a request
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        # Test health
-        health = await client.get("http://127.0.0.1:18081/health")
-        assert health.status_code == 200, f"Health check failed: {health.status_code}"
-        print("[test] Health check: OK")
+    finally:
+        proxy.stop()
+        mock.close()
+        await mock.wait_closed()
 
-        # Test chat completions (non-streaming)
-        resp = await client.post(
-            "http://127.0.0.1:18081/v1/chat/completions",
-            json={
-                "model": "test",
-                "messages": [
-                    {"role": "system", "content": "You are a weather assistant."},
-                    {"role": "user", "content": "What's the weather in Paris?"},
-                ],
-                "tools": [{
-                    "type": "function",
-                    "function": {
+
+# ── Test 2: Path 2 (Anthropic inbound → OpenAI backend) ──────────────
+
+async def test_path2_anthropic_to_openai() -> None:
+    print("\n=== test_path2_anthropic_to_openai (Anthropic inbound → OpenAI backend) ===")
+    mock = await asyncio.start_server(openai_mock_backend, "127.0.0.1", 18082)
+    proxy = _start_proxy(
+        backend_url="http://127.0.0.1:18082",
+        port=18083,
+        budget_tokens=8192,
+        backend_protocol="openai",  # default but be explicit
+    )
+    print("[setup] mock=:18082 proxy=:18083 backend_protocol=openai")
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            # --- Non-streaming Anthropic request ---
+            resp = await client.post(
+                "http://127.0.0.1:18083/v1/messages",
+                json={
+                    "model": "test-anthropic",
+                    "max_tokens": 1024,
+                    "system": "You are a weather assistant.",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "What's the weather in Paris?",
+                                    "cache_control": {"type": "ephemeral"},
+                                },
+                            ],
+                        },
+                    ],
+                    "tools": [{
                         "name": "get_weather",
                         "description": "Get weather for a city",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "city": {"type": "string", "description": "City name"},
-                            },
-                            "required": ["city"],
-                        },
-                    },
-                }],
-                "stream": False,
-            },
-        )
-
-        print(f"[test] Chat completions status: {resp.status_code}")
-        data = resp.json()
-        print(f"[test] Response: {json.dumps(data, indent=2)}")
-
-        choice = data["choices"][0]
-        assert choice["finish_reason"] == "tool_calls", f"Expected tool_calls, got {choice['finish_reason']}"
-        tc = choice["message"]["tool_calls"][0]
-        assert tc["function"]["name"] == "get_weather"
-        args = json.loads(tc["function"]["arguments"])
-        assert args["city"] == "Paris"
-        print("[test] Tool call validated: get_weather(city='Paris')")
-
-        # Test streaming
-        resp_stream = await client.post(
-            "http://127.0.0.1:18081/v1/chat/completions",
-            json={
-                "model": "test",
-                "messages": [
-                    {"role": "user", "content": "Weather in Paris?"},
-                ],
-                "tools": [{
-                    "type": "function",
-                    "function": {
-                        "name": "get_weather",
-                        "description": "Get weather",
-                        "parameters": {
+                        "input_schema": {
                             "type": "object",
                             "properties": {"city": {"type": "string"}},
                             "required": ["city"],
                         },
-                    },
-                }],
-                "stream": True,
-            },
-        )
-        print(f"[test] Streaming status: {resp_stream.status_code}")
-        body = resp_stream.text
-        lines = [l for l in body.split("\n") if l.startswith("data: ")]
-        print(f"[test] SSE events: {len(lines)}")
-        assert any("[DONE]" in l for l in body.split("\n")), "Missing [DONE]"
-        print("[test] Streaming validated: got SSE events + [DONE]")
+                    }],
+                    "tool_choice": {"type": "auto"},
+                    "stream": False,
+                },
+            )
+            assert resp.status_code == 200, f"path-2 non-stream: {resp.status_code} {resp.text}"
+            data = resp.json()
+            print(f"[response] {json.dumps(data, indent=2)}")
 
-    print("\n[PASS] All smoke tests passed!")
-    proxy.stop()
-    mock_server.close()
-    await mock_server.wait_closed()
+            # Anthropic-shape assertions
+            assert data["type"] == "message", f"type: {data.get('type')}"
+            assert data["role"] == "assistant"
+            assert data["id"].startswith("msg_"), f"id: {data['id']}"
+            assert data["stop_reason"] == "tool_use", f"stop_reason: {data['stop_reason']}"
+            tool_use_blocks = [b for b in data["content"] if b["type"] == "tool_use"]
+            assert len(tool_use_blocks) == 1, f"tool_use blocks: {len(tool_use_blocks)}"
+            block = tool_use_blocks[0]
+            assert block["name"] == "get_weather"
+            assert block["input"] == {"city": "Paris"}
+            assert block["id"].startswith("toolu_"), f"toolu id: {block['id']}"
+            print("[ok] non-streaming: Anthropic-shape response, tool_use block correct")
+
+            # --- Streaming Anthropic request ---
+            resp_stream = await client.post(
+                "http://127.0.0.1:18083/v1/messages",
+                json={
+                    "model": "test-anthropic",
+                    "max_tokens": 1024,
+                    "messages": [
+                        {"role": "user", "content": "Weather in Paris?"},
+                    ],
+                    "tools": [{
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    }],
+                    "stream": True,
+                },
+            )
+            assert resp_stream.status_code == 200, f"path-2 stream: {resp_stream.status_code}"
+            sse_text = resp_stream.text
+            print(f"[stream raw] {sse_text!r}")
+
+            assert "[DONE]" not in sse_text, "Anthropic SSE must NOT emit [DONE]"
+            event_lines = [l for l in sse_text.splitlines() if l.startswith("event: ")]
+            data_lines = [l for l in sse_text.splitlines() if l.startswith("data: ")]
+            event_types = [l.removeprefix("event: ").strip() for l in event_lines]
+            assert event_types[0] == "message_start", f"first event: {event_types[0]}"
+            assert event_types[-1] == "message_stop", f"last event: {event_types[-1]}"
+            assert "message_delta" in event_types, "missing message_delta"
+            assert any("tool_use" in l for l in data_lines), "no tool_use block in stream"
+            print(f"[ok] streaming: {len(event_types)} events, sequence {event_types[0]}…{event_types[-1]}, no [DONE]")
+
+    finally:
+        proxy.stop()
+        mock.close()
+        await mock.wait_closed()
+
+
+# ── Test 3: Path 1 (Anthropic inbound → Anthropic backend) ───────────
+
+async def test_path1_anthropic_passthrough() -> None:
+    print("\n=== test_path1_anthropic_passthrough (Anthropic inbound → Anthropic backend) ===")
+    _anthropic_mock_seen.clear()
+    mock = await asyncio.start_server(anthropic_mock_backend, "127.0.0.1", 18084)
+    proxy = _start_proxy(
+        backend_url="http://127.0.0.1:18084",
+        port=18085,
+        budget_tokens=8192,
+        backend_protocol="anthropic",
+        model="claude-mock",
+    )
+    print("[setup] mock=:18084 proxy=:18085 backend_protocol=anthropic")
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            cache_marker = {"type": "ephemeral"}
+            resp = await client.post(
+                "http://127.0.0.1:18085/v1/messages",
+                json={
+                    "model": "claude-mock",
+                    "max_tokens": 1024,
+                    "system": [
+                        {
+                            "type": "text",
+                            "text": "You are a weather assistant.",
+                            "cache_control": cache_marker,
+                        },
+                    ],
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Pretend this is a giant cached preamble.",
+                                    "cache_control": cache_marker,
+                                },
+                                {"type": "text", "text": "What's the weather in Paris?"},
+                            ],
+                        },
+                    ],
+                    "tools": [{
+                        "name": "get_weather",
+                        "description": "Get weather for a city",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    }],
+                    "stream": False,
+                },
+            )
+            assert resp.status_code == 200, f"path-1 non-stream: {resp.status_code} {resp.text}"
+            data = resp.json()
+            print(f"[response] {json.dumps(data, indent=2)}")
+
+            # Anthropic-shape on the response leg
+            assert data["type"] == "message"
+            assert data["role"] == "assistant"
+            assert data["id"].startswith("msg_")
+            tool_use_blocks = [b for b in data["content"] if b["type"] == "tool_use"]
+            assert len(tool_use_blocks) == 1, f"tool_use blocks: {len(tool_use_blocks)}"
+            assert tool_use_blocks[0]["name"] == "get_weather"
+            assert tool_use_blocks[0]["input"] == {"city": "Paris"}
+            print("[ok] response shape: Anthropic Message with tool_use block")
+
+            # The passthrough invariant — mock backend must have seen cache_control.
+            assert _anthropic_mock_seen, "mock backend never received a request"
+            seen_body = _anthropic_mock_seen[-1]
+            print(f"[mock saw] keys={sorted(seen_body.keys())}")
+            seen_str = json.dumps(seen_body)
+            assert "cache_control" in seen_str, (
+                "cache_control did NOT survive passthrough — "
+                f"mock saw body: {seen_str[:400]}"
+            )
+            assert '"ephemeral"' in seen_str, "cache_control value mangled"
+            print("[ok] cache_control survived end-to-end through forge proxy")
+
+    finally:
+        proxy.stop()
+        mock.close()
+        await mock.wait_closed()
+
+
+# ── Entry point ───────────────────────────────────────────────────────
+
+async def main() -> None:
+    await test_openai()
+    await test_path2_anthropic_to_openai()
+    await test_path1_anthropic_passthrough()
+    print("\n[PASS] All proxy smoke tests passed.")
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except AssertionError as exc:
+        print(f"\n[FAIL] {exc}")
+        sys.exit(1)

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -220,19 +220,27 @@ class AnthropicClient:
         self,
         messages: list[dict[str, Any]],
         tools: list[ToolSpec] | None,
+        passthrough: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Build kwargs dict for messages.create / messages.stream."""
+        """Build kwargs dict for messages.create / messages.stream.
+
+        ``passthrough`` (proxy use) supplies inbound-body fields the proxy
+        didn't deconstruct (``max_tokens``, ``stop_sequences``, ``tool_choice``,
+        ``metadata``, ``thinking``, etc.). Forge-owned fields (``model``,
+        ``messages``, ``system``, ``tools``) overlay it.
+        """
         system, converted = self._convert_messages(messages)
-        kwargs: dict[str, Any] = {
+        kwargs: dict[str, Any] = dict(passthrough or {})
+        kwargs.update({
             "model": self.model,
             "messages": converted,
-            "max_tokens": self.max_tokens,
-        }
+        })
+        kwargs.setdefault("max_tokens", self.max_tokens)
         if system:
             kwargs["system"] = system
         if tools:
             kwargs["tools"] = self._convert_tools(tools)
-            if self._tool_choice:
+            if self._tool_choice and "tool_choice" not in kwargs:
                 kwargs["tool_choice"] = {"type": self._tool_choice}
         return kwargs
 
@@ -241,19 +249,20 @@ class AnthropicClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> LLMResponse:
         """Send messages via the Anthropic Messages API.
 
         ``sampling`` is accepted for protocol symmetry but ignored —
         AnthropicClient does not currently expose sampling kwargs through
-        forge.
+        forge. ``passthrough`` merges inbound-body extras into the SDK call.
         """
         if sampling:
             log.debug(
                 "AnthropicClient ignores per-call sampling overrides: %s",
                 sorted(sampling.keys()),
             )
-        kwargs = self._build_kwargs(messages, tools)
+        kwargs = self._build_kwargs(messages, tools, passthrough)
         try:
             response = await self._client.messages.create(**kwargs)
         except anthropic.APIError as exc:
@@ -271,17 +280,19 @@ class AnthropicClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Stream via the Anthropic Messages API.
 
         ``sampling`` is accepted for protocol symmetry but ignored.
+        ``passthrough`` merges inbound-body extras into the SDK call.
         """
         if sampling:
             log.debug(
                 "AnthropicClient ignores per-call sampling overrides: %s",
                 sorted(sampling.keys()),
             )
-        kwargs = self._build_kwargs(messages, tools)
+        kwargs = self._build_kwargs(messages, tools, passthrough)
 
         accumulated_text = ""
         # Track multiple tool_use blocks by index.

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -39,6 +39,7 @@ class AnthropicClient:
         max_retries: int = 3,
         tool_choice: str | None = None,
         recommended_sampling: bool = False,
+        base_url: str | None = None,
     ) -> None:
         self.model = model
         self.max_tokens = max_tokens
@@ -50,11 +51,16 @@ class AnthropicClient:
             log.debug(
                 "AnthropicClient ignores recommended_sampling=True — no sampling kwargs are exposed."
             )
-        self._client = anthropic.AsyncAnthropic(
-            api_key=api_key,
-            timeout=timeout,
-            max_retries=max_retries,
-        )
+        sdk_kwargs: dict[str, Any] = {
+            "api_key": api_key,
+            "timeout": timeout,
+            "max_retries": max_retries,
+        }
+        # base_url retargets the SDK at an Anthropic-shape downstream
+        # (LiteLLM, a self-hosted proxy, etc.) — proxy path 1.
+        if base_url is not None:
+            sdk_kwargs["base_url"] = base_url
+        self._client = anthropic.AsyncAnthropic(**sdk_kwargs)
         # Populated after each send()/send_stream() call.
         self.last_usage: dict[str, int] | None = None
 
@@ -221,6 +227,7 @@ class AnthropicClient:
         messages: list[dict[str, Any]],
         tools: list[ToolSpec] | None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Build kwargs dict for messages.create / messages.stream.
 
@@ -228,9 +235,25 @@ class AnthropicClient:
         didn't deconstruct (``max_tokens``, ``stop_sequences``, ``tool_choice``,
         ``metadata``, ``thinking``, etc.). Forge-owned fields (``model``,
         ``messages``, ``system``, ``tools``) overlay it.
+
+        ``inbound_anthropic_body`` (proxy path 1) bypasses the deconstruct/
+        rebuild path: the SDK is called with the original inbound body
+        verbatim, preserving block-level fields like ``cache_control`` that
+        forge.Message doesn't represent. The runner only passes this on the
+        clean first-attempt call (no compaction, no retries) — see ADR-015.
         """
+        if inbound_anthropic_body is not None:
+            # Verbatim emit. Drop the proxy-internal ``stream`` field; the
+            # SDK call shape (messages.create vs messages.stream) selects
+            # streaming. ``model`` defaults to the inbound value but the
+            # client's configured model wins if the inbound omitted it.
+            kwargs = dict(inbound_anthropic_body)
+            kwargs.pop("stream", None)
+            kwargs.setdefault("model", self.model)
+            return kwargs
+
         system, converted = self._convert_messages(messages)
-        kwargs: dict[str, Any] = dict(passthrough or {})
+        kwargs = dict(passthrough or {})
         kwargs.update({
             "model": self.model,
             "messages": converted,
@@ -250,19 +273,24 @@ class AnthropicClient:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> LLMResponse:
         """Send messages via the Anthropic Messages API.
 
         ``sampling`` is accepted for protocol symmetry but ignored —
         AnthropicClient does not currently expose sampling kwargs through
         forge. ``passthrough`` merges inbound-body extras into the SDK call.
+        ``inbound_anthropic_body`` (path 1) triggers verbatim emit — see
+        ADR-015 for the cache_control preservation rationale.
         """
         if sampling:
             log.debug(
                 "AnthropicClient ignores per-call sampling overrides: %s",
                 sorted(sampling.keys()),
             )
-        kwargs = self._build_kwargs(messages, tools, passthrough)
+        kwargs = self._build_kwargs(
+            messages, tools, passthrough, inbound_anthropic_body,
+        )
         try:
             response = await self._client.messages.create(**kwargs)
         except anthropic.APIError as exc:
@@ -281,18 +309,22 @@ class AnthropicClient:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Stream via the Anthropic Messages API.
 
         ``sampling`` is accepted for protocol symmetry but ignored.
         ``passthrough`` merges inbound-body extras into the SDK call.
+        ``inbound_anthropic_body`` (path 1) triggers verbatim emit; see ADR-015.
         """
         if sampling:
             log.debug(
                 "AnthropicClient ignores per-call sampling overrides: %s",
                 sorted(sampling.keys()),
             )
-        kwargs = self._build_kwargs(messages, tools, passthrough)
+        kwargs = self._build_kwargs(
+            messages, tools, passthrough, inbound_anthropic_body,
+        )
 
         accumulated_text = ""
         # Track multiple tool_use blocks by index.

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import anthropic
 
-from forge.clients.base import ChunkType, StreamChunk
+from forge.clients.base import ChunkType, StreamChunk, TokenUsage
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
 from forge.errors import BackendError
 
@@ -61,8 +61,12 @@ class AnthropicClient:
         if base_url is not None:
             sdk_kwargs["base_url"] = base_url
         self._client = anthropic.AsyncAnthropic(**sdk_kwargs)
-        # Populated after each send()/send_stream() call.
-        self.last_usage: dict[str, int] | None = None
+        # Populated after each send()/send_stream() call. Slot-keyed
+        # ``{slot_id: TokenUsage}`` to match LlamafileClient / OllamaClient so
+        # ``inference._get_usage`` reads every client uniformly. The Anthropic
+        # SDK is per-call (no shared inference slot), so we always use slot 0 —
+        # same convention as OllamaClient.
+        self.last_usage: dict[int, TokenUsage] = {}
 
     # ── Tool schema conversion ───────────────────────────────────
 
@@ -298,8 +302,11 @@ class AnthropicClient:
                 getattr(exc, "status_code", 0), str(exc)
             ) from exc
         self.last_usage = {
-            "input_tokens": response.usage.input_tokens,
-            "output_tokens": response.usage.output_tokens,
+            0: TokenUsage(
+                prompt_tokens=response.usage.input_tokens,
+                completion_tokens=response.usage.output_tokens,
+                total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+            )
         }
         return self._parse_response(response)
 
@@ -375,8 +382,12 @@ class AnthropicClient:
                 # Grab usage from the final accumulated message.
                 final_message = await stream.get_final_message()
                 self.last_usage = {
-                    "input_tokens": final_message.usage.input_tokens,
-                    "output_tokens": final_message.usage.output_tokens,
+                    0: TokenUsage(
+                        prompt_tokens=final_message.usage.input_tokens,
+                        completion_tokens=final_message.usage.output_tokens,
+                        total_tokens=final_message.usage.input_tokens
+                        + final_message.usage.output_tokens,
+                    )
                 }
         except anthropic.APIError as exc:
             raise BackendError(

--- a/src/forge/clients/base.py
+++ b/src/forge/clients/base.py
@@ -84,6 +84,7 @@ class LLMClient(Protocol):
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> LLMResponse:
         """Send messages and return a parsed response.
 
@@ -101,6 +102,12 @@ class LLMClient(Protocol):
                 ``repeat_penalty``, ``presence_penalty``, ``seed``).
                 Per-call values win over instance state for this call only;
                 the client's instance fields are not mutated.
+            passthrough: Optional dict of inbound body fields forge doesn't
+                own. The client merges these into the outbound body before
+                overlaying its own fields (model, messages, tools, sampling).
+                Used by the proxy to preserve user intent (max_tokens, stop,
+                tool_choice, etc.) without forge having to enumerate every
+                supported field. None = no extras to merge.
         """
         ...
 
@@ -109,6 +116,7 @@ class LLMClient(Protocol):
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Send messages and yield streaming chunks.
 
@@ -124,6 +132,7 @@ class LLMClient(Protocol):
             tools: Tool specs to include with the request.
             sampling: Optional per-call sampling overrides (see ``send``).
                 Per-call values win over instance state without mutating self.
+            passthrough: Optional inbound-body extras dict (see ``send``).
         """
         ...
 

--- a/src/forge/clients/base.py
+++ b/src/forge/clients/base.py
@@ -85,6 +85,7 @@ class LLMClient(Protocol):
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> LLMResponse:
         """Send messages and return a parsed response.
 
@@ -108,6 +109,13 @@ class LLMClient(Protocol):
                 Used by the proxy to preserve user intent (max_tokens, stop,
                 tool_choice, etc.) without forge having to enumerate every
                 supported field. None = no extras to merge.
+            inbound_anthropic_body: Path-1 only — when set, the AnthropicClient
+                will send this body verbatim (bypassing its deconstruct/rebuild
+                path) to preserve block-level Anthropic fields like
+                ``cache_control``. The runner clears this kwarg on any
+                forge-mutation (retry / compaction / context warning) so
+                only the clean first-attempt call rides verbatim. Other
+                clients accept and ignore. See ADR-015.
         """
         ...
 
@@ -117,6 +125,7 @@ class LLMClient(Protocol):
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Send messages and yield streaming chunks.
 
@@ -133,6 +142,7 @@ class LLMClient(Protocol):
             sampling: Optional per-call sampling overrides (see ``send``).
                 Per-call values win over instance state without mutating self.
             passthrough: Optional inbound-body extras dict (see ``send``).
+            inbound_anthropic_body: Optional path-1 verbatim body (see ``send``).
         """
         ...
 

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -265,8 +265,13 @@ class LlamafileClient:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> LLMResponse:
-        """Resolve mode on first call with tools, then dispatch."""
+        """Resolve mode on first call with tools, then dispatch.
+
+        ``inbound_anthropic_body`` is accepted for protocol symmetry and
+        silently ignored — LlamafileClient only speaks OpenAI shape.
+        """
         if self.resolved_mode is None:
             return await self._resolve_and_send(messages, tools, sampling, passthrough)
         elif self.resolved_mode == "native":
@@ -280,8 +285,12 @@ class LlamafileClient:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
-        """Stream via SSE, handling both native FC and prompt-injected paths."""
+        """Stream via SSE, handling both native FC and prompt-injected paths.
+
+        ``inbound_anthropic_body`` accepted for protocol symmetry, ignored.
+        """
         if self.resolved_mode is None:
             # Probe with a non-streaming call to resolve native vs prompt.
             # Result is discarded — the runner will use the streamed response.

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -264,35 +264,37 @@ class LlamafileClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> LLMResponse:
         """Resolve mode on first call with tools, then dispatch."""
         if self.resolved_mode is None:
-            return await self._resolve_and_send(messages, tools, sampling)
+            return await self._resolve_and_send(messages, tools, sampling, passthrough)
         elif self.resolved_mode == "native":
-            return await self._send_native(messages, tools, sampling)
+            return await self._send_native(messages, tools, sampling, passthrough)
         else:
-            return await self._send_prompt(messages, tools, sampling)
+            return await self._send_prompt(messages, tools, sampling, passthrough)
 
     async def send_stream(
         self,
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Stream via SSE, handling both native FC and prompt-injected paths."""
         if self.resolved_mode is None:
             # Probe with a non-streaming call to resolve native vs prompt.
             # Result is discarded — the runner will use the streamed response.
-            await self._resolve_and_send(messages, tools, sampling)
+            await self._resolve_and_send(messages, tools, sampling, passthrough)
         mode = self.resolved_mode
 
-        model_name = (sampling or {}).get("model") or self.model
-        body: dict[str, Any] = {
-            "model": model_name,
+        body: dict[str, Any] = dict(passthrough or {})
+        body.update({
             "stream": True,
             "stream_options": {"include_usage": True},
             "cache_prompt": self._cache_prompt,
-        }
+        })
+        body.setdefault("model", self.model)
         self._apply_slot_id(body)
         self._apply_sampling(body, sampling)
 
@@ -439,6 +441,7 @@ class LlamafileClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> LLMResponse:
         """Auto-resolve mode on first send with tools.
 
@@ -451,30 +454,31 @@ class LlamafileClient:
         if not tools:
             # No tools to test with — send without tools, defer resolution
             self.resolved_mode = "native"
-            return await self._send_native(messages, tools, sampling)
+            return await self._send_native(messages, tools, sampling, passthrough)
 
         try:
-            result = await self._send_native(messages, tools, sampling)
+            result = await self._send_native(messages, tools, sampling, passthrough)
             self.resolved_mode = "native"
             return result
         except (httpx.HTTPStatusError, BackendError):
             self.resolved_mode = "prompt"
-            return await self._send_prompt(messages, tools, sampling)
+            return await self._send_prompt(messages, tools, sampling, passthrough)
 
     async def _send_native(
         self,
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> LLMResponse:
         """Send using native function calling (OpenAI tools parameter)."""
         merged = _merge_consecutive(messages)
-        model_name = (sampling or {}).get("model") or self.model
-        body: dict[str, Any] = {
-            "model": model_name,
+        body: dict[str, Any] = dict(passthrough or {})
+        body.update({
             "messages": merged,
             "cache_prompt": self._cache_prompt,
-        }
+        })
+        body.setdefault("model", self.model)
         self._apply_slot_id(body)
         self._apply_sampling(body, sampling)
         if tools:
@@ -526,6 +530,7 @@ class LlamafileClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> LLMResponse:
         """Send using prompt-injected tool calling."""
         prepared = _merge_consecutive(_downgrade_messages(messages))
@@ -536,12 +541,12 @@ class LlamafileClient:
                 "content": tool_prompt + "\n\n" + prepared[0]["content"],
             }
 
-        model_name = (sampling or {}).get("model") or self.model
-        body: dict[str, Any] = {
-            "model": model_name,
+        body: dict[str, Any] = dict(passthrough or {})
+        body.update({
             "messages": prepared,
             "cache_prompt": self._cache_prompt,
-        }
+        })
+        body.setdefault("model", self.model)
         self._apply_slot_id(body)
         self._apply_sampling(body, sampling)
 

--- a/src/forge/clients/ollama.py
+++ b/src/forge/clients/ollama.py
@@ -140,6 +140,7 @@ class OllamaClient:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> LLMResponse:
         """Send messages via /api/chat and parse the response.
 
@@ -147,6 +148,9 @@ class OllamaClient:
         plumbed — Ollama is not currently a proxy-side external backend
         (forge proxy uses LlamafileClient for external mode). Adding
         Ollama passthrough is a follow-up.
+
+        ``inbound_anthropic_body`` accepted for protocol symmetry, ignored
+        (Ollama is OpenAI-shape only).
         """
         body: dict[str, Any] = {
             "model": self.model,
@@ -206,10 +210,12 @@ class OllamaClient:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Stream via NDJSON from /api/chat.
 
-        ``passthrough`` accepted for protocol symmetry; see ``send`` notes.
+        ``passthrough`` / ``inbound_anthropic_body`` accepted for protocol
+        symmetry; see ``send`` notes.
         """
         body: dict[str, Any] = {
             "model": self.model,

--- a/src/forge/clients/ollama.py
+++ b/src/forge/clients/ollama.py
@@ -139,8 +139,15 @@ class OllamaClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> LLMResponse:
-        """Send messages via /api/chat and parse the response."""
+        """Send messages via /api/chat and parse the response.
+
+        ``passthrough`` is accepted for protocol symmetry but not yet
+        plumbed — Ollama is not currently a proxy-side external backend
+        (forge proxy uses LlamafileClient for external mode). Adding
+        Ollama passthrough is a follow-up.
+        """
         body: dict[str, Any] = {
             "model": self.model,
             "messages": messages,
@@ -198,8 +205,12 @@ class OllamaClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
-        """Stream via NDJSON from /api/chat."""
+        """Stream via NDJSON from /api/chat.
+
+        ``passthrough`` accepted for protocol symmetry; see ``send`` notes.
+        """
         body: dict[str, Any] = {
             "model": self.model,
             "messages": messages,

--- a/src/forge/core/inference.py
+++ b/src/forge/core/inference.py
@@ -119,6 +119,7 @@ async def run_inference(
     on_chunk: Callable[[StreamChunk], Awaitable[None]] | None = None,
     sampling: dict[str, Any] | None = None,
     passthrough: dict[str, Any] | None = None,
+    inbound_anthropic_body: dict[str, Any] | None = None,
 ) -> InferenceResult | None:
     """Send messages to the LLM with compaction, folding, validation, and retry.
 
@@ -166,6 +167,11 @@ async def run_inference(
         attempt_limit = min(attempt_limit, max_attempts)
     attempts = 0
 
+    # Path-1 verbatim opt-in: drop on any forge mutation (compaction,
+    # context warning, retry) so cache_control is only preserved on the
+    # clean first-attempt call. ADR-015.
+    verbatim_body = inbound_anthropic_body
+
     for _attempt in range(attempt_limit):
         attempts += 1
 
@@ -177,9 +183,12 @@ async def run_inference(
         if compacted is not messages:
             messages.clear()
             messages.extend(compacted)
+            verbatim_body = None  # mutation
 
         # Check context thresholds — inject warning if crossed
         context_warning = context_manager.check_thresholds(messages)
+        if context_warning:
+            verbatim_body = None  # mutation
 
         # Fold and serialize
         api_messages = fold_and_serialize(messages, api_format)
@@ -199,9 +208,17 @@ async def run_inference(
 
         # Send
         if stream:
-            response = await _send_streaming(client, api_messages, tool_specs, on_chunk, sampling, passthrough)
+            response = await _send_streaming(
+                client, api_messages, tool_specs, on_chunk, sampling, passthrough,
+                inbound_anthropic_body=verbatim_body,
+            )
         else:
-            response = await client.send(api_messages, tools=tool_specs, sampling=sampling, passthrough=passthrough)
+            response = await client.send(
+                api_messages, tools=tool_specs, sampling=sampling, passthrough=passthrough,
+                inbound_anthropic_body=verbatim_body,
+            )
+        # Subsequent attempts (retries) are mutations regardless of outcome.
+        verbatim_body = None
 
         # Update context manager with real token count if available.
         _sync_token_count(client, context_manager)
@@ -303,10 +320,14 @@ async def _send_streaming(
     on_chunk: Callable[[StreamChunk], Awaitable[None]] | None = None,
     sampling: dict[str, Any] | None = None,
     passthrough: dict[str, Any] | None = None,
+    inbound_anthropic_body: dict[str, Any] | None = None,
 ) -> LLMResponse:
     """Send via streaming, forwarding chunks to on_chunk callback."""
     response = None
-    async for chunk in client.send_stream(api_messages, tools=tool_specs, sampling=sampling, passthrough=passthrough):
+    async for chunk in client.send_stream(
+        api_messages, tools=tool_specs, sampling=sampling, passthrough=passthrough,
+        inbound_anthropic_body=inbound_anthropic_body,
+    ):
         if on_chunk is not None:
             await on_chunk(chunk)
         if chunk.type == ChunkType.FINAL:

--- a/src/forge/core/inference.py
+++ b/src/forge/core/inference.py
@@ -118,6 +118,7 @@ async def run_inference(
     stream: bool = False,
     on_chunk: Callable[[StreamChunk], Awaitable[None]] | None = None,
     sampling: dict[str, Any] | None = None,
+    passthrough: dict[str, Any] | None = None,
 ) -> InferenceResult | None:
     """Send messages to the LLM with compaction, folding, validation, and retry.
 
@@ -198,9 +199,9 @@ async def run_inference(
 
         # Send
         if stream:
-            response = await _send_streaming(client, api_messages, tool_specs, on_chunk, sampling)
+            response = await _send_streaming(client, api_messages, tool_specs, on_chunk, sampling, passthrough)
         else:
-            response = await client.send(api_messages, tools=tool_specs, sampling=sampling)
+            response = await client.send(api_messages, tools=tool_specs, sampling=sampling, passthrough=passthrough)
 
         # Update context manager with real token count if available.
         _sync_token_count(client, context_manager)
@@ -301,10 +302,11 @@ async def _send_streaming(
     tool_specs: list[ToolSpec],
     on_chunk: Callable[[StreamChunk], Awaitable[None]] | None = None,
     sampling: dict[str, Any] | None = None,
+    passthrough: dict[str, Any] | None = None,
 ) -> LLMResponse:
     """Send via streaming, forwarding chunks to on_chunk callback."""
     response = None
-    async for chunk in client.send_stream(api_messages, tools=tool_specs, sampling=sampling):
+    async for chunk in client.send_stream(api_messages, tools=tool_specs, sampling=sampling, passthrough=passthrough):
         if on_chunk is not None:
             await on_chunk(chunk)
         if chunk.type == ChunkType.FINAL:

--- a/src/forge/proxy/__main__.py
+++ b/src/forge/proxy/__main__.py
@@ -48,6 +48,14 @@ def main() -> None:
         help="Function-calling mode (default: native). Use 'prompt' for "
              "OpenAI-compatible backends without a function-calling template.",
     )
+    parser.add_argument(
+        "--backend-protocol",
+        choices=["openai", "anthropic"],
+        default="openai",
+        help="Wire format of the external backend (default: openai). Use "
+             "'anthropic' for Anthropic-shape downstreams (LiteLLM /v1/messages, "
+             "real Anthropic API, self-hosted Anthropic proxy). External mode only.",
+    )
 
     # Proxy options
     parser.add_argument("--host", default="127.0.0.1", help="Proxy listen host (default: 127.0.0.1)")
@@ -90,6 +98,7 @@ def main() -> None:
         max_retries=args.max_retries,
         rescue_enabled=not args.no_rescue,
         mode=args.mode,
+        backend_protocol=args.backend_protocol,
     )
 
     def _shutdown(sig: int, _frame: object) -> None:

--- a/src/forge/proxy/__main__.py
+++ b/src/forge/proxy/__main__.py
@@ -41,6 +41,13 @@ def main() -> None:
     )
     parser.add_argument("--budget-tokens", type=int, help="Manual token budget")
     parser.add_argument("--extra-flags", nargs="*", help="Additional backend CLI flags")
+    parser.add_argument(
+        "--mode",
+        choices=["native", "prompt"],
+        default="native",
+        help="Function-calling mode (default: native). Use 'prompt' for "
+             "OpenAI-compatible backends without a function-calling template.",
+    )
 
     # Proxy options
     parser.add_argument("--host", default="127.0.0.1", help="Proxy listen host (default: 127.0.0.1)")
@@ -82,6 +89,7 @@ def main() -> None:
         serialize=serialize,
         max_retries=args.max_retries,
         rescue_enabled=not args.no_rescue,
+        mode=args.mode,
     )
 
     def _shutdown(sig: int, _frame: object) -> None:

--- a/src/forge/proxy/convert_anthropic.py
+++ b/src/forge/proxy/convert_anthropic.py
@@ -1,0 +1,387 @@
+"""Convert between Anthropic Messages API format and forge Messages.
+
+Mirrors convert.py's shape: inbound parser + outbound emitter + SSE helpers.
+Used by the proxy's /v1/messages route.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from forge.core.messages import Message, MessageMeta, MessageRole, MessageType, ToolCallInfo
+from forge.core.workflow import ToolCall, ToolSpec
+
+
+# ── Inbound: Anthropic request → forge Messages ──────────────────
+
+def anthropic_to_messages(
+    anthropic_messages: list[dict[str, Any]],
+    system: str | list[dict[str, Any]] | None = None,
+) -> list[Message]:
+    """Convert Anthropic messages + system to forge Message objects.
+
+    The Anthropic protocol carries ``system`` as a top-level field (string
+    or list of content blocks); forge represents it as a SYSTEM-role message
+    prepended to the conversation.
+
+    Content blocks: ``text`` → string; ``tool_use`` → ToolCallInfo on the
+    assistant message; ``tool_result`` → role=tool message; ``thinking`` /
+    ``document`` / ``image`` → dropped (no forge analog today).
+    """
+    messages: list[Message] = []
+
+    if system:
+        sys_text = _flatten_text_blocks(system) if isinstance(system, list) else system
+        if sys_text:
+            messages.append(Message(
+                MessageRole.SYSTEM,
+                sys_text,
+                MessageMeta(MessageType.SYSTEM_PROMPT),
+            ))
+
+    for msg in anthropic_messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+
+        if isinstance(content, str):
+            if role == "assistant":
+                messages.append(Message(
+                    MessageRole.ASSISTANT,
+                    content,
+                    MessageMeta(MessageType.TEXT_RESPONSE),
+                ))
+            else:
+                messages.append(Message(
+                    MessageRole.USER,
+                    content,
+                    MessageMeta(MessageType.USER_INPUT),
+                ))
+            continue
+
+        # content is a list of blocks
+        text_parts: list[str] = []
+        tool_calls: list[ToolCallInfo] = []
+        tool_results: list[tuple[str, str, str]] = []  # (tool_use_id, name, content)
+
+        for block in content:
+            btype = block.get("type")
+            if btype == "text":
+                text_parts.append(block.get("text", ""))
+            elif btype == "tool_use":
+                tc_args = block.get("input", {})
+                tool_calls.append(ToolCallInfo(
+                    name=block.get("name", ""),
+                    args=tc_args if isinstance(tc_args, dict) else {},
+                    call_id=block.get("id", f"toolu_{uuid.uuid4().hex[:12]}"),
+                ))
+            elif btype == "tool_result":
+                tr_content = block.get("content", "")
+                if isinstance(tr_content, list):
+                    tr_content = _flatten_text_blocks(tr_content)
+                tool_results.append((
+                    block.get("tool_use_id", ""),
+                    "",  # Anthropic tool_result doesn't carry the tool name
+                    str(tr_content),
+                ))
+            # thinking, image, document, etc. → dropped
+
+        text = "\n".join(p for p in text_parts if p)
+
+        if role == "assistant" and tool_calls:
+            messages.append(Message(
+                MessageRole.ASSISTANT,
+                text,
+                MessageMeta(MessageType.TOOL_CALL),
+                tool_calls=tool_calls,
+            ))
+        elif role == "assistant":
+            messages.append(Message(
+                MessageRole.ASSISTANT,
+                text,
+                MessageMeta(MessageType.TEXT_RESPONSE),
+            ))
+        elif role == "user" and tool_results:
+            # Anthropic packs tool_results inside user messages; forge splits
+            # them into separate role=tool messages.
+            for tc_id, tname, tcontent in tool_results:
+                messages.append(Message(
+                    MessageRole.TOOL,
+                    tcontent,
+                    MessageMeta(MessageType.TOOL_RESULT),
+                    tool_name=tname,
+                    tool_call_id=tc_id,
+                ))
+            if text:
+                messages.append(Message(
+                    MessageRole.USER,
+                    text,
+                    MessageMeta(MessageType.USER_INPUT),
+                ))
+        else:
+            messages.append(Message(
+                MessageRole.USER,
+                text,
+                MessageMeta(MessageType.USER_INPUT),
+            ))
+
+    return messages
+
+
+def anthropic_tools_to_specs(tools: list[dict[str, Any]] | None) -> list[ToolSpec]:
+    """Anthropic tools array → forge ToolSpec list.
+
+    Anthropic shape: ``{"name", "description", "input_schema"}``.
+    """
+    if not tools:
+        return []
+    specs = []
+    for tool in tools:
+        name = tool.get("name", "")
+        if not name:
+            continue
+        specs.append(ToolSpec.from_json_schema(
+            name=name,
+            description=tool.get("description", ""),
+            schema=tool.get("input_schema", {}),
+        ))
+    return specs
+
+
+def anthropic_tool_choice_to_openai(tc: Any) -> Any:
+    """Translate Anthropic tool_choice to OpenAI tool_choice shape.
+
+    Anthropic: ``{type:"auto"|"any"|"none"|"tool", name?:"X"}``.
+    OpenAI: ``"auto"|"required"|"none"|{type:"function", function:{name:"X"}}``.
+    """
+    if not isinstance(tc, dict):
+        return tc
+    t = tc.get("type")
+    if t == "auto":
+        return "auto"
+    if t == "any":
+        return "required"
+    if t == "none":
+        return "none"
+    if t == "tool":
+        return {"type": "function", "function": {"name": tc.get("name", "")}}
+    return tc
+
+
+def anthropic_to_openai_passthrough(body: dict[str, Any]) -> dict[str, Any]:
+    """Build the OpenAI-shape passthrough body from an Anthropic inbound body.
+
+    Output is what the handler passes via ``passthrough`` to the OpenAI-
+    shape client (LlamafileClient) on path 2. Translates field names +
+    tool_choice/stop_sequences shapes. Excludes fields forge owns
+    (``messages``, ``tools``, ``system``, ``stream``) — those flow through
+    forge's normal parsing. Excludes Anthropic-only fields without an
+    OpenAI analog (``cache_control`` lives on blocks; ``thinking``,
+    ``metadata``, ``service_tier`` have no analog) — they drop here for
+    path 2 and are preserved via ``inbound_anthropic_body`` on path 1
+    (see ADR-015).
+    """
+    out: dict[str, Any] = {}
+
+    if "model" in body:
+        out["model"] = body["model"]
+    if "max_tokens" in body:
+        out["max_tokens"] = body["max_tokens"]
+    if "temperature" in body:
+        out["temperature"] = body["temperature"]
+    if "top_p" in body:
+        out["top_p"] = body["top_p"]
+    if "top_k" in body:
+        out["top_k"] = body["top_k"]
+
+    if "stop_sequences" in body:
+        out["stop"] = body["stop_sequences"]
+
+    if "tool_choice" in body:
+        out["tool_choice"] = anthropic_tool_choice_to_openai(body["tool_choice"])
+
+    return out
+
+
+def _flatten_text_blocks(blocks: list[dict[str, Any]] | str) -> str:
+    """Concatenate text from a list of content blocks. Non-text blocks dropped."""
+    if isinstance(blocks, str):
+        return blocks
+    parts = []
+    for b in blocks:
+        if isinstance(b, dict) and b.get("type") == "text":
+            parts.append(b.get("text", ""))
+        elif isinstance(b, str):
+            parts.append(b)
+    return "\n".join(p for p in parts if p)
+
+
+# ── Outbound: forge response → Anthropic response ────────────────
+
+def tool_calls_to_anthropic(
+    tool_calls: list[ToolCall],
+    model: str = "forge",
+) -> dict[str, Any]:
+    """Convert forge ToolCalls to an Anthropic Messages API response object."""
+    blocks: list[dict[str, Any]] = []
+
+    if tool_calls and tool_calls[0].reasoning:
+        blocks.append({"type": "text", "text": tool_calls[0].reasoning})
+
+    for tc in tool_calls:
+        blocks.append({
+            "type": "tool_use",
+            "id": f"toolu_{uuid.uuid4().hex[:24]}",
+            "name": tc.tool,
+            "input": tc.args,
+        })
+
+    return {
+        "id": f"msg_{uuid.uuid4().hex[:24]}",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": blocks,
+        "stop_reason": "tool_use",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
+
+
+def text_response_to_anthropic(
+    text: str,
+    model: str = "forge",
+) -> dict[str, Any]:
+    """Convert a text response to an Anthropic Messages API response object."""
+    return {
+        "id": f"msg_{uuid.uuid4().hex[:24]}",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": text}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
+
+
+# ── SSE event builders ───────────────────────────────────────────
+
+def tool_calls_to_anthropic_sse(
+    tool_calls: list[ToolCall],
+    model: str = "forge",
+) -> list[dict[str, Any]]:
+    """Build the Anthropic SSE event sequence for a tool-use response.
+
+    Each returned dict carries a top-level ``type`` field; the SSE wire
+    formatter reads that to emit ``event: <type>`` lines. Spec:
+    https://platform.claude.com/docs/en/build-with-claude/streaming
+    """
+    msg_id = f"msg_{uuid.uuid4().hex[:24]}"
+    events: list[dict[str, Any]] = []
+
+    events.append({
+        "type": "message_start",
+        "message": {
+            "id": msg_id,
+            "type": "message",
+            "role": "assistant",
+            "model": model,
+            "content": [],
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": {"input_tokens": 0, "output_tokens": 1},
+        },
+    })
+
+    block_idx = 0
+
+    # Reasoning text first, if present.
+    reasoning = tool_calls[0].reasoning if tool_calls else None
+    if reasoning:
+        events.append({
+            "type": "content_block_start",
+            "index": block_idx,
+            "content_block": {"type": "text", "text": ""},
+        })
+        events.append({
+            "type": "content_block_delta",
+            "index": block_idx,
+            "delta": {"type": "text_delta", "text": reasoning},
+        })
+        events.append({"type": "content_block_stop", "index": block_idx})
+        block_idx += 1
+
+    # One tool_use block per call.
+    for tc in tool_calls:
+        tc_id = f"toolu_{uuid.uuid4().hex[:24]}"
+        events.append({
+            "type": "content_block_start",
+            "index": block_idx,
+            "content_block": {
+                "type": "tool_use",
+                "id": tc_id,
+                "name": tc.tool,
+                "input": {},
+            },
+        })
+        events.append({
+            "type": "content_block_delta",
+            "index": block_idx,
+            "delta": {
+                "type": "input_json_delta",
+                "partial_json": json.dumps(tc.args),
+            },
+        })
+        events.append({"type": "content_block_stop", "index": block_idx})
+        block_idx += 1
+
+    events.append({
+        "type": "message_delta",
+        "delta": {"stop_reason": "tool_use", "stop_sequence": None},
+        "usage": {"output_tokens": 0},
+    })
+    events.append({"type": "message_stop"})
+
+    return events
+
+
+def text_to_anthropic_sse(
+    text: str,
+    model: str = "forge",
+) -> list[dict[str, Any]]:
+    """Build the Anthropic SSE event sequence for a text response."""
+    msg_id = f"msg_{uuid.uuid4().hex[:24]}"
+    return [
+        {
+            "type": "message_start",
+            "message": {
+                "id": msg_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 0, "output_tokens": 1},
+            },
+        },
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": text},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 0},
+        },
+        {"type": "message_stop"},
+    ]

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import json
 import logging
-from typing import Any
+from typing import Any, Literal
 
 from forge.clients.base import LLMClient
 from forge.context.manager import ContextManager
@@ -19,22 +18,35 @@ from forge.proxy.convert import (
     text_response_to_openai,
     text_to_sse_events,
 )
+from forge.proxy.convert_anthropic import (
+    anthropic_to_messages,
+    anthropic_to_openai_passthrough,
+    anthropic_tools_to_specs,
+    tool_calls_to_anthropic,
+    tool_calls_to_anthropic_sse,
+    text_response_to_anthropic,
+    text_to_anthropic_sse,
+)
 from forge.tools.respond import RESPOND_TOOL_NAME, respond_spec
 
 logger = logging.getLogger("forge.proxy")
 
 
-# OpenAI-compatible top-level body fields plumbed from inbound body to
-# client. llama-server / Ollama support the sampling fields below as
-# top-level body / options fields. Anthropic ignores them.
-# ``chat_template_kwargs`` is a nested dict of Jinja template variables
-# (e.g. {"reasoning_effort": "high"}) — passed through to the LlamafileClient
-# as part of the ``sampling`` kwarg; OllamaClient drops it (no analog field).
+# OpenAI-compatible sampling fields plumbed from inbound to the client.
+# llama-server / Ollama accept these as top-level body / options fields.
+# Anthropic ignores them. ``chat_template_kwargs`` is a nested dict of
+# Jinja template variables (e.g. {"reasoning_effort": "high"}) — passed
+# through as part of ``sampling``; clients that don't understand it drop it.
+# Everything else in the inbound body rides through via ``passthrough`` —
+# the client merges it into its outbound body verbatim.
 _SAMPLING_FIELDS = (
     "temperature", "top_p", "top_k", "min_p",
     "repeat_penalty", "presence_penalty", "seed",
-    "chat_template_kwargs", "model",
+    "chat_template_kwargs",
 )
+
+# Body fields forge owns and reasons about — never go into passthrough.
+_FORGE_OWNED = frozenset({"messages", "tools", "stream", "system"})
 
 
 def _extract_sampling(body: dict[str, Any]) -> dict[str, Any] | None:
@@ -45,6 +57,22 @@ def _extract_sampling(body: dict[str, Any]) -> dict[str, Any] | None:
     """
     extracted = {f: body[f] for f in _SAMPLING_FIELDS if f in body}
     return extracted or None
+
+
+def _extract_passthrough(body: dict[str, Any]) -> dict[str, Any] | None:
+    """Pull non-forge-owned, non-sampling fields for the passthrough channel.
+
+    Everything that isn't ``messages``/``tools``/``stream``/``system`` and
+    isn't already in the sampling extraction flows to the outbound body
+    unchanged. Lets the proxy honor user-set ``max_tokens``, ``stop``,
+    ``tool_choice``, ``model``, etc. without forge needing to enumerate
+    every supported field.
+    """
+    extras = {
+        k: v for k, v in body.items()
+        if k not in _FORGE_OWNED and k not in _SAMPLING_FIELDS
+    }
+    return extras or None
 
 
 def _extract_tool_specs(request_tools: list[dict[str, Any]] | None) -> list[ToolSpec]:
@@ -78,11 +106,13 @@ async def handle_chat_completions(
     context_manager: ContextManager,
     max_retries: int = 3,
     rescue_enabled: bool = True,
+    protocol: Literal["openai", "anthropic"] = "openai",
 ) -> dict[str, Any] | list[dict[str, Any]]:
-    """Handle a /v1/chat/completions request.
+    """Handle an inbound completions request.
 
-    Converts inbound OpenAI messages to forge Messages, runs inference
-    with guardrails, and converts the result back to OpenAI format.
+    Converts inbound messages to forge Messages, runs inference with
+    guardrails, and converts the result back to the inbound protocol's
+    shape.
 
     Args:
         body: Parsed JSON request body.
@@ -90,20 +120,33 @@ async def handle_chat_completions(
         context_manager: For context compaction.
         max_retries: Max consecutive retries for bad responses.
         rescue_enabled: Whether to attempt rescue parsing.
+        protocol: Inbound wire format. ``openai`` for
+            ``/v1/chat/completions``; ``anthropic`` for ``/v1/messages``.
 
     Returns:
-        If stream=false: a single OpenAI response dict.
-        If stream=true: a list of SSE chunk dicts.
+        If stream=false: a single response dict (protocol-shaped).
+        If stream=true: a list of SSE event dicts (protocol-shaped).
     """
-    openai_messages = body.get("messages", [])
-    request_tools = body.get("tools")
     is_stream = body.get("stream", False)
     model_name = body.get("model", "forge")
-    sampling = _extract_sampling(body)
 
-    # Convert inbound
-    messages = openai_to_messages(openai_messages)
-    tool_specs = _extract_tool_specs(request_tools)
+    # Inbound parse + sampling/passthrough extraction (protocol-specific)
+    if protocol == "anthropic":
+        messages = anthropic_to_messages(
+            body.get("messages", []),
+            body.get("system"),
+        )
+        tool_specs = anthropic_tools_to_specs(body.get("tools"))
+        # Anthropic inbound's sampling fields don't overlap with the OpenAI
+        # sampling set; the translated passthrough carries them in OpenAI
+        # shape for the (OpenAI-shape) backend client.
+        sampling = None
+        passthrough = anthropic_to_openai_passthrough(body) or None
+    else:
+        messages = openai_to_messages(body.get("messages", []))
+        tool_specs = _extract_tool_specs(body.get("tools"))
+        sampling = _extract_sampling(body)
+        passthrough = _extract_passthrough(body)
 
     # Inject respond tool when tools are present.  The model calls
     # respond(message="...") instead of producing bare text, keeping it
@@ -120,11 +163,11 @@ async def handle_chat_completions(
         logger.info("No tools in request, passing through to backend")
         api_format = getattr(client, "api_format", "ollama")
         api_messages = fold_and_serialize(messages, api_format)
-        response = await client.send(api_messages, tools=None, sampling=sampling)
+        response = await client.send(
+            api_messages, tools=None, sampling=sampling, passthrough=passthrough,
+        )
         text = response.content if isinstance(response, TextResponse) else ""
-        if is_stream:
-            return text_to_sse_events(text, model=model_name)
-        return text_response_to_openai(text, model=model_name)
+        return _emit_text(text, model_name, protocol, is_stream)
 
     # Set up guardrails
     validator = ResponseValidator(tool_names, rescue_enabled=rescue_enabled)
@@ -140,6 +183,7 @@ async def handle_chat_completions(
             error_tracker=error_tracker,
             tool_specs=tool_specs,
             sampling=sampling,
+            passthrough=passthrough,
         )
     except ToolCallError as exc:
         # Retries exhausted — the model kept returning text instead of tool
@@ -147,21 +191,18 @@ async def handle_chat_completions(
         # error. The client's own agentic loop can decide what to do.
         raw = exc.raw_response or ""
         logger.warning("Retries exhausted, passing through text: %.120s", raw)
-        if is_stream:
-            return text_to_sse_events(raw, model=model_name)
-        return text_response_to_openai(raw, model=model_name)
+        return _emit_text(raw, model_name, protocol, is_stream)
 
     # run_inference returns None when max_attempts exhausted
     if result is None:
-        if is_stream:
-            return text_to_sse_events("", model=model_name)
-        return text_response_to_openai("", model=model_name)
+        return _emit_text("", model_name, protocol, is_stream)
 
     tool_calls = result.response
 
     # Strip respond() calls — convert to plain text for the client.
     # If the model called respond(message="..."), the client sees a
-    # normal text response (finish_reason="stop"), not a tool call.
+    # normal text response (stop_reason/finish_reason indicates "stop"),
+    # not a tool call.
     respond_calls = [tc for tc in tool_calls if tc.tool == RESPOND_TOOL_NAME]
     other_calls = [tc for tc in tool_calls if tc.tool != RESPOND_TOOL_NAME]
 
@@ -169,18 +210,44 @@ async def handle_chat_completions(
         # Pure respond — convert to text
         text = respond_calls[0].args.get("message", "")
         logger.info("Stripping respond() call, returning as text")
-        if is_stream:
-            return text_to_sse_events(text, model=model_name)
-        return text_response_to_openai(text, model=model_name)
+        return _emit_text(text, model_name, protocol, is_stream)
 
     if other_calls:
         # Real tool calls (possibly mixed with respond) — return the
         # real tool calls only, drop respond.
-        if is_stream:
-            return tool_calls_to_sse_events(other_calls, model=model_name)
-        return tool_calls_to_openai(other_calls, model=model_name)
+        return _emit_tool_calls(other_calls, model_name, protocol, is_stream)
 
     # Shouldn't happen, but handle empty tool_calls gracefully
+    return _emit_text("", model_name, protocol, is_stream)
+
+
+def _emit_text(
+    text: str,
+    model: str,
+    protocol: str,
+    is_stream: bool,
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Protocol-aware text response emitter."""
+    if protocol == "anthropic":
+        if is_stream:
+            return text_to_anthropic_sse(text, model=model)
+        return text_response_to_anthropic(text, model=model)
     if is_stream:
-        return text_to_sse_events("", model=model_name)
-    return text_response_to_openai("", model=model_name)
+        return text_to_sse_events(text, model=model)
+    return text_response_to_openai(text, model=model)
+
+
+def _emit_tool_calls(
+    tool_calls: list[ToolCall],
+    model: str,
+    protocol: str,
+    is_stream: bool,
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Protocol-aware tool-call response emitter."""
+    if protocol == "anthropic":
+        if is_stream:
+            return tool_calls_to_anthropic_sse(tool_calls, model=model)
+        return tool_calls_to_anthropic(tool_calls, model=model)
+    if is_stream:
+        return tool_calls_to_sse_events(tool_calls, model=model)
+    return tool_calls_to_openai(tool_calls, model=model)

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -142,11 +142,17 @@ async def handle_chat_completions(
         # shape for the (OpenAI-shape) backend client.
         sampling = None
         passthrough = anthropic_to_openai_passthrough(body) or None
+        # Path-1 cache_control opt-in. The Anthropic client uses this when
+        # the runner hasn't mutated messages (clean first-attempt call);
+        # OpenAI-shape clients (LlamafileClient) accept and ignore. See
+        # ADR-015.
+        inbound_anthropic_body = body
     else:
         messages = openai_to_messages(body.get("messages", []))
         tool_specs = _extract_tool_specs(body.get("tools"))
         sampling = _extract_sampling(body)
         passthrough = _extract_passthrough(body)
+        inbound_anthropic_body = None
 
     # Inject respond tool when tools are present.  The model calls
     # respond(message="...") instead of producing bare text, keeping it
@@ -165,6 +171,7 @@ async def handle_chat_completions(
         api_messages = fold_and_serialize(messages, api_format)
         response = await client.send(
             api_messages, tools=None, sampling=sampling, passthrough=passthrough,
+            inbound_anthropic_body=inbound_anthropic_body,
         )
         text = response.content if isinstance(response, TextResponse) else ""
         return _emit_text(text, model_name, protocol, is_stream)
@@ -184,6 +191,7 @@ async def handle_chat_completions(
             tool_specs=tool_specs,
             sampling=sampling,
             passthrough=passthrough,
+            inbound_anthropic_body=inbound_anthropic_body,
         )
     except ToolCallError as exc:
         # Retries exhausted — the model kept returning text instead of tool

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from forge.clients.base import LLMClient
 from forge.clients.llamafile import LlamafileClient
@@ -59,6 +59,7 @@ class ProxyServer:
         serialize: bool | None = None,
         max_retries: int = 3,
         rescue_enabled: bool = True,
+        mode: Literal["native", "prompt"] = "native",
     ) -> None:
         """
         Args:
@@ -76,6 +77,10 @@ class ProxyServer:
                 managed, False for external).
             max_retries: Max consecutive retries for bad LLM responses.
             rescue_enabled: Attempt rescue parsing of text responses.
+            mode: Function-calling mode for OpenAI-compatible backends —
+                "native" uses the backend's native tools API, "prompt"
+                uses forge's prompt-injection fallback for backends
+                without a function-calling template.
         """
         if backend_url is None and backend is None:
             raise ValueError("Provide either backend_url (external) or backend (managed)")
@@ -92,6 +97,7 @@ class ProxyServer:
         self._port = port
         self._max_retries = max_retries
         self._rescue_enabled = rescue_enabled
+        self._mode = mode
 
         # Auto-detect serialization: managed = single GPU = serialize
         if serialize is None:
@@ -169,7 +175,7 @@ class ProxyServer:
             client = LlamafileClient(
                 gguf_path=self._model or "default",
                 base_url=base,
-                mode="native",
+                mode=self._mode,
             )
             if self._budget_tokens is not None:
                 budget = self._budget_tokens
@@ -191,7 +197,7 @@ class ProxyServer:
                 client = LlamafileClient(
                     gguf_path=self._gguf or "default",
                     base_url=f"http://localhost:{self._backend_port}/v1",
-                    mode="native",
+                    mode=self._mode,
                 )
 
             server_mgr = ServerManager(

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -13,7 +13,6 @@ import threading
 from pathlib import Path
 from typing import Any, Literal
 
-from forge.clients.anthropic import AnthropicClient
 from forge.clients.base import LLMClient
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
@@ -191,6 +190,17 @@ class ProxyServer:
                 # AnthropicClient handles base_url and SDK retries; forge
                 # guardrails wrap its inference loop the same way they
                 # wrap any other client.
+                # Lazy import: the anthropic SDK is an optional dependency
+                # (forge-guardrails[anthropic]). Only Path 1 needs it, so
+                # Path 2 / local-backend users must not be forced to install
+                # it just to start the proxy.
+                try:
+                    from forge.clients.anthropic import AnthropicClient
+                except ImportError as exc:
+                    raise RuntimeError(
+                        "backend_protocol='anthropic' requires the anthropic SDK. "
+                        "Install it with: pip install 'forge-guardrails[anthropic]'"
+                    ) from exc
                 client = AnthropicClient(
                     model=self._model or "claude",
                     base_url=self._backend_url.rstrip("/"),

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -13,6 +13,7 @@ import threading
 from pathlib import Path
 from typing import Any, Literal
 
+from forge.clients.anthropic import AnthropicClient
 from forge.clients.base import LLMClient
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
@@ -60,6 +61,7 @@ class ProxyServer:
         max_retries: int = 3,
         rescue_enabled: bool = True,
         mode: Literal["native", "prompt"] = "native",
+        backend_protocol: Literal["openai", "anthropic"] = "openai",
     ) -> None:
         """
         Args:
@@ -81,9 +83,26 @@ class ProxyServer:
                 "native" uses the backend's native tools API, "prompt"
                 uses forge's prompt-injection fallback for backends
                 without a function-calling template.
+            backend_protocol: Wire format of the external backend.
+                ``openai`` (default) for llama.cpp, vLLM, Ollama. ``anthropic``
+                for Anthropic-shape downstreams (the official Anthropic API,
+                LiteLLM's /v1/messages, a self-hosted Anthropic proxy).
+                Only meaningful in external mode; ignored in managed mode.
         """
         if backend_url is None and backend is None:
             raise ValueError("Provide either backend_url (external) or backend (managed)")
+        if backend_protocol == "anthropic" and mode == "prompt":
+            raise ValueError(
+                "mode='prompt' is not supported with backend_protocol='anthropic' — "
+                "Anthropic protocol has native tool calling; the prompt-injection "
+                "fallback only applies to OpenAI-shape backends without a function-"
+                "calling template."
+            )
+        if backend_protocol == "anthropic" and backend_url is None:
+            raise ValueError(
+                "backend_protocol='anthropic' requires external mode (backend_url=...). "
+                "Managed mode launches local llama.cpp / Ollama, which only speak OpenAI."
+            )
 
         self._backend_url = backend_url
         self._backend = backend
@@ -98,6 +117,7 @@ class ProxyServer:
         self._max_retries = max_retries
         self._rescue_enabled = rescue_enabled
         self._mode = mode
+        self._backend_protocol = backend_protocol
 
         # Auto-detect serialization: managed = single GPU = serialize
         if serialize is None:
@@ -164,25 +184,38 @@ class ProxyServer:
         context_manager: ContextManager
 
         if self._backend_url is not None:
-            # External mode — connect to existing backend
-            # LlamafileClient expects base_url with /v1 suffix
-            base = self._backend_url.rstrip("/")
-            if not base.endswith("/v1"):
-                base = base + "/v1"
-            # External mode: caller manages the backend, so we don't have a
-            # GGUF path. "default" is a placeholder identity for the wire
-            # model field (llama-server ignores it) and JSONL model field.
-            client = LlamafileClient(
-                gguf_path=self._model or "default",
-                base_url=base,
-                mode=self._mode,
-            )
-            if self._budget_tokens is not None:
-                budget = self._budget_tokens
+            # External mode — connect to existing backend.
+            if self._backend_protocol == "anthropic":
+                # Path 1 — downstream speaks Anthropic Messages API
+                # (LiteLLM /v1/messages, real Anthropic, self-hosted proxy).
+                # AnthropicClient handles base_url and SDK retries; forge
+                # guardrails wrap its inference loop the same way they
+                # wrap any other client.
+                client = AnthropicClient(
+                    model=self._model or "claude",
+                    base_url=self._backend_url.rstrip("/"),
+                )
+                budget = self._budget_tokens or await client.get_context_length() or 8192
             else:
-                # Try to auto-detect from backend /props
-                ctx_len = await client.get_context_length()
-                budget = ctx_len if ctx_len is not None else 8192
+                # Path 2 / default — OpenAI-shape downstream.
+                # LlamafileClient expects base_url with /v1 suffix.
+                base = self._backend_url.rstrip("/")
+                if not base.endswith("/v1"):
+                    base = base + "/v1"
+                # External mode: caller manages the backend, so we don't have a
+                # GGUF path. "default" is a placeholder identity for the wire
+                # model field (llama-server ignores it) and JSONL model field.
+                client = LlamafileClient(
+                    gguf_path=self._model or "default",
+                    base_url=base,
+                    mode=self._mode,
+                )
+                if self._budget_tokens is not None:
+                    budget = self._budget_tokens
+                else:
+                    # Try to auto-detect from backend /props
+                    ctx_len = await client.get_context_length()
+                    budget = ctx_len if ctx_len is not None else 8192
             context_manager = ContextManager(
                 strategy=TieredCompact(),
                 budget_tokens=budget,

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -28,6 +28,7 @@ class _QueueItem:
     """A request waiting to be processed by the inference worker."""
 
     body: dict[str, Any]
+    protocol: str = "openai"
     future: asyncio.Future = field(default_factory=lambda: asyncio.get_event_loop().create_future())
     cancelled: bool = False
 
@@ -90,7 +91,7 @@ class HTTPServer:
                 if item.cancelled or item.future.cancelled():
                     logger.info("   Skipping cancelled request")
                     continue
-                result = await self._run_handler(item.body)
+                result = await self._run_handler(item.body, item.protocol)
                 if not item.future.done():
                     item.future.set_result(result)
             except asyncio.CancelledError:
@@ -144,7 +145,9 @@ class HTTPServer:
             elif method == "GET" and path == "/v1/models":
                 await self._handle_models(writer)
             elif method == "POST" and path == "/v1/chat/completions":
-                await self._handle_completions(writer, body_bytes)
+                await self._handle_completions(writer, body_bytes, protocol="openai")
+            elif method == "POST" and path == "/v1/messages":
+                await self._handle_completions(writer, body_bytes, protocol="anthropic")
             elif method == "OPTIONS":
                 await self._send_cors_preflight(writer)
             else:
@@ -195,8 +198,9 @@ class HTTPServer:
         self,
         writer: asyncio.StreamWriter,
         body_bytes: bytes,
+        protocol: str = "openai",
     ) -> None:
-        """POST /v1/chat/completions — the main proxy endpoint."""
+        """POST /v1/chat/completions (or /v1/messages) — the main proxy endpoint."""
         try:
             body = json.loads(body_bytes)
         except json.JSONDecodeError:
@@ -207,13 +211,13 @@ class HTTPServer:
         msg_count = len(body.get("messages", []))
         tool_count = len(body.get("tools", []))
         logger.info(
-            "   stream=%s messages=%d tools=%d model=%s",
-            is_stream, msg_count, tool_count, body.get("model", "?"),
+            "   proto=%s stream=%s messages=%d tools=%d model=%s",
+            protocol, is_stream, msg_count, tool_count, body.get("model", "?"),
         )
 
         if self._serialize:
             # Queue the request and wait for the worker to process it
-            item = _QueueItem(body=body)
+            item = _QueueItem(body=body, protocol=protocol)
             queue_depth = self._queue.qsize()
             if queue_depth > 0:
                 logger.info("   Queued (depth=%d)", queue_depth + 1)
@@ -230,7 +234,7 @@ class HTTPServer:
         else:
             if is_stream:
                 await self._send_sse_header(writer)
-            result = await self._run_handler(body)
+            result = await self._run_handler(body, protocol)
 
         if result is None:
             # Client disconnected
@@ -241,14 +245,14 @@ class HTTPServer:
             error_msg = str(result)
             logger.info("<< ERROR: %s", error_msg[:120])
             if is_stream:
-                await self._send_sse_body(writer, [{"error": error_msg}])
+                await self._send_sse_body(writer, [{"error": error_msg}], protocol=protocol)
             else:
                 await self._send_error(writer, 502, error_msg)
             return
 
         if is_stream:
             logger.info("<< SSE %d events", len(result))
-            await self._send_sse_body(writer, result)
+            await self._send_sse_body(writer, result, protocol=protocol)
         else:
             logger.info("<< JSON 200")
             await self._send_json(writer, 200, json.dumps(result))
@@ -276,7 +280,7 @@ class HTTPServer:
         return item.future.result()
 
     async def _run_handler(
-        self, body: dict[str, Any],
+        self, body: dict[str, Any], protocol: str = "openai",
     ) -> dict[str, Any] | list[dict[str, Any]] | Exception:
         """Run the handler, catching errors."""
         try:
@@ -286,6 +290,7 @@ class HTTPServer:
                 context_manager=self._context_manager,
                 max_retries=self._max_retries,
                 rescue_enabled=self._rescue_enabled,
+                protocol=protocol,
             )
         except Exception as exc:
             logger.exception("Handler error")
@@ -322,22 +327,39 @@ class HTTPServer:
         await writer.drain()
 
     async def _send_sse_body(
-        self, writer: asyncio.StreamWriter, events: list[dict[str, Any]],
+        self,
+        writer: asyncio.StreamWriter,
+        events: list[dict[str, Any]],
+        protocol: str = "openai",
     ) -> None:
-        """Send SSE event data and terminator. Headers must already be sent."""
+        """Send SSE event data and terminator. Headers must already be sent.
+
+        OpenAI wire format: ``data: {json}\\n\\n`` per event, terminated by
+        ``data: [DONE]\\n\\n``.
+
+        Anthropic wire format: ``event: <type>\\ndata: {json}\\n\\n`` per
+        event (type read from the event's top-level ``type`` field). No
+        ``[DONE]`` terminator — the ``message_stop`` event ends the stream.
+        """
         for event in events:
             if writer.is_closing():
                 return
-            data = f"data: {json.dumps(event)}\n\n".encode()
-            writer.write(f"{len(data):x}\r\n".encode() + data + b"\r\n")
+            if protocol == "anthropic":
+                event_type = event.get("type", "")
+                payload = f"event: {event_type}\ndata: {json.dumps(event)}\n\n".encode()
+            else:
+                payload = f"data: {json.dumps(event)}\n\n".encode()
+            writer.write(f"{len(payload):x}\r\n".encode() + payload + b"\r\n")
             await writer.drain()
 
-        done = b"data: [DONE]\n\n"
-        writer.write(f"{len(done):x}\r\n".encode() + done + b"\r\n")
+        if protocol == "openai":
+            done = b"data: [DONE]\n\n"
+            writer.write(f"{len(done):x}\r\n".encode() + done + b"\r\n")
+
         # Terminating zero-length chunk
         writer.write(b"0\r\n\r\n")
         await writer.drain()
-        logger.info("<< SSE complete, [DONE] sent")
+        logger.info("<< SSE complete (%s)", protocol)
 
     async def _send_error(
         self, writer: asyncio.StreamWriter, status: int, message: str,

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -122,8 +122,12 @@ class HTTPServer:
                 await self._send_error(writer, 400, "Bad request")
                 return
 
-            method, path = parts[0], parts[1]
-            logger.info(">> %s %s", method, path)
+            method, raw_path = parts[0], parts[1]
+            logger.info(">> %s %s", method, raw_path)
+            # Strip the query string before routing. Real clients append
+            # query params (e.g. Claude Code POSTs /v1/messages?beta=true);
+            # exact-matching the raw target would 404 every such request.
+            path = raw_path.split("?", 1)[0]
 
             # Read headers
             headers = await self._read_headers(reader)

--- a/tests/eval/eval_runner.py
+++ b/tests/eval/eval_runner.py
@@ -89,9 +89,12 @@ class CountingClientWrapper:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> Any:
         self.call_count += 1
-        result = await self._client.send(messages, tools=tools, sampling=sampling)
+        result = await self._client.send(
+            messages, tools=tools, sampling=sampling, passthrough=passthrough,
+        )
         self._collect_usage()
         return result
 
@@ -100,9 +103,12 @@ class CountingClientWrapper:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         self.call_count += 1
-        async for chunk in self._client.send_stream(messages, tools=tools, sampling=sampling):
+        async for chunk in self._client.send_stream(
+            messages, tools=tools, sampling=sampling, passthrough=passthrough,
+        ):
             yield chunk
         self._collect_usage()
 

--- a/tests/eval/eval_runner.py
+++ b/tests/eval/eval_runner.py
@@ -90,10 +90,12 @@ class CountingClientWrapper:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> Any:
         self.call_count += 1
         result = await self._client.send(
             messages, tools=tools, sampling=sampling, passthrough=passthrough,
+            inbound_anthropic_body=inbound_anthropic_body,
         )
         self._collect_usage()
         return result
@@ -104,10 +106,12 @@ class CountingClientWrapper:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         self.call_count += 1
         async for chunk in self._client.send_stream(
             messages, tools=tools, sampling=sampling, passthrough=passthrough,
+            inbound_anthropic_body=inbound_anthropic_body,
         ):
             yield chunk
         self._collect_usage()

--- a/tests/eval/eval_runner.py
+++ b/tests/eval/eval_runner.py
@@ -81,8 +81,11 @@ class CountingClientWrapper:
         """Read last_usage from the wrapped client if available."""
         usage = getattr(self._client, "last_usage", None)
         if usage:
-            self.total_input_tokens += usage.get("input_tokens", 0)
-            self.total_output_tokens += usage.get("output_tokens", 0)
+            # Slot-keyed {slot_id: TokenUsage} across all clients (llamaserver,
+            # ollama, anthropic). Sum across slots (usually one).
+            for tu in usage.values():
+                self.total_input_tokens += tu.prompt_tokens
+                self.total_output_tokens += tu.completion_tokens
 
     async def send(
         self,

--- a/tests/unit/test_anthropic_client.py
+++ b/tests/unit/test_anthropic_client.py
@@ -12,6 +12,8 @@ import pytest
 from pydantic import BaseModel, Field
 
 from forge.clients.anthropic import AnthropicClient
+from forge.clients.base import TokenUsage
+from forge.core.inference import _get_usage
 from forge.core.workflow import TextResponse, ToolCall, ToolSpec
 
 
@@ -405,3 +407,37 @@ class TestParseResponse:
         result = AnthropicClient._parse_response(response)
         assert isinstance(result, TextResponse)
         assert result.content == ""
+
+
+# ── Usage reporting (slot-keyed last_usage) ──────────────────────
+
+
+class TestUsageReporting:
+    @pytest.mark.asyncio
+    async def test_send_records_slot_keyed_usage(self) -> None:
+        """send() stores last_usage as {0: TokenUsage} so inference._get_usage
+        reads it the same way it reads LlamafileClient / OllamaClient — without
+        this, proxy path-1 (CC -> forge -> Anthropic/LiteLLM) reports zero usage.
+        """
+        client = AnthropicClient(model="claude-test", api_key="dummy")
+
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "hello"
+        response = MagicMock()
+        response.content = [text_block]
+        response.usage.input_tokens = 12
+        response.usage.output_tokens = 7
+
+        async def fake_create(**kwargs):
+            return response
+
+        client._client.messages.create = fake_create
+
+        result = await client.send([{"role": "user", "content": "hi"}])
+
+        assert isinstance(result, TextResponse)
+        expected = TokenUsage(prompt_tokens=12, completion_tokens=7, total_tokens=19)
+        assert client.last_usage == {0: expected}
+        # Cross-client contract: _get_usage resolves slot 0 to the TokenUsage.
+        assert _get_usage(client) == expected

--- a/tests/unit/test_context_thresholds.py
+++ b/tests/unit/test_context_thresholds.py
@@ -205,7 +205,7 @@ class TestInferenceInjection:
         # Mock client — capture what api_messages it receives
         captured_messages = []
 
-        async def mock_send(api_messages, tools=None, sampling=None, passthrough=None):
+        async def mock_send(api_messages, tools=None, sampling=None, passthrough=None, inbound_anthropic_body=None):
             captured_messages.extend(api_messages)
             return [ToolCall(tool="done", args={})]
 
@@ -248,7 +248,7 @@ class TestInferenceInjection:
 
         captured_messages = []
 
-        async def mock_send(api_messages, tools=None, sampling=None, passthrough=None):
+        async def mock_send(api_messages, tools=None, sampling=None, passthrough=None, inbound_anthropic_body=None):
             captured_messages.extend(api_messages)
             return [ToolCall(tool="done", args={})]
 

--- a/tests/unit/test_context_thresholds.py
+++ b/tests/unit/test_context_thresholds.py
@@ -205,7 +205,7 @@ class TestInferenceInjection:
         # Mock client — capture what api_messages it receives
         captured_messages = []
 
-        async def mock_send(api_messages, tools=None, sampling=None):
+        async def mock_send(api_messages, tools=None, sampling=None, passthrough=None):
             captured_messages.extend(api_messages)
             return [ToolCall(tool="done", args={})]
 
@@ -248,7 +248,7 @@ class TestInferenceInjection:
 
         captured_messages = []
 
-        async def mock_send(api_messages, tools=None, sampling=None):
+        async def mock_send(api_messages, tools=None, sampling=None, passthrough=None):
             captured_messages.extend(api_messages)
             return [ToolCall(tool="done", args={})]
 

--- a/tests/unit/test_eval_budget.py
+++ b/tests/unit/test_eval_budget.py
@@ -29,6 +29,7 @@ class _MockClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
+        passthrough: dict[str, object] | None = None,
     ) -> LLMResponse:
         if self._idx < len(self._calls):
             tc = self._calls[self._idx]
@@ -41,6 +42,7 @@ class _MockClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
+        passthrough: dict[str, object] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         resp = await self.send(messages, tools)
         yield StreamChunk(type=ChunkType.FINAL, response=resp)

--- a/tests/unit/test_eval_budget.py
+++ b/tests/unit/test_eval_budget.py
@@ -30,6 +30,7 @@ class _MockClient:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
         passthrough: dict[str, object] | None = None,
+        inbound_anthropic_body: dict[str, object] | None = None,
     ) -> LLMResponse:
         if self._idx < len(self._calls):
             tc = self._calls[self._idx]
@@ -43,6 +44,7 @@ class _MockClient:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
         passthrough: dict[str, object] | None = None,
+        inbound_anthropic_body: dict[str, object] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         resp = await self.send(messages, tools)
         yield StreamChunk(type=ChunkType.FINAL, response=resp)

--- a/tests/unit/test_proxy_convert_anthropic.py
+++ b/tests/unit/test_proxy_convert_anthropic.py
@@ -1,0 +1,341 @@
+"""Tests for proxy message conversion (Anthropic ↔ forge)."""
+
+import json
+
+from forge.core.messages import MessageRole, MessageType
+from forge.core.workflow import ToolCall
+from forge.proxy.convert_anthropic import (
+    anthropic_to_messages,
+    anthropic_tools_to_specs,
+    anthropic_tool_choice_to_openai,
+    anthropic_to_openai_passthrough,
+    tool_calls_to_anthropic,
+    text_response_to_anthropic,
+    tool_calls_to_anthropic_sse,
+    text_to_anthropic_sse,
+)
+
+
+# ── Inbound: Anthropic → forge ─────────────────────────────
+
+
+class TestAnthropicToMessages:
+    def test_system_string_becomes_system_message(self):
+        msgs = anthropic_to_messages(
+            [{"role": "user", "content": "hi"}],
+            system="You are helpful.",
+        )
+        assert msgs[0].role == MessageRole.SYSTEM
+        assert msgs[0].content == "You are helpful."
+        assert msgs[0].metadata.type == MessageType.SYSTEM_PROMPT
+
+    def test_system_block_list_concatenated(self):
+        msgs = anthropic_to_messages(
+            [{"role": "user", "content": "hi"}],
+            system=[
+                {"type": "text", "text": "Be terse."},
+                {"type": "text", "text": "Use tools."},
+            ],
+        )
+        assert msgs[0].role == MessageRole.SYSTEM
+        assert "Be terse." in msgs[0].content
+        assert "Use tools." in msgs[0].content
+
+    def test_no_system_omits_system_message(self):
+        msgs = anthropic_to_messages([{"role": "user", "content": "hi"}])
+        assert msgs[0].role == MessageRole.USER
+
+    def test_user_string_content(self):
+        msgs = anthropic_to_messages([{"role": "user", "content": "Hello"}])
+        assert msgs[0].role == MessageRole.USER
+        assert msgs[0].content == "Hello"
+        assert msgs[0].metadata.type == MessageType.USER_INPUT
+
+    def test_assistant_text_block(self):
+        msgs = anthropic_to_messages([{
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Sure."}],
+        }])
+        assert msgs[0].role == MessageRole.ASSISTANT
+        assert msgs[0].content == "Sure."
+        assert msgs[0].metadata.type == MessageType.TEXT_RESPONSE
+
+    def test_assistant_tool_use_block(self):
+        msgs = anthropic_to_messages([{
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Checking."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_abc",
+                    "name": "search",
+                    "input": {"q": "weather"},
+                },
+            ],
+        }])
+        assert msgs[0].role == MessageRole.ASSISTANT
+        assert msgs[0].metadata.type == MessageType.TOOL_CALL
+        assert msgs[0].content == "Checking."
+        assert len(msgs[0].tool_calls) == 1
+        tc = msgs[0].tool_calls[0]
+        assert tc.name == "search"
+        assert tc.args == {"q": "weather"}
+        assert tc.call_id == "toolu_abc"
+
+    def test_user_tool_result_becomes_tool_message(self):
+        msgs = anthropic_to_messages([{
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_abc",
+                "content": "sunny, 22C",
+            }],
+        }])
+        assert msgs[0].role == MessageRole.TOOL
+        assert msgs[0].metadata.type == MessageType.TOOL_RESULT
+        assert msgs[0].content == "sunny, 22C"
+        assert msgs[0].tool_call_id == "toolu_abc"
+
+    def test_user_mixed_tool_result_plus_text(self):
+        """Anthropic packs tool_result + follow-up user text in one user message;
+        forge splits them into separate role=tool then role=user messages."""
+        msgs = anthropic_to_messages([{
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_x", "content": "ok"},
+                {"type": "text", "text": "Now what?"},
+            ],
+        }])
+        assert len(msgs) == 2
+        assert msgs[0].role == MessageRole.TOOL
+        assert msgs[1].role == MessageRole.USER
+        assert msgs[1].content == "Now what?"
+
+    def test_tool_result_content_as_block_list(self):
+        msgs = anthropic_to_messages([{
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_y",
+                "content": [{"type": "text", "text": "block content"}],
+            }],
+        }])
+        assert msgs[0].content == "block content"
+
+    def test_thinking_image_document_dropped(self):
+        """Anthropic-only block types with no forge analog are silently dropped."""
+        msgs = anthropic_to_messages([{
+            "role": "user",
+            "content": [
+                {"type": "thinking", "thinking": "internal monologue"},
+                {"type": "image", "source": {"type": "base64", "data": "..."}},
+                {"type": "document", "source": {"type": "base64", "data": "..."}},
+                {"type": "text", "text": "Here is the file."},
+            ],
+        }])
+        assert len(msgs) == 1
+        assert msgs[0].content == "Here is the file."
+
+
+class TestAnthropicToolsToSpecs:
+    def test_basic_tool(self):
+        specs = anthropic_tools_to_specs([{
+            "name": "get_weather",
+            "description": "Get weather.",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }])
+        assert len(specs) == 1
+        assert specs[0].name == "get_weather"
+        assert specs[0].description == "Get weather."
+
+    def test_empty_or_none(self):
+        assert anthropic_tools_to_specs(None) == []
+        assert anthropic_tools_to_specs([]) == []
+
+    def test_skips_nameless_tool(self):
+        specs = anthropic_tools_to_specs([{"description": "no name"}])
+        assert specs == []
+
+
+class TestAnthropicToolChoiceTranslation:
+    def test_auto(self):
+        assert anthropic_tool_choice_to_openai({"type": "auto"}) == "auto"
+
+    def test_any_becomes_required(self):
+        assert anthropic_tool_choice_to_openai({"type": "any"}) == "required"
+
+    def test_none(self):
+        assert anthropic_tool_choice_to_openai({"type": "none"}) == "none"
+
+    def test_named_tool(self):
+        result = anthropic_tool_choice_to_openai({"type": "tool", "name": "search"})
+        assert result == {"type": "function", "function": {"name": "search"}}
+
+    def test_passes_through_unknown_shape(self):
+        # Non-dict input passes through (already in target shape).
+        assert anthropic_tool_choice_to_openai("auto") == "auto"
+
+
+class TestAnthropicToOpenAIPassthrough:
+    def test_translates_known_fields(self):
+        body = {
+            "model": "claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "hi"}],
+            "system": "be helpful",
+            "max_tokens": 1024,
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "top_k": 40,
+            "stop_sequences": ["</done>"],
+            "tool_choice": {"type": "any"},
+        }
+        out = anthropic_to_openai_passthrough(body)
+        assert out["model"] == "claude-3-5-sonnet"
+        assert out["max_tokens"] == 1024
+        assert out["temperature"] == 0.5
+        assert out["top_p"] == 0.9
+        assert out["top_k"] == 40
+        assert out["stop"] == ["</done>"]
+        assert out["tool_choice"] == "required"
+
+    def test_excludes_forge_owned(self):
+        body = {
+            "messages": [],
+            "tools": [],
+            "system": "x",
+            "stream": True,
+        }
+        out = anthropic_to_openai_passthrough(body)
+        # None of the forge-owned fields appear in the passthrough.
+        assert "messages" not in out
+        assert "tools" not in out
+        assert "system" not in out
+        assert "stream" not in out
+
+    def test_drops_anthropic_only_fields(self):
+        """cache_control on blocks lives inside messages (filtered).
+        thinking/metadata/service_tier have no OpenAI analog — dropped here,
+        preserved via inbound_anthropic_body on path 1 (ADR-015)."""
+        body = {
+            "thinking": {"type": "enabled", "budget_tokens": 2000},
+            "metadata": {"user_id": "u-123"},
+            "service_tier": "auto",
+        }
+        out = anthropic_to_openai_passthrough(body)
+        assert out == {}
+
+
+# ── Outbound: forge → Anthropic ────────────────────────────
+
+
+class TestToolCallsToAnthropic:
+    def test_shape(self):
+        result = tool_calls_to_anthropic(
+            [ToolCall(tool="get_weather", args={"city": "Paris"})],
+            model="claude-3-5-sonnet",
+        )
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["model"] == "claude-3-5-sonnet"
+        assert result["stop_reason"] == "tool_use"
+        assert result["id"].startswith("msg_")
+        # One tool_use block
+        tu_blocks = [b for b in result["content"] if b["type"] == "tool_use"]
+        assert len(tu_blocks) == 1
+        assert tu_blocks[0]["name"] == "get_weather"
+        assert tu_blocks[0]["input"] == {"city": "Paris"}
+        assert tu_blocks[0]["id"].startswith("toolu_")
+
+    def test_reasoning_emitted_as_text_block(self):
+        result = tool_calls_to_anthropic([
+            ToolCall(tool="search", args={"q": "x"}, reasoning="Let me search."),
+        ])
+        text_blocks = [b for b in result["content"] if b["type"] == "text"]
+        assert text_blocks and text_blocks[0]["text"] == "Let me search."
+
+    def test_multiple_tool_calls(self):
+        result = tool_calls_to_anthropic([
+            ToolCall(tool="a", args={"x": 1}),
+            ToolCall(tool="b", args={"y": 2}),
+        ])
+        tu_blocks = [b for b in result["content"] if b["type"] == "tool_use"]
+        assert len(tu_blocks) == 2
+        assert tu_blocks[0]["name"] == "a"
+        assert tu_blocks[1]["name"] == "b"
+
+
+class TestTextResponseToAnthropic:
+    def test_shape(self):
+        result = text_response_to_anthropic("Hello!", model="claude-3-5-sonnet")
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["model"] == "claude-3-5-sonnet"
+        assert result["stop_reason"] == "end_turn"
+        assert result["content"] == [{"type": "text", "text": "Hello!"}]
+
+
+# ── SSE event sequence ─────────────────────────────────────
+
+
+class TestToolCallsToAnthropicSSE:
+    def test_event_sequence(self):
+        events = tool_calls_to_anthropic_sse(
+            [ToolCall(tool="get_weather", args={"city": "Paris"})],
+        )
+        types = [e["type"] for e in events]
+        # Must start with message_start and end with message_stop
+        assert types[0] == "message_start"
+        assert types[-1] == "message_stop"
+        # Must contain a content_block triplet for the tool_use
+        assert types.count("content_block_start") >= 1
+        assert types.count("content_block_delta") >= 1
+        assert types.count("content_block_stop") >= 1
+        # Must include message_delta with stop_reason
+        delta = next(e for e in events if e["type"] == "message_delta")
+        assert delta["delta"]["stop_reason"] == "tool_use"
+
+    def test_reasoning_block_precedes_tool_use(self):
+        events = tool_calls_to_anthropic_sse([
+            ToolCall(tool="search", args={"q": "x"}, reasoning="Hmm."),
+        ])
+        # First content_block_start should be type=text (reasoning), then tool_use
+        starts = [e for e in events if e["type"] == "content_block_start"]
+        assert starts[0]["content_block"]["type"] == "text"
+        assert starts[1]["content_block"]["type"] == "tool_use"
+        # The reasoning text delta has the text
+        text_delta = next(
+            e for e in events
+            if e["type"] == "content_block_delta"
+            and e["delta"]["type"] == "text_delta"
+        )
+        assert text_delta["delta"]["text"] == "Hmm."
+
+    def test_input_json_delta_is_parseable(self):
+        events = tool_calls_to_anthropic_sse(
+            [ToolCall(tool="x", args={"a": 1, "b": "two"})],
+        )
+        json_delta = next(
+            e for e in events
+            if e["type"] == "content_block_delta"
+            and e["delta"]["type"] == "input_json_delta"
+        )
+        assert json.loads(json_delta["delta"]["partial_json"]) == {"a": 1, "b": "two"}
+
+
+class TestTextToAnthropicSSE:
+    def test_event_sequence(self):
+        events = text_to_anthropic_sse("Hi there.")
+        types = [e["type"] for e in events]
+        assert types[0] == "message_start"
+        assert types[-1] == "message_stop"
+        delta = next(e for e in events if e["type"] == "message_delta")
+        assert delta["delta"]["stop_reason"] == "end_turn"
+        text_delta = next(
+            e for e in events
+            if e["type"] == "content_block_delta"
+        )
+        assert text_delta["delta"]["text"] == "Hi there."

--- a/tests/unit/test_proxy_handler.py
+++ b/tests/unit/test_proxy_handler.py
@@ -239,11 +239,11 @@ class TestSamplingPlumbing:
 
         client.send.assert_called_once()
         sampling = client.send.call_args.kwargs["sampling"]
-        assert sampling == {"temperature": 0.5, "top_p": 0.9, "model": "test"}
+        assert sampling == {"temperature": 0.5, "top_p": 0.9}
 
     @pytest.mark.asyncio
     async def test_no_tools_path_no_sampling_fields(self):
-        """No sampling fields in body → sampling contains only model."""
+        """No sampling fields in body → sampling=None."""
         client = _mock_client(TextResponse(content="ok"))
 
         await handle_chat_completions(
@@ -251,7 +251,7 @@ class TestSamplingPlumbing:
         )
 
         sampling = client.send.call_args.kwargs["sampling"]
-        assert sampling == {"model": "test"}
+        assert sampling is None
 
     @pytest.mark.asyncio
     async def test_tools_path_passes_sampling_to_run_inference(self, monkeypatch):
@@ -279,7 +279,7 @@ class TestSamplingPlumbing:
 
         await handle_chat_completions(body, client, _context_manager(), max_retries=1)
 
-        assert captured["sampling"] == {"temperature": 0.3, "seed": 42, "model": "test"}
+        assert captured["sampling"] == {"temperature": 0.3, "seed": 42}
 
     @pytest.mark.asyncio
     async def test_per_call_sampling_does_not_mutate_client(self):
@@ -291,9 +291,133 @@ class TestSamplingPlumbing:
         body1["temperature"] = 0.99
         await handle_chat_completions(body1, client, _context_manager(), max_retries=1)
         first_sampling = client.send.call_args.kwargs["sampling"]
-        assert first_sampling == {"temperature": 0.99, "model": "test"}
+        assert first_sampling == {"temperature": 0.99}
 
         # Second request: no sampling fields.
         await handle_chat_completions(_body(), client, _context_manager(), max_retries=1)
         second_sampling = client.send.call_args.kwargs["sampling"]
-        assert second_sampling == {"model": "test"}
+        assert second_sampling is None
+
+    @pytest.mark.asyncio
+    async def test_passthrough_carries_unknown_body_fields(self):
+        """Inbound body fields outside sampling/forge-owned flow through passthrough."""
+        client = _mock_client(TextResponse(content="ok"))
+        body = _body(messages=[{"role": "user", "content": "hi"}])
+        body["max_tokens"] = 256
+        body["tool_choice"] = "auto"
+
+        await handle_chat_completions(body, client, _context_manager(), max_retries=1)
+
+        passthrough = client.send.call_args.kwargs["passthrough"]
+        assert passthrough == {
+            "model": "test",
+            "max_tokens": 256,
+            "tool_choice": "auto",
+        }
+
+
+# ── Anthropic protocol routing ───────────────────────────────
+
+
+class TestAnthropicProtocol:
+    """End-to-end handler tests for the /v1/messages (protocol="anthropic") path."""
+
+    def _anthropic_body(self, messages=None, tools=None, system=None, **extra):
+        body = {
+            "model": "claude-3-5-sonnet",
+            "messages": messages or [{"role": "user", "content": "hi"}],
+            "max_tokens": 256,
+        }
+        if tools is not None:
+            body["tools"] = tools
+        if system is not None:
+            body["system"] = system
+        body.update(extra)
+        return body
+
+    @pytest.mark.asyncio
+    async def test_no_tools_returns_anthropic_shape(self):
+        client = _mock_client(TextResponse(content="hello"))
+        body = self._anthropic_body()
+        result = await handle_chat_completions(
+            body, client, _context_manager(), max_retries=1, protocol="anthropic",
+        )
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["stop_reason"] == "end_turn"
+        assert result["content"] == [{"type": "text", "text": "hello"}]
+
+    @pytest.mark.asyncio
+    async def test_tool_call_returns_anthropic_shape(self, monkeypatch):
+        from forge.core.inference import InferenceResult
+
+        async def fake_run_inference(**kwargs):
+            return InferenceResult(
+                response=[ToolCall(tool="get_weather", args={"city": "Paris"})],
+                new_messages=[],
+                tool_call_counter=0,
+                attempts=1,
+            )
+        monkeypatch.setattr("forge.proxy.handler.run_inference", fake_run_inference)
+
+        client = _mock_client([ToolCall(tool="get_weather", args={"city": "Paris"})])
+        body = self._anthropic_body(
+            tools=[{
+                "name": "get_weather",
+                "description": "Weather.",
+                "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}},
+            }],
+        )
+        result = await handle_chat_completions(
+            body, client, _context_manager(), max_retries=1, protocol="anthropic",
+        )
+        assert result["type"] == "message"
+        assert result["stop_reason"] == "tool_use"
+        tu_blocks = [b for b in result["content"] if b["type"] == "tool_use"]
+        assert len(tu_blocks) == 1
+        assert tu_blocks[0]["name"] == "get_weather"
+        assert tu_blocks[0]["input"] == {"city": "Paris"}
+
+    @pytest.mark.asyncio
+    async def test_streaming_returns_anthropic_event_sequence(self):
+        client = _mock_client(TextResponse(content="streamed"))
+        body = self._anthropic_body(stream=True)
+        events = await handle_chat_completions(
+            body, client, _context_manager(), max_retries=1, protocol="anthropic",
+        )
+        assert isinstance(events, list)
+        types = [e["type"] for e in events]
+        assert types[0] == "message_start"
+        assert types[-1] == "message_stop"
+
+    @pytest.mark.asyncio
+    async def test_anthropic_passthrough_translates_to_openai_shape(self):
+        """tool_choice and stop_sequences land in passthrough in OpenAI shape."""
+        client = _mock_client(TextResponse(content="ok"))
+        body = self._anthropic_body(
+            stop_sequences=["</done>"],
+            tool_choice={"type": "any"},
+        )
+        await handle_chat_completions(
+            body, client, _context_manager(), max_retries=1, protocol="anthropic",
+        )
+        passthrough = client.send.call_args.kwargs["passthrough"]
+        assert passthrough["stop"] == ["</done>"]
+        assert passthrough["tool_choice"] == "required"
+        assert passthrough["model"] == "claude-3-5-sonnet"
+        assert passthrough["max_tokens"] == 256
+        # Anthropic-only fields with no OpenAI analog don't appear.
+        assert "thinking" not in passthrough
+        assert "metadata" not in passthrough
+
+    @pytest.mark.asyncio
+    async def test_system_top_level_flows_into_messages(self):
+        """Anthropic puts system at top level; forge prepends it as a SYSTEM message."""
+        client = _mock_client(TextResponse(content="ok"))
+        body = self._anthropic_body(system="You are helpful.")
+        await handle_chat_completions(
+            body, client, _context_manager(), max_retries=1, protocol="anthropic",
+        )
+        api_messages = client.send.call_args.args[0]
+        assert api_messages[0]["role"] == "system"
+        assert api_messages[0]["content"] == "You are helpful."

--- a/tests/unit/test_proxy_path1.py
+++ b/tests/unit/test_proxy_path1.py
@@ -1,0 +1,277 @@
+"""Path-1 tests — Anthropic-protocol downstream + cache_control verbatim emit.
+
+Covers:
+- ProxyServer init-time validation of backend_protocol + mode combinations.
+- AnthropicClient verbatim path when inbound_anthropic_body is set.
+- AnthropicClient falling back to _convert_messages rebuild when None.
+- End-to-end: cache_control on inbound blocks reaches the underlying
+  Anthropic SDK call unchanged (the headline path-1 capability).
+
+See ADR-015 for the cache_control preservation rationale.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from forge.clients.anthropic import AnthropicClient
+from forge.core.workflow import TextResponse
+from forge.proxy.proxy import ProxyServer
+
+
+# ── ProxyServer construction validation ──────────────────────
+
+
+class TestProxyServerValidation:
+    def test_anthropic_with_prompt_mode_rejected(self):
+        with pytest.raises(ValueError, match="mode='prompt'"):
+            ProxyServer(
+                backend_url="http://localhost:8080",
+                backend_protocol="anthropic",
+                mode="prompt",
+            )
+
+    def test_anthropic_in_managed_mode_rejected(self):
+        with pytest.raises(ValueError, match="external mode"):
+            ProxyServer(
+                backend="llamaserver",
+                gguf="x.gguf",
+                backend_protocol="anthropic",
+            )
+
+    def test_anthropic_external_default_mode_ok(self):
+        # Should construct without raising
+        proxy = ProxyServer(
+            backend_url="http://localhost:8080",
+            backend_protocol="anthropic",
+        )
+        assert proxy._backend_protocol == "anthropic"
+
+    def test_openai_default_unchanged(self):
+        proxy = ProxyServer(
+            backend_url="http://localhost:8080",
+        )
+        assert proxy._backend_protocol == "openai"
+
+
+# ── AnthropicClient verbatim path ────────────────────────────
+
+
+class TestAnthropicClientVerbatim:
+    def test_verbatim_body_used_when_provided(self):
+        """When inbound_anthropic_body is set, _build_kwargs returns it verbatim
+        (drops only 'stream', sets model default)."""
+        client = AnthropicClient(model="claude-3-5-sonnet")
+        inbound = {
+            "model": "claude-3-5-sonnet",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "long stable content"},
+                        # Block-level cache_control survives because we never
+                        # touch the dict.
+                    ],
+                }
+            ],
+            "system": [
+                {
+                    "type": "text",
+                    "text": "you are helpful",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            "metadata": {"user_id": "test"},
+            "stream": True,  # Should be stripped — SDK call selects streaming
+        }
+        kwargs = client._build_kwargs(
+            messages=[],
+            tools=None,
+            passthrough=None,
+            inbound_anthropic_body=inbound,
+        )
+        # cache_control preserved verbatim
+        assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
+        # metadata preserved verbatim
+        assert kwargs["metadata"] == {"user_id": "test"}
+        # stream stripped
+        assert "stream" not in kwargs
+        # messages used as-is (forge's deconstruction not applied)
+        assert kwargs["messages"] == inbound["messages"]
+
+    def test_verbatim_body_sets_model_default(self):
+        """If inbound omits model, client's configured model fills in."""
+        client = AnthropicClient(model="claude-3-5-sonnet")
+        inbound = {"max_tokens": 256, "messages": []}
+        kwargs = client._build_kwargs(
+            messages=[],
+            tools=None,
+            inbound_anthropic_body=inbound,
+        )
+        assert kwargs["model"] == "claude-3-5-sonnet"
+
+    def test_inbound_model_wins_over_client_model(self):
+        """If inbound carries a model, it wins."""
+        client = AnthropicClient(model="claude-default")
+        inbound = {"model": "claude-opus-4-7", "messages": []}
+        kwargs = client._build_kwargs(
+            messages=[],
+            tools=None,
+            inbound_anthropic_body=inbound,
+        )
+        assert kwargs["model"] == "claude-opus-4-7"
+
+    def test_none_inbound_uses_convert_messages_path(self):
+        """When inbound_anthropic_body is None, falls back to rebuild path."""
+        client = AnthropicClient(model="claude-3-5-sonnet")
+        messages = [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": "hi"},
+        ]
+        kwargs = client._build_kwargs(
+            messages=messages,
+            tools=None,
+            inbound_anthropic_body=None,
+        )
+        # System lifted to top-level (forge's _convert_messages behavior)
+        assert kwargs["system"] == "be helpful"
+        # Messages converted (forge-shape, not original-Anthropic-shape blocks)
+        assert kwargs["messages"][0]["role"] == "user"
+        # max_tokens defaulted from client
+        assert kwargs["max_tokens"] == client.max_tokens
+
+
+# ── AnthropicClient base_url ─────────────────────────────────
+
+
+class TestAnthropicClientBaseURL:
+    def test_base_url_passed_to_sdk(self):
+        """base_url retargets the SDK at an Anthropic-shape downstream."""
+        client = AnthropicClient(
+            model="claude",
+            base_url="http://litellm.local:4000",
+            api_key="dummy",
+        )
+        # The SDK stores the base URL; verifying via the SDK's internal state
+        # is fragile but the construction path is what matters here.
+        assert client._client is not None
+
+
+# ── End-to-end: cache_control wire preservation ──────────────
+
+
+def _stub_anthropic_response():
+    """Build a minimal Anthropic-shape response object for AsyncMock."""
+    msg = MagicMock()
+    msg.content = [MagicMock(type="text", text="ok")]
+    msg.usage.input_tokens = 1
+    msg.usage.output_tokens = 1
+    return msg
+
+
+class TestCacheControlSurvivesWire:
+    """The headline path-1 capability: a cache_control block on inbound must
+    reach the Anthropic SDK call unchanged."""
+
+    @pytest.mark.asyncio
+    async def test_cache_control_on_system_block_reaches_sdk(self):
+        client = AnthropicClient(model="claude-3-5-sonnet", api_key="dummy")
+        # Patch the SDK at the boundary; capture call_args.
+        client._client.messages.create = AsyncMock(
+            return_value=_stub_anthropic_response(),
+        )
+
+        inbound = {
+            "model": "claude-3-5-sonnet",
+            "max_tokens": 1024,
+            "system": [
+                {
+                    "type": "text",
+                    "text": "large stable system prompt",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            ],
+        }
+
+        await client.send(
+            messages=[],
+            tools=None,
+            inbound_anthropic_body=inbound,
+        )
+
+        # SDK was called once with verbatim system blocks
+        client._client.messages.create.assert_called_once()
+        kwargs = client._client.messages.create.call_args.kwargs
+        assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
+        # The block text survives unchanged
+        assert kwargs["system"][0]["text"] == "large stable system prompt"
+
+    @pytest.mark.asyncio
+    async def test_cache_control_on_message_block_reaches_sdk(self):
+        client = AnthropicClient(model="claude-3-5-sonnet", api_key="dummy")
+        client._client.messages.create = AsyncMock(
+            return_value=_stub_anthropic_response(),
+        )
+
+        inbound = {
+            "model": "claude-3-5-sonnet",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "huge cached prefix",
+                            "cache_control": {"type": "ephemeral"},
+                        },
+                        {"type": "text", "text": "fresh query"},
+                    ],
+                }
+            ],
+        }
+
+        await client.send(
+            messages=[],
+            tools=None,
+            inbound_anthropic_body=inbound,
+        )
+
+        kwargs = client._client.messages.create.call_args.kwargs
+        msg_blocks = kwargs["messages"][0]["content"]
+        assert msg_blocks[0]["cache_control"] == {"type": "ephemeral"}
+
+    @pytest.mark.asyncio
+    async def test_rebuild_path_drops_cache_control(self):
+        """Sanity check: WITHOUT inbound_anthropic_body, _convert_messages
+        rebuilds blocks without cache_control. Documents the limit ADR-015
+        addresses."""
+        client = AnthropicClient(model="claude-3-5-sonnet", api_key="dummy")
+        client._client.messages.create = AsyncMock(
+            return_value=_stub_anthropic_response(),
+        )
+
+        # OpenAI-shape messages (what the runner would serialize to).
+        # cache_control has nowhere to live in this shape — it was already
+        # lost upstream in forge's deconstruction.
+        openai_messages = [
+            {"role": "system", "content": "large stable system prompt"},
+            {"role": "user", "content": "hi"},
+        ]
+
+        await client.send(
+            messages=openai_messages,
+            tools=None,
+            inbound_anthropic_body=None,  # rebuild path
+        )
+
+        kwargs = client._client.messages.create.call_args.kwargs
+        # System is a plain string (no blocks, no cache_control)
+        assert kwargs["system"] == "large stable system prompt"
+        assert not isinstance(kwargs["system"], list)

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -58,6 +58,7 @@ class MockClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
+        passthrough: dict[str, object] | None = None,
     ) -> LLMResponse:
         self.send_calls.append((messages, tools))
         return self._next()
@@ -67,6 +68,7 @@ class MockClient:
         messages: list[dict[str, str]],
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
+        passthrough: dict[str, object] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         self.send_stream_calls.append((messages, tools))
         resp = self._next()
@@ -779,10 +781,10 @@ class TestStreaming:
         class NoFinalClient:
             """Mock client whose send_stream yields deltas but no FINAL."""
 
-            async def send(self, messages, tools=None, sampling=None):
+            async def send(self, messages, tools=None, sampling=None, passthrough=None):
                 return [ToolCall(tool="fetch", args={})]
 
-            async def send_stream(self, messages, tools=None, sampling=None):
+            async def send_stream(self, messages, tools=None, sampling=None, passthrough=None):
                 yield StreamChunk(type=ChunkType.TEXT_DELTA, content="partial")
 
             async def get_context_length(self):

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -59,6 +59,7 @@ class MockClient:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
         passthrough: dict[str, object] | None = None,
+        inbound_anthropic_body: dict[str, object] | None = None,
     ) -> LLMResponse:
         self.send_calls.append((messages, tools))
         return self._next()
@@ -69,6 +70,7 @@ class MockClient:
         tools: list[ToolSpec] | None = None,
         sampling: dict[str, object] | None = None,
         passthrough: dict[str, object] | None = None,
+        inbound_anthropic_body: dict[str, object] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         self.send_stream_calls.append((messages, tools))
         resp = self._next()
@@ -781,10 +783,10 @@ class TestStreaming:
         class NoFinalClient:
             """Mock client whose send_stream yields deltas but no FINAL."""
 
-            async def send(self, messages, tools=None, sampling=None, passthrough=None):
+            async def send(self, messages, tools=None, sampling=None, passthrough=None, inbound_anthropic_body=None):
                 return [ToolCall(tool="fetch", args={})]
 
-            async def send_stream(self, messages, tools=None, sampling=None, passthrough=None):
+            async def send_stream(self, messages, tools=None, sampling=None, passthrough=None, inbound_anthropic_body=None):
                 yield StreamChunk(type=ChunkType.TEXT_DELTA, content="partial")
 
             async def get_context_length(self):

--- a/tests/unit/test_slot_worker.py
+++ b/tests/unit/test_slot_worker.py
@@ -61,14 +61,14 @@ class MockClient:
         self.responses = list(responses)
         self._call_index = 0
 
-    async def send(self, messages, tools=None, sampling=None, passthrough=None):
+    async def send(self, messages, tools=None, sampling=None, passthrough=None, inbound_anthropic_body=None):
         resp = self.responses[self._call_index]
         self._call_index += 1
         if isinstance(resp, ToolCall):
             return [resp]
         return resp
 
-    async def send_stream(self, messages, tools=None, sampling=None, passthrough=None):
+    async def send_stream(self, messages, tools=None, sampling=None, passthrough=None, inbound_anthropic_body=None):
         raise NotImplementedError
 
     async def get_context_length(self):

--- a/tests/unit/test_slot_worker.py
+++ b/tests/unit/test_slot_worker.py
@@ -61,14 +61,14 @@ class MockClient:
         self.responses = list(responses)
         self._call_index = 0
 
-    async def send(self, messages, tools=None, sampling=None):
+    async def send(self, messages, tools=None, sampling=None, passthrough=None):
         resp = self.responses[self._call_index]
         self._call_index += 1
         if isinstance(resp, ToolCall):
             return [resp]
         return resp
 
-    async def send_stream(self, messages, tools=None, sampling=None):
+    async def send_stream(self, messages, tools=None, sampling=None, passthrough=None):
         raise NotImplementedError
 
     async def get_context_length(self):


### PR DESCRIPTION
## v0.7.1 — proxy hardening

forge now works with Claude Code. This branch makes the proxy speak the Anthropic Messages API and hardens it for real multi-client use, and folds in the post-0.7.0 `main` work (#79/#80/#81) so the next PyPI cut includes everything since the last release.

Full notes in [CHANGELOG.md](CHANGELOG.md) under `[0.7.1]`.

### Anthropic Messages API on `POST /v1/messages`
Point Claude Code — or any Anthropic-protocol client — at a forge-guarded model.
- **Path 2** (default, `--backend-protocol openai`): translate Anthropic ↔ OpenAI for local llama.cpp / Ollama, emit Anthropic SSE back.
- **Path 1** (`--backend-protocol anthropic`, external): forward to an Anthropic-shape downstream (LiteLLM, the Anthropic API), passing unknown fields through verbatim; `cache_control` preserved on clean turns (ADR-015).
- `base_url` kwarg on `AnthropicClient`.

### Other features
- **`--mode {native,prompt}`** — prompt-injected FC through the proxy for backends without a native tool-calling template. Closes #53.
- **Real token-usage reporting** — usage flows end-to-end in both OpenAI and Anthropic response shapes (#81, thanks @mhajder), via a `last_usage` contract unified on slot-keyed `{slot: TokenUsage}` across all clients.
- Folded in for this release: **#80** model pass-through, **#79** Dockerfile (thanks @mhajder).

### Fixes surfaced by testing with real Claude Code
- Proxy no longer hard-imports the optional `anthropic` SDK at load — a plain `forge-guardrails` install can start the proxy for local backends without the `[anthropic]` extra.
- Router tolerates query strings — Claude Code posts `/v1/messages?beta=true`, which previously 404'd.
- `eval_runner` local-backend token accounting (was silently zero from the flat-vs-slot-keyed `last_usage` mismatch).

### Validation
- **934 unit tests** + **3/3** mock smoke (`scripts/smoke_test_proxy.py`).
- Real-backend integration suite (`scripts/integration_test_proxy.py`) on a Strix Halo APU (128 GB unified memory), native + prompt: OpenAI/Anthropic text, tool round-trip, streaming SSE, multi-turn `tool_result`, with real token counts asserted.
- **End-to-end with real Claude Code:** `claude -p` → forge proxy → local llama.cpp (Ministral-3-14B), native + prompt — tool round-trips converged with correct answers.

Version bumped to `0.7.1`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
