### PR TITLE
vLLM backend support (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to forge are documented here.
 
+## [0.7.2] — 2026-05-24
+
+vLLM backend support — serve AWQ/GPTQ and other vLLM-hosted models behind forge's guardrails, in both proxy modes and via `WorkflowRunner`.
+
+### Added
+- **vLLM backend (`VLLMClient`).** OpenAI-compatible client for a vLLM server, consuming vLLM's server-side `tool_calls` and `reasoning` (vLLM 0.21) fields. Native function calling only — vLLM parses tools server-side via `--enable-auto-tool-choice --tool-call-parser`, so there is no prompt-injection mode. Exported from `forge` and `forge.clients`.
+- **vLLM in managed + external proxy modes.** `--backend vllm --model-path <dir|hf-repo-id>` launches and manages a vLLM server; `--backend-url <url> --backend vllm` proxies an externally managed one. `setup_backend()` / `ServerManager` gain a `model_path` parameter (the vLLM identity, distinct from `gguf_path`).
+- **vLLM served-model-name discovery in external mode.** vLLM validates the request `model` field against its `--served-model-name` and 404s on a mismatch (unlike llama.cpp, which ignores the field). The proxy discovers the served name from `/v1/models` instead of sending a placeholder. #74 (thanks @srinathh).
+- **vLLM section in [Backend Setup](docs/BACKEND_SETUP.md)** covering the server flags and `VLLMClient` usage.
+
+### Changed
+- **Proxy managed mode now delegates to `setup_backend()`** instead of reimplementing the server-start/budget dance, so every managed backend (including vLLM) shares one path. No public API change — `ProxyServer` and the `forge.proxy` CLI keep their v0.7.1 signatures, with `model_path` / `--model-path` and the `vllm` backend added.
+- **External mode fails fast when a backend reports no context length** and no `--budget-tokens` is set, instead of silently falling back to an 8192-token budget that could truncate context. Anthropic-protocol downstreams are unaffected.
+
+### Known limitations
+- **The vLLM backend is unit-validated but was not exercised against a live vLLM server in this release cycle.** Its client and server-management code carry full unit coverage, and the proxy's protocol translation is verified end-to-end against llama.cpp (the proxy layer is backend-agnostic). `scripts/integration_test_proxy.py --vllm-url <url>` runs the full request battery against a real vLLM server when one is available.
+
 ## [0.7.1] — 2026-05-24
 
 Proxy hardening: forge now works with Claude Code. First PyPI release to include the Docker, model-pass-through, and token-usage work that landed on `main` after v0.7.0.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Forge takes an 8B local model from single digits to 84% across forge's 26-scenar
 
 - **Guardrails middleware** — Use forge's reliability stack ([composable middleware](examples/foreign_loop.py)) inside your own orchestration loop. You control the loop; forge validates responses, rescues malformed tool calls, and enforces required steps.
 
-Supports Ollama, llama-server (llama.cpp), Llamafile, and Anthropic as backends.
+Supports Ollama, llama-server (llama.cpp), Llamafile, vLLM, and Anthropic as backends.
 
 ## Requirements
 
@@ -136,6 +136,9 @@ python -m forge.proxy --backend-url http://localhost:8080 --port 8081
 
 # Managed mode — forge starts the backend and the proxy together
 python -m forge.proxy --backend llamaserver --gguf path/to/model.gguf --port 8081
+
+# Managed vLLM — pass a model directory or HF repo id via --model-path
+python -m forge.proxy --backend vllm --model-path /path/to/awq-dir --port 8081
 ```
 
 Then configure your client to use `http://localhost:8081/v1` as the API base URL.
@@ -144,8 +147,8 @@ Then configure your client to use `http://localhost:8081/v1` as the API base URL
 
 **Backend compatibility:**
 
-- **Managed mode** spins up the backend for you. Supported backends: `llamaserver`, `llamafile`, `ollama` (use `--backend <name>` with `--gguf` for the GGUF-based backends, or `--model` for ollama).
-- **External mode** is backend-agnostic — forge talks `POST /v1/chat/completions` to whatever you point `--backend-url` at, as long as it speaks the OpenAI schema. Tool calls must come back in OpenAI `tool_calls` format or in one of forge's rescue-parsed formats (Mistral `[TOOL_CALLS]`, Qwen `<tool_call>` XML, fenced JSON).
+- **Managed mode** spins up the backend for you. Supported backends: `llamaserver`, `llamafile`, `ollama`, `vllm` (use `--backend <name>` with `--gguf` for the GGUF-based backends, `--model-path` for vllm, or `--model` for ollama).
+- **External mode** is backend-agnostic — forge talks `POST /v1/chat/completions` to whatever you point `--backend-url` at, as long as it speaks the OpenAI schema. Tool calls must come back in OpenAI `tool_calls` format or in one of forge's rescue-parsed formats (Mistral `[TOOL_CALLS]`, Qwen `<tool_call>` XML, fenced JSON). For a vLLM server, add `--backend vllm` so the proxy adopts vLLM's `--served-model-name` (vLLM 404s on a mismatched `model` field, unlike llama.cpp).
 
 ### What proxy mode fortifies
 
@@ -190,7 +193,7 @@ docker build -t forge-proxy .
 
 ```bash
 # Connect to an external backend (e.g. vLLM hosted on the same machine)
-docker run -p 8081:8081 forge-proxy --backend-url http://host.docker.internal:8000 --budget-mode manual --budget-tokens 8192
+docker run -p 8081:8081 forge-proxy --backend-url http://host.docker.internal:8000 --backend vllm --budget-mode manual --budget-tokens 8192
 ```
 
 Note: If your backend is running on `localhost` of the host machine, use `http://host.docker.internal:PORT` (on macOS/Windows) or the host's IP address to allow the container to reach it.
@@ -202,6 +205,7 @@ Note: If your backend is running on `localhost` of the host machine, use `http:/
 | **Ollama** | Easiest setup, model management built-in | Yes |
 | **llama-server** | Best performance, full control | Yes (with `--jinja`) |
 | **Llamafile** | Single binary, zero dependencies | No (prompt-injected) |
+| **vLLM** | High-throughput serving, AWQ/GPTQ weights | Yes (server-side parser) |
 | **Anthropic** | Frontier baseline, hybrid workflows | Yes |
 
 See [Backend Setup](docs/BACKEND_SETUP.md) for installation and [Model Guide](docs/MODEL_GUIDE.md) for which model to pick.

--- a/docs/BACKEND_SETUP.md
+++ b/docs/BACKEND_SETUP.md
@@ -135,6 +135,46 @@ Notes:
 
 ---
 
+## vLLM
+
+Upstream: [vLLM docs](https://docs.vllm.ai). vLLM is a separate install (not a forge extra) — follow vLLM's guide for your CUDA/ROCm setup.
+
+Boot with server-side tool parsing for native function calling:
+
+```bash
+vllm serve /path/to/awq-dir \
+  --enable-auto-tool-choice --tool-call-parser hermes \
+  --port 8000
+```
+
+| Flag | Purpose |
+|---|---|
+| `--enable-auto-tool-choice` | **Required for native FC.** Without it, the `tools` parameter 400s. |
+| `--tool-call-parser <name>` | Parser matching the model family (`hermes`, `mistral`, `llama3_json`, …). |
+| `--reasoning-parser <name>` | Splits thinking into a separate `reasoning` field (reasoning models). |
+| `--max-model-len <N>` | Context size (forge reads it back from `/v1/models`). |
+| `--served-model-name <name>` | Alias clients must send in the `model` field (vLLM 404s on a mismatch). |
+
+vLLM parses tool calls and reasoning **server-side** (unlike llama.cpp's `--jinja` chat-template path), so there is no prompt-injection mode — `VLLMClient` is native-only.
+
+Smoke-test the server is up:
+
+```bash
+curl http://localhost:8000/v1/models
+```
+
+Forge client:
+
+```python
+from forge.clients import VLLMClient
+
+client = VLLMClient(model_path="/path/to/awq-dir")  # or a HuggingFace repo id
+```
+
+`model_path` is the canonical identity — a directory of safetensors/config or a HuggingFace repo id; its trailing segment is used for sampling-defaults lookup and the wire `model` field. Unlike llama.cpp, vLLM validates that field against its `--served-model-name`, so in proxy external mode forge auto-discovers the served name from `/v1/models` (pass `--backend vllm`).
+
+---
+
 ## Anthropic
 
 Anthropic is a published optional extra:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -373,7 +373,7 @@ client = LlamafileClient(
 )
 ```
 
-For local-server backends, the GGUF (or llamafile) path is the canonical model identity — its filename stem (e.g. `Qwen3.5-27B-Q4_K_M`) is what forge uses for sampling-defaults lookup, the wire-format `model` field, and JSONL eval rows. Use Ollama-style strings only with `OllamaClient`.
+For local-server backends, the GGUF (or llamafile) path is the canonical model identity — its filename stem (e.g. `Qwen3.5-27B-Q4_K_M`) is what forge uses for sampling-defaults lookup, the wire-format `model` field, and JSONL eval rows. For vLLM the equivalent is `model_path` (a model directory or HF repo id), whose trailing segment serves the same role. Use Ollama-style strings only with `OllamaClient`.
 
 The flag is opt-in. Default behavior (`recommended_sampling=False`) leaves sampling to backend defaults; if forge has opinions about the model, it logs a one-shot INFO message pointing the caller at the flag. With `recommended_sampling=True`, an unknown model raises `UnsupportedModelError`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forge-guardrails"
-version = "0.7.1"
+version = "0.7.2"
 description = "A reliability layer for self-hosted LLM tool-calling. Guardrails, context management, and backend adapters for multi-step agentic workflows."
 requires-python = ">=3.12"
 license = "MIT"

--- a/scripts/integration_test_proxy.py
+++ b/scripts/integration_test_proxy.py
@@ -56,6 +56,8 @@ EXTERNAL_BACKEND_PORT = 18086
 EXTERNAL_PROXY_PORT = 18087
 MANAGED_BACKEND_PORT = 18088
 MANAGED_PROXY_PORT = 18089
+# External vLLM is user-managed (we only own the proxy port here).
+VLLM_PROXY_PORT = 18091
 
 LOG_FILE = Path(__file__).parent / "integration_test_proxy.log"
 
@@ -440,6 +442,38 @@ async def phase_managed(
         print("[managed] proxy + managed llama-server stopped")
 
 
+# ── Phase 3: External vLLM (opt-in) ──────────────────────────────────
+
+async def phase_external_vllm(vllm_url: str) -> list[tuple[str, str, str]]:
+    """Run the T1–T5 battery against a user-managed vLLM server.
+
+    External mode only — vLLM is not spawned/torn down here. The same
+    protocol-translation tests apply (the proxy layer is backend-agnostic);
+    this exercises VLLMClient + served-model-name discovery against a real
+    vLLM server. Start vLLM with ``--enable-auto-tool-choice
+    --tool-call-parser <name>`` (and ``--reasoning-parser`` for thinking
+    models) so the tool tests (T3–T5) have a native tool surface.
+    """
+    print("\n===== Phase 3: external vLLM (fc=native) =====")
+    print(f"      user-managed vLLM at {vllm_url}, proxy on :{VLLM_PROXY_PORT}")
+
+    from forge.proxy import ProxyServer
+    proxy = ProxyServer(
+        backend_url=vllm_url,
+        backend="vllm",
+        port=VLLM_PROXY_PORT,
+        mode="native",
+        backend_protocol="openai",
+    )
+    proxy.start()
+    print(f"[vllm] proxy ready at {proxy.url}")
+    try:
+        return await _run_all_tests(proxy.url)
+    finally:
+        proxy.stop()
+        print("[vllm] proxy stopped (vLLM server left running — user-managed)")
+
+
 # ── Entry point ──────────────────────────────────────────────────────
 
 def _print_summary(phase: str, results: list[tuple[str, str, str]]) -> None:
@@ -464,10 +498,19 @@ async def main() -> int:
     )
     parser.add_argument("--skip-external", action="store_true")
     parser.add_argument("--skip-managed", action="store_true")
+    parser.add_argument(
+        "--vllm-url", default=None,
+        help="Run an extra external-mode phase against a user-managed vLLM "
+             "server at this URL (e.g. http://localhost:8000). Start vLLM with "
+             "--enable-auto-tool-choice --tool-call-parser <name> for the tool "
+             "tests. Skipped if not provided. The --gguf flag is ignored for "
+             "this phase.",
+    )
     args = parser.parse_args()
 
     gguf = Path(args.gguf)
-    if not gguf.exists():
+    needs_gguf = not args.skip_external or not args.skip_managed
+    if needs_gguf and not gguf.exists():
         print(f"[FATAL] GGUF not found: {gguf}")
         return 2
 
@@ -491,6 +534,11 @@ async def main() -> int:
         man = await phase_managed(gguf, args.mode, extra_flags)
         _print_summary("managed", man)
         summaries.append(("managed", man))
+
+    if args.vllm_url:
+        vll = await phase_external_vllm(args.vllm_url)
+        _print_summary("vllm-external", vll)
+        summaries.append(("vllm-external", vll))
 
     print("\n===== Final =====")
     any_fail = False

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -23,6 +23,7 @@ from forge.core.slot_worker import SlotWorker
 from forge.clients.base import ChunkType, LLMClient, StreamChunk, TokenUsage
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
+from forge.clients.vllm import VLLMClient
 from forge.context import (
     CompactEvent,
     CompactStrategy,
@@ -95,6 +96,7 @@ __all__ = [
     "LLMClient",
     "LlamafileClient",
     "OllamaClient",
+    "VLLMClient",
     "StreamChunk",
     "TokenUsage",
     # Context

--- a/src/forge/clients/__init__.py
+++ b/src/forge/clients/__init__.py
@@ -3,6 +3,7 @@
 from forge.clients.base import ChunkType, LLMClient, StreamChunk
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
+from forge.clients.vllm import VLLMClient
 from forge.clients.sampling_defaults import (
     MODEL_SAMPLING_DEFAULTS,
     apply_sampling_defaults,
@@ -16,6 +17,7 @@ __all__ = [
     "MODEL_SAMPLING_DEFAULTS",
     "OllamaClient",
     "StreamChunk",
+    "VLLMClient",
     "apply_sampling_defaults",
     "get_sampling_defaults",
 ]

--- a/src/forge/clients/vllm.py
+++ b/src/forge/clients/vllm.py
@@ -1,0 +1,356 @@
+"""vLLM client adapter using native function calling.
+
+vLLM's HTTP API is OpenAI-compatible. Tool calling and reasoning extraction
+both happen server-side (via ``--tool-call-parser`` and ``--reasoning-parser``
+flags at server boot). The client consumes the structured response fields
+``tool_calls`` (list) and ``reasoning`` (string) directly.
+
+Differences from LlamafileClient:
+- No prompt-mode injection path. vLLM parses tool calls server-side.
+- No ``--jinja`` negotiation. vLLM uses the model's bundled chat template.
+- Reasoning content arrives in ``reasoning`` (vLLM 0.21), not
+  ``reasoning_content`` (llama.cpp's name).
+- Context length is discovered via ``/v1/models`` (``max_model_len``),
+  not ``/props``.
+- The model identity is a path to a model directory (or HF repo id),
+  not a single ``.gguf`` file. Constructor accepts ``model_path``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from forge.clients.base import ChunkType, StreamChunk, TokenUsage, format_tool
+from forge.clients.sampling_defaults import apply_sampling_defaults
+from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
+from forge.errors import BackendError
+
+
+class VLLMClient:
+    """Native function calling via vLLM's OpenAI-compatible API.
+
+    Requires the vLLM server to be started with ``--enable-auto-tool-choice
+    --tool-call-parser <name>`` for tool calling, and (for reasoning models)
+    ``--reasoning-parser <name>`` to split thinking content into a separate
+    response field. Without those flags, tool calls return 400 and reasoning
+    arrives inline in ``content``.
+    """
+
+    api_format: str = "openai"
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        *,
+        base_url: str = "http://localhost:8000/v1",
+        temperature: float | None = None,
+        top_p: float | None = None,
+        top_k: int | None = None,
+        min_p: float | None = None,
+        repeat_penalty: float | None = None,
+        presence_penalty: float | None = None,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        timeout: float = 300.0,
+        think: bool = True,
+        recommended_sampling: bool = False,
+    ) -> None:
+        self.base_url = base_url
+        # model_path is the canonical identity. vLLM accepts either a local
+        # directory containing safetensors + config or a HuggingFace repo id
+        # (e.g. "google/gemma-4-26B-A4B-it"). We pass it through as-is in
+        # the wire-format "model" field and as the sampling-defaults lookup
+        # key (using the path stem for directory paths so registry lookups
+        # match the existing GGUF-stem convention).
+        self.model_path = str(model_path)
+        path_obj = Path(self.model_path)
+        # If model_path is a filesystem path, use the directory name as the
+        # registry lookup key. If it's an HF repo id (no leading slash, has
+        # a "/"), use the trailing segment. Otherwise the full string.
+        if path_obj.is_absolute() or path_obj.exists():
+            self.model = path_obj.name
+        elif "/" in self.model_path:
+            self.model = self.model_path.split("/")[-1]
+        else:
+            self.model = self.model_path
+
+        # Apply per-model recommended sampling defaults. Caller's explicit
+        # (non-None) kwargs win over the map field-by-field.
+        defaults = apply_sampling_defaults(self.model, strict=recommended_sampling)
+        self.temperature = temperature if temperature is not None else defaults.get("temperature")
+        self.top_p = top_p if top_p is not None else defaults.get("top_p")
+        self.top_k = top_k if top_k is not None else defaults.get("top_k")
+        self.min_p = min_p if min_p is not None else defaults.get("min_p")
+        self.repeat_penalty = repeat_penalty if repeat_penalty is not None else defaults.get("repeat_penalty")
+        self.presence_penalty = presence_penalty if presence_penalty is not None else defaults.get("presence_penalty")
+        # chat_template_kwargs is a nested dict of Jinja template variables
+        # (e.g. {"enable_thinking": True}) that vLLM unpacks into the chat
+        # template at render time. Whole-value replacement at the field
+        # level — no nested merge.
+        self.chat_template_kwargs = (
+            chat_template_kwargs if chat_template_kwargs is not None
+            else defaults.get("chat_template_kwargs")
+        )
+        self._http = httpx.AsyncClient(timeout=timeout)
+        self._think: bool = think
+        self.last_usage: dict[int, TokenUsage] = {}
+
+    # Sampling fields recognized in per-call overrides. ``seed`` is
+    # accepted only as a per-call override (not an instance field).
+    # ``chat_template_kwargs`` is a nested dict of Jinja template variables
+    # — whole-value replacement at this field level (no nested merge).
+    _SAMPLING_FIELDS = (
+        "temperature", "top_p", "top_k", "min_p",
+        "repeat_penalty", "presence_penalty", "seed",
+        "chat_template_kwargs",
+    )
+
+    def _apply_sampling(
+        self, body: dict[str, Any], sampling: dict[str, Any] | None = None,
+    ) -> None:
+        """Inject optional sampling params into a request body.
+
+        Instance fields supply the base sampling values; ``sampling`` (when
+        provided) overrides per call. The instance is not mutated. None =
+        don't send; backend default applies.
+        """
+        for field in self._SAMPLING_FIELDS:
+            override = (sampling or {}).get(field)
+            if override is not None:
+                body[field] = override
+                continue
+            instance_val = getattr(self, field, None)
+            if instance_val is not None:
+                body[field] = instance_val
+
+    def _record_usage(self, data: dict[str, Any]) -> None:
+        """Extract usage from a response."""
+        usage = data.get("usage")
+        if not usage:
+            return
+        self.last_usage[0] = TokenUsage(
+            prompt_tokens=usage.get("prompt_tokens", 0),
+            completion_tokens=usage.get("completion_tokens", 0),
+            total_tokens=usage.get("total_tokens", 0),
+        )
+
+    def _resolve_reasoning(
+        self, message_or_accum: dict[str, Any] | str, accumulated_content: str = "",
+    ) -> str | None:
+        """Extract reasoning, gated on _think.
+
+        vLLM 0.21 returns reasoning in the ``reasoning`` field of the
+        assistant message when ``--reasoning-parser`` is enabled at server
+        boot. If thinking is disabled or the field is empty, return None.
+
+        Accepts either a message dict (from send()) or an accumulated
+        reasoning string (from send_stream()).
+        """
+        if not self._think:
+            return None
+        if isinstance(message_or_accum, dict):
+            return message_or_accum.get("reasoning") or None
+        return message_or_accum or accumulated_content or None
+
+    async def send(
+        self,
+        messages: list[dict[str, str]],
+        tools: list[ToolSpec] | None = None,
+        sampling: dict[str, Any] | None = None,
+    ) -> LLMResponse:
+        """Send messages via /v1/chat/completions and parse the response."""
+        body: dict[str, Any] = {
+            "model": self.model_path,
+            "messages": messages,
+            "stream": False,
+        }
+        if tools:
+            body["tools"] = [format_tool(t) for t in tools]
+            body["tool_choice"] = "auto"
+        self._apply_sampling(body, sampling)
+
+        try:
+            resp = await self._http.post(
+                f"{self.base_url}/chat/completions", json=body,
+            )
+        except httpx.ReadTimeout as exc:
+            raise BackendError(408, "Read timeout") from exc
+
+        if resp.status_code != 200:
+            raise BackendError(resp.status_code, resp.text)
+        data = resp.json()
+        self._record_usage(data)
+
+        choices = data.get("choices") or []
+        if not choices:
+            raise BackendError(500, f"vLLM response has no choices: {data}")
+        message = choices[0].get("message", {})
+
+        tool_calls = message.get("tool_calls") or []
+        if tool_calls:
+            reasoning = self._resolve_reasoning(message)
+            return [
+                ToolCall(
+                    tool=tc["function"]["name"],
+                    args=self._parse_tool_args(tc["function"].get("arguments", {})),
+                    reasoning=reasoning if i == 0 else None,
+                )
+                for i, tc in enumerate(tool_calls)
+            ]
+
+        return TextResponse(content=message.get("content") or "")
+
+    async def send_stream(
+        self,
+        messages: list[dict[str, str]],
+        tools: list[ToolSpec] | None = None,
+        sampling: dict[str, Any] | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """Stream via SSE from /v1/chat/completions."""
+        body: dict[str, Any] = {
+            "model": self.model_path,
+            "messages": messages,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+        if tools:
+            body["tools"] = [format_tool(t) for t in tools]
+            body["tool_choice"] = "auto"
+        self._apply_sampling(body, sampling)
+
+        accumulated_content = ""
+        accumulated_reasoning = ""
+        # Track multiple tool calls by index — OpenAI streaming sends
+        # tool_calls[N] deltas with an index field.
+        tool_call_parts: dict[int, dict[str, str]] = {}
+
+        async with self._http.stream(
+            "POST", f"{self.base_url}/chat/completions", json=body,
+        ) as response:
+            if response.status_code != 200:
+                error_body = ""
+                async for line in response.aiter_lines():
+                    error_body += line
+                raise BackendError(response.status_code, error_body)
+
+            async for line in response.aiter_lines():
+                line = line.strip()
+                if not line or not line.startswith("data: "):
+                    continue
+                data_str = line[6:]
+                if data_str == "[DONE]":
+                    break
+
+                chunk = json.loads(data_str)
+                if "choices" not in chunk or not chunk["choices"]:
+                    self._record_usage(chunk)
+                    continue
+                choice = chunk["choices"][0]
+                delta = choice.get("delta", {})
+
+                if "tool_calls" in delta:
+                    for tc_delta in delta["tool_calls"]:
+                        idx = tc_delta.get("index", 0)
+                        if idx not in tool_call_parts:
+                            tool_call_parts[idx] = {"name": "", "args": ""}
+                        func = tc_delta.get("function", {})
+                        if "name" in func:
+                            tool_call_parts[idx]["name"] = func["name"]
+                        if "arguments" in func:
+                            tool_call_parts[idx]["args"] += func["arguments"]
+                            yield StreamChunk(
+                                type=ChunkType.TOOL_CALL_DELTA,
+                                content=func["arguments"],
+                            )
+
+                # vLLM 0.21 streams reasoning as `reasoning` deltas (mirroring
+                # the non-streaming response field). If a future vLLM renames,
+                # this assignment becomes empty and tests should catch it.
+                reasoning_delta = delta.get("reasoning") or ""
+                if reasoning_delta:
+                    accumulated_reasoning += reasoning_delta
+
+                content = delta.get("content") or ""
+                if content:
+                    accumulated_content += content
+                    yield StreamChunk(
+                        type=ChunkType.TEXT_DELTA, content=content,
+                    )
+
+        # Build the final response
+        if tool_call_parts:
+            reasoning = self._resolve_reasoning(
+                accumulated_reasoning, accumulated_content,
+            )
+            final: LLMResponse = [
+                ToolCall(
+                    tool=part["name"],
+                    args=self._parse_tool_args(part["args"]),
+                    reasoning=reasoning if i == 0 else None,
+                )
+                for i, part in enumerate(
+                    tool_call_parts[k] for k in sorted(tool_call_parts)
+                )
+            ]
+        else:
+            final = TextResponse(content=accumulated_content)
+        yield StreamChunk(type=ChunkType.FINAL, response=final)
+
+    @staticmethod
+    def _parse_tool_args(raw: Any) -> dict[str, Any]:
+        """Tool args from vLLM arrive as JSON-encoded string in the
+        OpenAI native format. Decode to dict.
+        """
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            if not raw:
+                return {}
+            return json.loads(raw)
+        raise BackendError(500, f"unexpected tool args shape: {type(raw).__name__}")
+
+    async def get_context_length(self) -> int | None:
+        """Query the vLLM /v1/models endpoint for max_model_len.
+
+        vLLM exposes the configured context window via the OpenAI-compat
+        models endpoint. Single endpoint, single field — raises on
+        unexpected response shape.
+        """
+        resp = await self._http.get(f"{self.base_url}/models")
+        resp.raise_for_status()
+        data = resp.json()
+        models = data.get("data") or []
+        if not models:
+            raise BackendError(500, f"/v1/models returned no entries: {data}")
+        max_model_len = models[0].get("max_model_len")
+        if max_model_len is None:
+            raise BackendError(
+                500, f"/v1/models entry missing max_model_len: {models[0]}",
+            )
+        return int(max_model_len)
+
+    async def get_served_model_name(self) -> str | None:
+        """Query /v1/models for the name vLLM is actually serving.
+
+        vLLM validates the request ``model`` field against its
+        ``--served-model-name`` aliases and returns 404 for an unknown name —
+        unlike llama.cpp, which ignores the field entirely. In external mode
+        the proxy has no model path to send, so it discovers the served
+        identity here (the first ``data[].id``) rather than guessing.
+
+        Returns None if the endpoint reports no models or is unreachable, in
+        which case the caller keeps its placeholder identity.
+        """
+        try:
+            resp = await self._http.get(f"{self.base_url}/models")
+            resp.raise_for_status()
+        except httpx.HTTPError:
+            return None
+        models = resp.json().get("data") or []
+        if not models:
+            return None
+        return models[0].get("id")

--- a/src/forge/proxy/__main__.py
+++ b/src/forge/proxy/__main__.py
@@ -17,21 +17,25 @@ def main() -> None:
         description="forge proxy — OpenAI-compatible proxy with guardrails",
     )
 
-    # Mode selection
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument(
+    # Mode selection. External mode uses --backend-url; managed mode uses
+    # --backend (+ an identity flag). For an external vLLM server, pass both
+    # --backend-url and --backend vllm so the proxy selects the vLLM adapter.
+    # ProxyServer enforces "exactly one of url/backend" and the per-backend rules.
+    parser.add_argument(
         "--backend-url",
-        help="URL of externally managed backend (external mode)",
+        help="URL of an externally managed backend (external mode)",
     )
-    group.add_argument(
+    parser.add_argument(
         "--backend",
-        choices=["llamaserver", "llamafile", "ollama"],
-        help="Backend type (managed mode)",
+        choices=["llamaserver", "llamafile", "ollama", "vllm"],
+        help="Backend type. Required for managed mode; in external mode use "
+             "'vllm' to select the vLLM adapter (default adapter is llama.cpp).",
     )
 
     # Managed mode options
     parser.add_argument("--model", help="Model name (required for ollama)")
     parser.add_argument("--gguf", help="Path to GGUF file (llamaserver/llamafile)")
+    parser.add_argument("--model-path", help="Model directory or HF repo id (vllm, managed mode)")
     parser.add_argument("--backend-port", type=int, default=8080, help="Backend port (default: 8080)")
     parser.add_argument(
         "--budget-mode",
@@ -88,6 +92,7 @@ def main() -> None:
         backend=args.backend,
         model=args.model,
         gguf=args.gguf,
+        model_path=args.model_path,
         backend_port=args.backend_port,
         budget_mode=BudgetMode(args.budget_mode),
         budget_tokens=args.budget_tokens,

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -11,31 +11,37 @@ import asyncio
 import logging
 import threading
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 from forge.clients.base import LLMClient
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
+from forge.clients.vllm import VLLMClient
 from forge.context.manager import ContextManager
 from forge.context.strategies import TieredCompact
 from forge.proxy.server import HTTPServer
-from forge.server import BudgetMode, ServerManager
+from forge.server import BudgetMode, ServerManager, setup_backend
 
 logger = logging.getLogger("forge.proxy")
 
 
 class ProxyServer:
-    """OpenAI-compatible proxy that applies forge guardrails transparently.
+    """OpenAI- and Anthropic-compatible proxy that applies forge guardrails transparently.
 
     Managed mode — forge starts the backend::
 
-        proxy = ProxyServer(backend="llamaserver", gguf="model.gguf")
-        proxy.start()   # starts llama-server on :8080 + proxy on :8081
+        ProxyServer(backend="llamaserver", gguf="model.gguf")
+        ProxyServer(backend="vllm", model_path="/path/to/awq-dir")
+        ProxyServer(backend="ollama", model="ministral-3:14b")
+        proxy.start()   # starts the backend on :8080 + proxy on :8081
         proxy.stop()    # stops both
 
     External mode — user manages the backend::
 
-        proxy = ProxyServer(backend_url="http://localhost:8080")
+        ProxyServer(backend_url="http://localhost:8080")                  # llama.cpp (default)
+        ProxyServer(backend_url="http://localhost:8000", backend="vllm")  # vLLM
+        ProxyServer(backend_url="https://api.anthropic.com",
+                    backend_protocol="anthropic")                         # Anthropic-shape
         proxy.start()   # starts proxy on :8081 only
         proxy.stop()
 
@@ -49,6 +55,7 @@ class ProxyServer:
         backend: str | None = None,
         model: str | None = None,
         gguf: str | Path | None = None,
+        model_path: str | Path | None = None,
         backend_port: int = 8080,
         budget_mode: BudgetMode = BudgetMode.BACKEND,
         budget_tokens: int | None = None,
@@ -65,12 +72,18 @@ class ProxyServer:
         """
         Args:
             backend_url: URL of an externally managed backend (external mode).
-            backend: Backend type — "llamaserver" or "ollama" (managed mode).
+            backend: Backend type — "llamaserver", "llamafile", "ollama", or
+                "vllm". Required for managed mode; in external mode it selects
+                the client adapter ("vllm" for a vLLM server, otherwise the
+                OpenAI-compatible llama.cpp adapter).
             model: Model name (managed mode, required for ollama).
             gguf: Path to GGUF file (managed mode, llamaserver/llamafile).
+            model_path: Path to a model directory or HF repo id (managed mode,
+                vllm only).
             backend_port: Port for the managed backend (default 8080).
             budget_mode: How to determine context budget.
-            budget_tokens: Explicit token budget (for MANUAL mode).
+            budget_tokens: Explicit token budget. In external mode this is
+                required if the backend doesn't report its context length.
             extra_flags: Additional CLI flags for the managed backend.
             host: Proxy listen host.
             port: Proxy listen port.
@@ -81,7 +94,8 @@ class ProxyServer:
             mode: Function-calling mode for OpenAI-compatible backends —
                 "native" uses the backend's native tools API, "prompt"
                 uses forge's prompt-injection fallback for backends
-                without a function-calling template.
+                without a function-calling template. Not applicable to vLLM
+                (parses tool calls server-side) or the Anthropic protocol.
             backend_protocol: Wire format of the external backend.
                 ``openai`` (default) for llama.cpp, vLLM, Ollama. ``anthropic``
                 for Anthropic-shape downstreams (the official Anthropic API,
@@ -102,11 +116,31 @@ class ProxyServer:
                 "backend_protocol='anthropic' requires external mode (backend_url=...). "
                 "Managed mode launches local llama.cpp / Ollama, which only speak OpenAI."
             )
+        if backend == "vllm" and backend_protocol == "anthropic":
+            raise ValueError(
+                "backend='vllm' speaks the OpenAI protocol; backend_protocol='anthropic' "
+                "is not applicable."
+            )
+        if backend == "vllm" and mode == "prompt":
+            raise ValueError(
+                "backend='vllm' parses tool calls server-side (native only); "
+                "mode='prompt' is not applicable."
+            )
+        # Managed mode: each backend requires its own identity field. Fail
+        # fast at construction with a clear message (mirrors setup_backend).
+        if backend_url is None:
+            if backend == "ollama" and model is None:
+                raise ValueError("backend='ollama' requires model")
+            if backend in ("llamaserver", "llamafile") and gguf is None:
+                raise ValueError(f"backend={backend!r} requires gguf")
+            if backend == "vllm" and model_path is None:
+                raise ValueError("backend='vllm' requires model_path")
 
         self._backend_url = backend_url
         self._backend = backend
         self._model = model
         self._gguf = gguf
+        self._model_path = model_path
         self._backend_port = backend_port
         self._budget_mode = budget_mode
         self._budget_tokens = budget_tokens
@@ -118,9 +152,10 @@ class ProxyServer:
         self._mode = mode
         self._backend_protocol = backend_protocol
 
-        # Auto-detect serialization: managed = single GPU = serialize
+        # Auto-detect serialization: managed (no external url) = single local
+        # GPU = serialize. External callers manage their own concurrency.
         if serialize is None:
-            self._serialize = backend is not None
+            self._serialize = backend_url is None
         else:
             self._serialize = serialize
 
@@ -179,92 +214,10 @@ class ProxyServer:
 
     async def _async_start(self, ready: threading.Event) -> None:
         """Async startup: backend + HTTP server."""
-        client: LLMClient
-        context_manager: ContextManager
-
         if self._backend_url is not None:
-            # External mode — connect to existing backend.
-            if self._backend_protocol == "anthropic":
-                # Path 1 — downstream speaks Anthropic Messages API
-                # (LiteLLM /v1/messages, real Anthropic, self-hosted proxy).
-                # AnthropicClient handles base_url and SDK retries; forge
-                # guardrails wrap its inference loop the same way they
-                # wrap any other client.
-                # Lazy import: the anthropic SDK is an optional dependency
-                # (forge-guardrails[anthropic]). Only Path 1 needs it, so
-                # Path 2 / local-backend users must not be forced to install
-                # it just to start the proxy.
-                try:
-                    from forge.clients.anthropic import AnthropicClient
-                except ImportError as exc:
-                    raise RuntimeError(
-                        "backend_protocol='anthropic' requires the anthropic SDK. "
-                        "Install it with: pip install 'forge-guardrails[anthropic]'"
-                    ) from exc
-                client = AnthropicClient(
-                    model=self._model or "claude",
-                    base_url=self._backend_url.rstrip("/"),
-                )
-                budget = self._budget_tokens or await client.get_context_length() or 8192
-            else:
-                # Path 2 / default — OpenAI-shape downstream.
-                # LlamafileClient expects base_url with /v1 suffix.
-                base = self._backend_url.rstrip("/")
-                if not base.endswith("/v1"):
-                    base = base + "/v1"
-                # External mode: caller manages the backend, so we don't have a
-                # GGUF path. "default" is a placeholder identity for the wire
-                # model field (llama-server ignores it) and JSONL model field.
-                client = LlamafileClient(
-                    gguf_path=self._model or "default",
-                    base_url=base,
-                    mode=self._mode,
-                )
-                if self._budget_tokens is not None:
-                    budget = self._budget_tokens
-                else:
-                    # Try to auto-detect from backend /props
-                    ctx_len = await client.get_context_length()
-                    budget = ctx_len if ctx_len is not None else 8192
-            context_manager = ContextManager(
-                strategy=TieredCompact(),
-                budget_tokens=budget,
-            )
+            client, context_manager = await self._setup_external()
         else:
-            # Managed mode
-            assert self._backend is not None
-            if self._backend == "ollama":
-                assert self._model is not None
-                client = OllamaClient(model=self._model)
-            else:
-                client = LlamafileClient(
-                    gguf_path=self._gguf or "default",
-                    base_url=f"http://localhost:{self._backend_port}/v1",
-                    mode=self._mode,
-                )
-
-            server_mgr = ServerManager(
-                backend=self._backend,
-                port=self._backend_port,
-            )
-            self._server_manager = server_mgr
-
-            budget = await server_mgr.start_with_budget(
-                model=self._model or "",
-                gguf_path=self._gguf or "",
-                mode="native",
-                budget_mode=self._budget_mode,
-                manual_tokens=self._budget_tokens,
-                extra_flags=self._extra_flags,
-            )
-
-            if self._backend == "ollama" and hasattr(client, "set_num_ctx"):
-                client.set_num_ctx(budget)
-
-            context_manager = ContextManager(
-                strategy=TieredCompact(),
-                budget_tokens=budget,
-            )
+            client, context_manager = await self._setup_managed()
 
         self._http_server = HTTPServer(
             client=client,
@@ -278,6 +231,135 @@ class ProxyServer:
         await self._http_server.start()
         self._started = True
         ready.set()
+
+    async def _setup_external(self) -> tuple[LLMClient, ContextManager]:
+        """External mode: connect to a caller-managed backend."""
+        assert self._backend_url is not None
+
+        if self._backend_protocol == "anthropic":
+            # Path 1 — downstream speaks the Anthropic Messages API
+            # (LiteLLM /v1/messages, real Anthropic, self-hosted proxy).
+            # AnthropicClient handles base_url and SDK retries; forge
+            # guardrails wrap its inference loop like any other client.
+            # Lazy import: the anthropic SDK is an optional dependency
+            # (forge-guardrails[anthropic]). Only Path 1 needs it, so
+            # Path 2 / local-backend users must not be forced to install
+            # it just to start the proxy.
+            try:
+                from forge.clients.anthropic import AnthropicClient
+            except ImportError as exc:
+                raise RuntimeError(
+                    "backend_protocol='anthropic' requires the anthropic SDK. "
+                    "Install it with: pip install 'forge-guardrails[anthropic]'"
+                ) from exc
+            client: LLMClient = AnthropicClient(
+                model=self._model or "claude",
+                base_url=self._backend_url.rstrip("/"),
+            )
+            # Anthropic models report a known context length; keep the legacy
+            # 8192 fallback rather than failing the well-behaved Path-1 case.
+            budget = self._budget_tokens or await client.get_context_length() or 8192
+            context_manager = ContextManager(
+                strategy=TieredCompact(),
+                budget_tokens=budget,
+            )
+            return client, context_manager
+
+        # Path 2 / default — OpenAI-shape downstream (llama.cpp or vLLM).
+        base = self._backend_url.rstrip("/")
+        if not base.endswith("/v1"):
+            base = base + "/v1"
+
+        if self._backend == "vllm":
+            client = VLLMClient(model_path="default", base_url=base)
+            # Unlike llama.cpp, vLLM validates the wire `model` field against
+            # its --served-model-name aliases (404 on mismatch). External mode
+            # has no model path to send, so discover the served identity from
+            # /v1/models instead of shipping the "default" placeholder.
+            served = await client.get_served_model_name()
+            if served:
+                logger.info("Discovered vLLM served model name: %s", served)
+                client.model_path = served
+                client.model = served
+            else:
+                logger.warning(
+                    "Could not discover a served model name from %s/models; "
+                    "sending placeholder 'default' (vLLM will 404 if it "
+                    "validates the model field)",
+                    base,
+                )
+        else:
+            # llamaserver / llamafile / unspecified — OpenAI-compatible adapter.
+            # Caller manages the backend, so we don't have a GGUF path. "default"
+            # is a placeholder identity for the wire model field (llama-server
+            # ignores it) and the JSONL model field.
+            client = LlamafileClient(
+                gguf_path=self._model or "default",
+                base_url=base,
+                mode=self._mode,
+            )
+
+        if self._budget_tokens is not None:
+            budget = self._budget_tokens
+        else:
+            ctx_len = await client.get_context_length()
+            if ctx_len is None:
+                raise RuntimeError(
+                    f"backend at {self._backend_url} did not report a context "
+                    "length; pass budget_tokens explicitly"
+                )
+            budget = ctx_len
+
+        context_manager = ContextManager(
+            strategy=TieredCompact(),
+            budget_tokens=budget,
+        )
+        return client, context_manager
+
+    async def _setup_managed(self) -> tuple[LLMClient, ContextManager]:
+        """Managed mode: forge starts the backend via setup_backend."""
+        assert self._backend is not None
+        client = self._build_managed_client()
+
+        # The backend process is always launched in native mode (--jinja is
+        # harmless and enables the native tools API where available); prompt
+        # mode is a client-side injection concern carried by the client.
+        # Pass each backend only its own identity field — setup_backend
+        # enforces mutual exclusivity.
+        server, context_manager = await setup_backend(
+            backend=self._backend,
+            model=self._model if self._backend == "ollama" else None,
+            gguf_path=self._gguf if self._backend in ("llamaserver", "llamafile") else None,
+            model_path=self._model_path if self._backend == "vllm" else None,
+            mode="native",
+            budget_mode=self._budget_mode,
+            manual_tokens=self._budget_tokens,
+            client=client,
+            port=self._backend_port,
+            extra_flags=self._extra_flags,
+        )
+        self._server_manager = server
+        return client, context_manager
+
+    def _build_managed_client(self) -> LLMClient:
+        """Construct the right client for the managed backend."""
+        base_url = f"http://localhost:{self._backend_port}/v1"
+        if self._backend == "ollama":
+            assert self._model is not None
+            return OllamaClient(model=self._model)
+        if self._backend in ("llamaserver", "llamafile"):
+            return LlamafileClient(
+                gguf_path=self._gguf or "default",
+                base_url=base_url,
+                mode=self._mode,
+            )
+        if self._backend == "vllm":
+            assert self._model_path is not None
+            return VLLMClient(
+                model_path=self._model_path,
+                base_url=base_url,
+            )
+        raise ValueError(f"unsupported backend: {self._backend!r}")
 
     async def _async_stop(self) -> None:
         """Async shutdown."""

--- a/src/forge/server.py
+++ b/src/forge/server.py
@@ -49,8 +49,9 @@ class ServerManager:
         """
         Args:
             backend: Which backend this manager controls
-                     (``"ollama"`` | ``"llamaserver"`` | ``"llamafile"``).
-            port: Server port (llama-server / llamafile only).
+                     (``"ollama"`` | ``"llamaserver"`` | ``"llamafile"`` |
+                     ``"vllm"``).
+            port: Server port (llama-server / llamafile / vllm only).
             models_dir: Directory containing GGUF files.
         """
         self._backend = backend
@@ -72,7 +73,9 @@ class ServerManager:
     async def start(
         self,
         model: str,
-        gguf_path: str | Path,
+        *,
+        gguf_path: str | Path | None = None,
+        model_path: str | Path | None = None,
         mode: str = "native",
         extra_flags: list[str] | None = None,
         ctx_override: int | None = None,
@@ -81,11 +84,17 @@ class ServerManager:
         n_slots: int | None = None,
         kv_unified: bool = False,
     ) -> None:
-        """Start a llama-server/llamafile process.
+        """Start a llama-server/llamafile/vllm process.
 
         No-op if the same model + mode + ctx + extra_flags + cache types
         + slots + kv_unified is already running.
         For ``backend="ollama"`` this is always a no-op.
+
+        Path argument is backend-specific (mutually exclusive, validated):
+        - ``gguf_path`` required for ``llamaserver`` / ``llamafile``
+          (single .gguf file).
+        - ``model_path`` required for ``vllm`` (directory containing
+          safetensors or HuggingFace repo id).
 
         For ``backend="llamafile"``, the llamafile runtime binary is
         located automatically in the same directory as *gguf_path*
@@ -93,23 +102,60 @@ class ServerManager:
 
         Args:
             model: Canonical model name.
-            gguf_path: Path to the GGUF or llamafile model file.
-            mode: ``"native"`` or ``"prompt"``.
-            extra_flags: Additional CLI flags (e.g. ``["--reasoning-format", "auto"]``).
-            ctx_override: If set, pass ``-c <value>`` to the server.
+            gguf_path: Path to the GGUF or llamafile model file
+                       (llamaserver / llamafile only).
+            model_path: Path to model directory or HF repo id (vllm only).
+            mode: ``"native"`` or ``"prompt"``. vLLM ignores this — its
+                  chat template comes from the model and tool/reasoning
+                  parsing is configured at server boot via extra_flags.
+            extra_flags: Additional CLI flags.
+            ctx_override: If set, pass ``-c <value>`` (llama-server /
+                          llamafile) or ``--max-model-len <value>``
+                          (vllm).
             cache_type_k: KV cache quantization type for keys
-                          (e.g. ``"q8_0"``, ``"q4_0"``).
+                          (e.g. ``"q8_0"``, ``"q4_0"``). llama-server /
+                          llamafile only.
             cache_type_v: KV cache quantization type for values
-                          (e.g. ``"q8_0"``, ``"q4_0"``).
+                          (e.g. ``"q8_0"``, ``"q4_0"``). llama-server /
+                          llamafile only.
             n_slots: Number of concurrent slots (each with its own KV
-                     cache). Used for multi-agent architectures.
+                     cache). llama-server / llamafile only.
             kv_unified: If True, use a single unified KV cache shared
-                        across all slots. Each slot can use up to the
-                        full context. Without this, context is hard-
-                        partitioned per slot.
+                        across all slots. llama-server / llamafile only.
         """
         if self._backend == "ollama":
             return
+
+        # Per-backend path validation (fail-fast on misuse).
+        if self._backend in ("llamaserver", "llamafile"):
+            if model_path is not None:
+                raise ValueError(
+                    f"backend={self._backend!r} does not accept model_path "
+                    "(use gguf_path)"
+                )
+            if not gguf_path:
+                raise ValueError(
+                    f"backend={self._backend!r} requires gguf_path"
+                )
+        elif self._backend == "vllm":
+            if gguf_path is not None:
+                raise ValueError(
+                    "backend='vllm' does not accept gguf_path (use model_path)"
+                )
+            if not model_path:
+                raise ValueError("backend='vllm' requires model_path")
+            if cache_type_k is not None or cache_type_v is not None:
+                raise ValueError(
+                    "backend='vllm' does not support cache_type_k/cache_type_v "
+                    "(quantization is baked into the model artifact)"
+                )
+            if n_slots is not None or kv_unified:
+                raise ValueError(
+                    "backend='vllm' does not support n_slots/kv_unified "
+                    "(vLLM has its own scheduler concepts)"
+                )
+        else:
+            raise ValueError(f"unsupported backend: {self._backend!r}")
 
         # Reuse if same configuration is already running
         flags = tuple(extra_flags) if extra_flags else ()
@@ -140,7 +186,21 @@ class ServerManager:
                 "--port",
                 str(self._port),
             ]
-        else:
+            if mode == "native":
+                cmd.append("--jinja")
+            if extra_flags:
+                cmd.extend(extra_flags)
+            if ctx_override is not None:
+                cmd.extend(["-c", str(ctx_override)])
+            if cache_type_k is not None:
+                cmd.extend(["--cache-type-k", cache_type_k])
+            if cache_type_v is not None:
+                cmd.extend(["--cache-type-v", cache_type_v])
+            if n_slots is not None:
+                cmd.extend(["--parallel", str(n_slots)])
+            if kv_unified:
+                cmd.append("--kv-unified")
+        elif self._backend == "llamaserver":
             cmd = [
                 "llama-server",
                 "-m",
@@ -150,20 +210,32 @@ class ServerManager:
                 "--port",
                 str(self._port),
             ]
-        if mode == "native":
-            cmd.append("--jinja")
-        if extra_flags:
-            cmd.extend(extra_flags)
-        if ctx_override is not None:
-            cmd.extend(["-c", str(ctx_override)])
-        if cache_type_k is not None:
-            cmd.extend(["--cache-type-k", cache_type_k])
-        if cache_type_v is not None:
-            cmd.extend(["--cache-type-v", cache_type_v])
-        if n_slots is not None:
-            cmd.extend(["--parallel", str(n_slots)])
-        if kv_unified:
-            cmd.append("--kv-unified")
+            if mode == "native":
+                cmd.append("--jinja")
+            if extra_flags:
+                cmd.extend(extra_flags)
+            if ctx_override is not None:
+                cmd.extend(["-c", str(ctx_override)])
+            if cache_type_k is not None:
+                cmd.extend(["--cache-type-k", cache_type_k])
+            if cache_type_v is not None:
+                cmd.extend(["--cache-type-v", cache_type_v])
+            if n_slots is not None:
+                cmd.extend(["--parallel", str(n_slots)])
+            if kv_unified:
+                cmd.append("--kv-unified")
+        else:  # vllm
+            cmd = [
+                "vllm",
+                "serve",
+                str(model_path),
+                "--port",
+                str(self._port),
+            ]
+            if extra_flags:
+                cmd.extend(extra_flags)
+            if ctx_override is not None:
+                cmd.extend(["--max-model-len", str(ctx_override)])
 
         self._proc = subprocess.Popen(
             cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
@@ -224,20 +296,36 @@ class ServerManager:
             return resp.json()
 
     async def get_server_context(self) -> int:
-        """Read the actual n_ctx from the running server.
+        """Read the actual context length from the running server.
 
-        Note: Without ``--kv-unified``, llama-server's ``/props`` endpoint
-        reports **per-slot** context (``total_ctx / n_parallel``). With
-        ``--kv-unified``, it reports the full available context (each slot
-        can use the whole pool).
+        llamaserver/llamafile: reads from ``/props``. Without
+        ``--kv-unified`` this is the per-slot partition; with it, the
+        full pool. Either is the correct compaction budget.
 
-        Returns:
-            The context length as reported by ``/props``.
+        vllm: reads ``max_model_len`` from ``/v1/models``.
 
         Raises:
             BudgetResolutionError: Server unreachable, returned an error,
-                or response missing the n_ctx field.
+                or response missing the expected field.
         """
+        if self._backend == "vllm":
+            url = f"http://localhost:{self._port}/v1/models"
+            try:
+                async with httpx.AsyncClient(timeout=10.0) as client:
+                    resp = await client.get(url)
+                    if resp.status_code != 200:
+                        raise BackendError(resp.status_code, resp.text)
+                    data = resp.json()
+            except (httpx.HTTPError, BackendError) as exc:
+                raise BudgetResolutionError(cause=exc) from exc
+            models = data.get("data") or []
+            if not models:
+                raise BudgetResolutionError()
+            ctx = models[0].get("max_model_len")
+            if ctx is None:
+                raise BudgetResolutionError()
+            return int(ctx)
+
         try:
             props = await self.query_props()
         except (httpx.HTTPError, BackendError) as exc:
@@ -291,7 +379,9 @@ class ServerManager:
     async def start_with_budget(
         self,
         model: str,
-        gguf_path: str | Path,
+        *,
+        gguf_path: str | Path | None = None,
+        model_path: str | Path | None = None,
         mode: str = "native",
         budget_mode: BudgetMode = BudgetMode.BACKEND,
         manual_tokens: int | None = None,
@@ -350,7 +440,8 @@ class ServerManager:
         if budget_mode == BudgetMode.FORGE_FAST:
             # Phase 1: start with auto-tune to discover max
             await self.start(
-                model, gguf_path, mode, extra_flags, ctx_override=None,
+                model, gguf_path=gguf_path, model_path=model_path,
+                mode=mode, extra_flags=extra_flags, ctx_override=None,
                 cache_type_k=cache_type_k, cache_type_v=cache_type_v,
                 n_slots=n_slots, kv_unified=kv_unified,
             )
@@ -365,7 +456,8 @@ class ServerManager:
 
             # Phase 2: restart with half total context
             await self.start(
-                model, gguf_path, mode, extra_flags, ctx_override=half_total,
+                model, gguf_path=gguf_path, model_path=model_path,
+                mode=mode, extra_flags=extra_flags, ctx_override=half_total,
                 cache_type_k=cache_type_k, cache_type_v=cache_type_v,
                 n_slots=n_slots, kv_unified=kv_unified,
             )
@@ -374,7 +466,8 @@ class ServerManager:
         # BACKEND / FORGE_FULL / MANUAL
         ctx_override = manual_tokens if budget_mode == BudgetMode.MANUAL else None
         await self.start(
-            model, gguf_path, mode, extra_flags, ctx_override=ctx_override,
+            model, gguf_path=gguf_path, model_path=model_path,
+            mode=mode, extra_flags=extra_flags, ctx_override=ctx_override,
             cache_type_k=cache_type_k, cache_type_v=cache_type_v,
             n_slots=n_slots, kv_unified=kv_unified,
         )
@@ -406,32 +499,43 @@ class ServerManager:
 
     # ── health polling ──────────────────────────────────────────
 
-    async def _wait_healthy(self, timeout: float = 180.0) -> None:
-        """Poll ``/props`` until the server is fully ready.
+    async def _wait_healthy(self, timeout: float | None = None) -> None:
+        """Poll until the server is fully ready.
 
-        Uses ``/props`` rather than ``/health`` because llama-server's
-        middleware gates both endpoints behind ``is_ready``, but polling
-        ``/props`` directly confirms the model is loaded and serving —
-        eliminating any gap between health-ok and props-available.
+        llamaserver/llamafile: polls ``/props`` (which gates ``is_ready``
+        AND confirms model loaded). 180s default.
+
+        vllm: polls ``/v1/models`` (returns the loaded model entry only
+        after the engine is fully initialized — strictly stronger than
+        ``/health`` which can flip true mid-load). 300s default to
+        accommodate vLLM's 2-3 min cold-start with tensor parallel.
 
         Raises:
             RuntimeError: If the server doesn't become ready within *timeout*.
         """
-        url = f"http://localhost:{self._port}/props"
-        deadline = time.monotonic() + timeout
+        if self._backend == "vllm":
+            url = f"http://localhost:{self._port}/v1/models"
+            effective_timeout = timeout if timeout is not None else 300.0
+            readiness_check = lambda data: bool(data.get("data"))
+        else:
+            url = f"http://localhost:{self._port}/props"
+            effective_timeout = timeout if timeout is not None else 180.0
+            readiness_check = lambda data: "default_generation_settings" in data
+
+        deadline = time.monotonic() + effective_timeout
         async with httpx.AsyncClient(timeout=5.0) as client:
             while time.monotonic() < deadline:
                 try:
                     resp = await client.get(url)
                     if resp.status_code == 200:
                         data = resp.json()
-                        if "default_generation_settings" in data:
+                        if readiness_check(data):
                             return
                 except (httpx.ConnectError, httpx.ReadError, httpx.TimeoutException):
                     pass
                 await asyncio.sleep(2)
         raise RuntimeError(
-            f"Server did not become ready within {timeout}s"
+            f"Server did not become ready within {effective_timeout}s"
         )
 
 
@@ -442,6 +546,7 @@ async def setup_backend(
     manual_tokens: int | None = None,
     client: Any | None = None,
     gguf_path: str | Path | None = None,
+    model_path: str | Path | None = None,
     mode: str = "native",
     port: int = 8080,
     extra_flags: list[str] | None = None,
@@ -459,26 +564,30 @@ async def setup_backend(
 
     Identity rules (mutually exclusive, enforced at call time):
 
-    - ``backend="ollama"``: ``model`` required, ``gguf_path`` rejected. The
-      Ollama runtime is keyed by the model string.
-    - ``backend in ("llamaserver", "llamafile")``: ``gguf_path`` required,
-      ``model`` rejected. The model file *is* the identity.
+    - ``backend="ollama"``: ``model`` required; ``gguf_path`` and
+      ``model_path`` rejected. The Ollama runtime is keyed by the model
+      string.
+    - ``backend in ("llamaserver", "llamafile")``: ``gguf_path`` required;
+      ``model`` and ``model_path`` rejected. The model file *is* the
+      identity.
+    - ``backend="vllm"``: ``model_path`` required; ``model`` and
+      ``gguf_path`` rejected. ``model_path`` is a directory containing
+      model weights/config (safetensors) or a HuggingFace repo id.
 
     For Ollama backends, pass the ``client`` so that ``set_num_ctx()`` is
     called automatically — keeping the client's per-request ``num_ctx``
     in sync with the resolved budget.  For llama-server / llamafile the
     context size is baked into the server process via ``-c``, so the
-    client parameter is ignored.
+    client parameter is ignored. For vllm, context size is baked in via
+    ``--max-model-len``; the client parameter is ignored.
 
     KV cache quantization (``cache_type_k`` / ``cache_type_v``) reduces
-    VRAM usage per token, effectively increasing usable context for the
-    same GPU memory.  Common values: ``"q8_0"`` (~50% savings vs F16),
-    ``"q4_0"`` (~75% savings).  Only applies to llama-server / llamafile.
+    VRAM usage per token. Llama-server / llamafile only — vLLM rejects
+    these (quantization is baked into the model artifact).
 
     When ``kv_unified=True``, all slots share a single KV cache pool.
-    Each slot can use up to the full context. The returned budget reflects
-    the total available context (not per-slot). Without it, context is
-    hard-partitioned per slot and the budget reflects the per-slot amount.
+    Llama-server / llamafile only — vLLM has its own scheduler concepts
+    and rejects ``n_slots`` / ``kv_unified``.
 
     Example usage::
 
@@ -500,12 +609,24 @@ async def setup_backend(
     if backend == "ollama":
         if gguf_path is not None:
             raise ValueError("backend='ollama' does not accept gguf_path (use model)")
+        if model_path is not None:
+            raise ValueError("backend='ollama' does not accept model_path (use model)")
         if not model:
             raise ValueError("backend='ollama' requires model")
         identity = model
-    else:  # llamaserver / llamafile
+    elif backend == "vllm":
+        if gguf_path is not None:
+            raise ValueError("backend='vllm' does not accept gguf_path (use model_path)")
+        if model is not None:
+            raise ValueError("backend='vllm' does not accept model (use model_path)")
+        if not model_path:
+            raise ValueError("backend='vllm' requires model_path")
+        identity = str(model_path)
+    elif backend in ("llamaserver", "llamafile"):
         if model is not None:
             raise ValueError(f"backend={backend!r} does not accept model (use gguf_path)")
+        if model_path is not None:
+            raise ValueError(f"backend={backend!r} does not accept model_path (use gguf_path)")
         if not gguf_path:
             raise ValueError(f"backend={backend!r} requires gguf_path")
         # ServerManager's cache-equality check keys off the identity string.
@@ -514,11 +635,14 @@ async def setup_backend(
         # 'model' field is set elsewhere (LlamafileClient derives it from
         # gguf_path stem); ServerManager only needs equality semantics.
         identity = str(gguf_path)
+    else:
+        raise ValueError(f"unsupported backend: {backend!r}")
 
     server = ServerManager(backend=backend, port=port)
     budget = await server.start_with_budget(
         model=identity,
-        gguf_path=gguf_path or "",
+        gguf_path=gguf_path,
+        model_path=model_path,
         mode=mode,
         budget_mode=budget_mode,
         manual_tokens=manual_tokens,

--- a/tests/unit/test_proxy_proxy.py
+++ b/tests/unit/test_proxy_proxy.py
@@ -1,0 +1,288 @@
+"""Tests for ProxyServer construction and wiring.
+
+HTTPServer protocol-level tests live in test_proxy_server.py; Anthropic
+Path-1 wiring in test_proxy_path1.py. This file covers the ProxyServer
+wrapper: construction validation, client selection, and the external/
+managed setup paths (including vLLM).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from forge.clients.llamafile import LlamafileClient
+from forge.clients.ollama import OllamaClient
+from forge.clients.vllm import VLLMClient
+from forge.context.manager import ContextManager
+from forge.proxy.proxy import ProxyServer
+from forge.server import BudgetMode
+
+
+class TestConstructorValidation:
+    """__init__ validation: mode/protocol guards and managed identity rules."""
+
+    def test_neither_url_nor_backend_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Provide either backend_url"):
+            ProxyServer()
+
+    def test_anthropic_requires_external(self) -> None:
+        with pytest.raises(ValueError, match="requires external mode"):
+            ProxyServer(backend="llamaserver", gguf="m.gguf", backend_protocol="anthropic")
+
+    def test_anthropic_rejects_prompt_mode(self) -> None:
+        with pytest.raises(ValueError, match="mode='prompt' is not supported"):
+            ProxyServer(
+                backend_url="http://x", backend_protocol="anthropic", mode="prompt",
+            )
+
+    def test_vllm_rejects_anthropic_protocol(self) -> None:
+        with pytest.raises(ValueError, match="speaks the OpenAI protocol"):
+            ProxyServer(backend_url="http://x:8000", backend="vllm", backend_protocol="anthropic")
+
+    def test_vllm_rejects_prompt_mode(self) -> None:
+        with pytest.raises(ValueError, match="parses tool calls server-side"):
+            ProxyServer(backend="vllm", model_path="/m", mode="prompt")
+
+    # Managed identity rules
+    def test_managed_ollama_requires_model(self) -> None:
+        with pytest.raises(ValueError, match="backend='ollama' requires model"):
+            ProxyServer(backend="ollama")
+
+    def test_managed_llamaserver_requires_gguf(self) -> None:
+        with pytest.raises(ValueError, match="requires gguf"):
+            ProxyServer(backend="llamaserver")
+
+    def test_managed_llamafile_requires_gguf(self) -> None:
+        with pytest.raises(ValueError, match="requires gguf"):
+            ProxyServer(backend="llamafile")
+
+    def test_managed_vllm_requires_model_path(self) -> None:
+        with pytest.raises(ValueError, match="requires model_path"):
+            ProxyServer(backend="vllm")
+
+    def test_managed_ok(self) -> None:
+        ProxyServer(backend="llamaserver", gguf="m.gguf")
+        ProxyServer(backend="llamafile", gguf="m.gguf")
+        ProxyServer(backend="vllm", model_path="/m")
+        ProxyServer(backend="ollama", model="llama3")
+
+    def test_external_ok(self) -> None:
+        proxy = ProxyServer(backend_url="http://x:8080")
+        assert proxy._backend_url == "http://x:8080"
+        assert proxy._backend is None
+        proxy2 = ProxyServer(backend_url="http://x:8000", backend="vllm")
+        assert proxy2._backend == "vllm"
+
+    # Serialize auto-detection: managed (no url) serializes, external does not.
+    def test_serialize_auto_managed_true(self) -> None:
+        assert ProxyServer(backend="vllm", model_path="/m")._serialize is True
+
+    def test_serialize_auto_external_false(self) -> None:
+        # Even with backend set (external vLLM), external mode does not serialize.
+        assert ProxyServer(backend_url="http://x:8000", backend="vllm")._serialize is False
+
+    def test_serialize_override(self) -> None:
+        assert ProxyServer(backend_url="http://x:8000", serialize=True)._serialize is True
+
+
+class TestSetupExternal:
+    """External mode constructs the right client and resolves budget."""
+
+    @pytest.mark.asyncio
+    async def test_llamaserver_uses_llamafile_client(self) -> None:
+        proxy = ProxyServer(backend_url="http://localhost:8080", budget_tokens=8192)
+        client, ctx = await proxy._setup_external()
+        assert isinstance(client, LlamafileClient)
+        assert client.base_url == "http://localhost:8080/v1"
+        assert ctx.budget_tokens == 8192
+
+    @pytest.mark.asyncio
+    async def test_explicit_llamafile_backend_uses_llamafile_client(self) -> None:
+        proxy = ProxyServer(
+            backend_url="http://localhost:8080", backend="llamafile", budget_tokens=8192,
+        )
+        client, _ = await proxy._setup_external()
+        assert isinstance(client, LlamafileClient)
+
+    @pytest.mark.asyncio
+    async def test_vllm_uses_vllm_client(self) -> None:
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm", budget_tokens=8192,
+        )
+        with patch.object(
+            VLLMClient, "get_served_model_name", new_callable=AsyncMock, return_value=None,
+        ):
+            client, ctx = await proxy._setup_external()
+        assert isinstance(client, VLLMClient)
+        assert client.base_url == "http://localhost:8000/v1"
+        assert ctx.budget_tokens == 8192
+
+    @pytest.mark.asyncio
+    async def test_vllm_adopts_served_model_name(self) -> None:
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm", budget_tokens=8192,
+        )
+        with patch.object(
+            VLLMClient, "get_served_model_name",
+            new_callable=AsyncMock, return_value="my-awq-model",
+        ):
+            client, _ = await proxy._setup_external()
+        assert client.model_path == "my-awq-model"
+        assert client.model == "my-awq-model"
+
+    @pytest.mark.asyncio
+    async def test_vllm_keeps_placeholder_when_discovery_fails(self) -> None:
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm", budget_tokens=8192,
+        )
+        with patch.object(
+            VLLMClient, "get_served_model_name", new_callable=AsyncMock, return_value=None,
+        ):
+            client, _ = await proxy._setup_external()
+        assert client.model_path == "default"
+
+    @pytest.mark.asyncio
+    async def test_url_v1_suffix_preserved(self) -> None:
+        proxy = ProxyServer(backend_url="http://localhost:8080/v1", budget_tokens=8192)
+        client, _ = await proxy._setup_external()
+        assert client.base_url == "http://localhost:8080/v1"
+
+    @pytest.mark.asyncio
+    async def test_url_trailing_slash_stripped(self) -> None:
+        proxy = ProxyServer(backend_url="http://localhost:8080/", budget_tokens=8192)
+        client, _ = await proxy._setup_external()
+        assert client.base_url == "http://localhost:8080/v1"
+
+    @pytest.mark.asyncio
+    async def test_budget_from_backend_when_unspecified(self) -> None:
+        proxy = ProxyServer(backend_url="http://localhost:8080")
+        with patch.object(
+            LlamafileClient, "get_context_length",
+            new_callable=AsyncMock, return_value=32768,
+        ):
+            _, ctx = await proxy._setup_external()
+        assert ctx.budget_tokens == 32768
+
+    @pytest.mark.asyncio
+    async def test_budget_unresolvable_raises(self) -> None:
+        proxy = ProxyServer(backend_url="http://localhost:8080")
+        with patch.object(
+            LlamafileClient, "get_context_length",
+            new_callable=AsyncMock, return_value=None,
+        ), pytest.raises(RuntimeError, match="did not report a context length"):
+            await proxy._setup_external()
+
+
+class TestSetupManaged:
+    """Managed mode delegates to setup_backend with the right identity field."""
+
+    @pytest.mark.asyncio
+    async def test_llamaserver_wiring(self) -> None:
+        proxy = ProxyServer(
+            backend="llamaserver",
+            gguf="/models/x.gguf",
+            backend_port=8080,
+            budget_mode=BudgetMode.FORGE_FAST,
+            extra_flags=["-ngl", "99"],
+        )
+        mock_ctx = ContextManager.__new__(ContextManager)
+        mock_ctx.budget_tokens = 16384
+        mock_server = MagicMock()
+
+        with patch(
+            "forge.proxy.proxy.setup_backend",
+            new_callable=AsyncMock, return_value=(mock_server, mock_ctx),
+        ) as mock_setup:
+            client, ctx = await proxy._setup_managed()
+
+        assert isinstance(client, LlamafileClient)
+        assert client.base_url == "http://localhost:8080/v1"
+        kwargs = mock_setup.await_args.kwargs
+        assert kwargs["backend"] == "llamaserver"
+        assert kwargs["gguf_path"] == "/models/x.gguf"
+        assert kwargs["model"] is None
+        assert kwargs["model_path"] is None
+        assert kwargs["mode"] == "native"
+        assert kwargs["port"] == 8080
+        assert kwargs["budget_mode"] == BudgetMode.FORGE_FAST
+        assert kwargs["extra_flags"] == ["-ngl", "99"]
+        assert kwargs["client"] is client
+        assert proxy._server_manager is mock_server
+        assert ctx is mock_ctx
+
+    @pytest.mark.asyncio
+    async def test_vllm_wiring(self) -> None:
+        proxy = ProxyServer(
+            backend="vllm", model_path="/models/awq", backend_port=8000,
+            budget_tokens=113000, budget_mode=BudgetMode.MANUAL,
+        )
+        mock_ctx = ContextManager.__new__(ContextManager)
+        mock_ctx.budget_tokens = 113000
+        with patch(
+            "forge.proxy.proxy.setup_backend",
+            new_callable=AsyncMock, return_value=(MagicMock(), mock_ctx),
+        ) as mock_setup:
+            client, _ = await proxy._setup_managed()
+
+        assert isinstance(client, VLLMClient)
+        assert client.base_url == "http://localhost:8000/v1"
+        kwargs = mock_setup.await_args.kwargs
+        assert kwargs["backend"] == "vllm"
+        assert kwargs["model_path"] == "/models/awq"
+        assert kwargs["gguf_path"] is None
+        assert kwargs["model"] is None
+        assert kwargs["manual_tokens"] == 113000
+        assert kwargs["budget_mode"] == BudgetMode.MANUAL
+
+    @pytest.mark.asyncio
+    async def test_ollama_wiring(self) -> None:
+        proxy = ProxyServer(backend="ollama", model="ministral-3:14b")
+        mock_ctx = ContextManager.__new__(ContextManager)
+        mock_ctx.budget_tokens = 4096
+        with patch(
+            "forge.proxy.proxy.setup_backend",
+            new_callable=AsyncMock, return_value=(MagicMock(), mock_ctx),
+        ) as mock_setup:
+            client, _ = await proxy._setup_managed()
+        assert isinstance(client, OllamaClient)
+        kwargs = mock_setup.await_args.kwargs
+        assert kwargs["backend"] == "ollama"
+        assert kwargs["model"] == "ministral-3:14b"
+        assert kwargs["gguf_path"] is None
+        assert kwargs["model_path"] is None
+        # Client is passed through so setup_backend can wire num_ctx.
+        assert kwargs["client"] is client
+
+    @pytest.mark.asyncio
+    async def test_managed_llamafile_carries_client_mode(self) -> None:
+        # prompt mode is a client-side concern; the server still starts native.
+        proxy = ProxyServer(backend="llamafile", gguf="/m/x.gguf", mode="prompt")
+        mock_ctx = ContextManager.__new__(ContextManager)
+        mock_ctx.budget_tokens = 8192
+        with patch(
+            "forge.proxy.proxy.setup_backend",
+            new_callable=AsyncMock, return_value=(MagicMock(), mock_ctx),
+        ) as mock_setup:
+            client, _ = await proxy._setup_managed()
+        assert isinstance(client, LlamafileClient)
+        assert client.mode == "prompt"
+        assert mock_setup.await_args.kwargs["mode"] == "native"
+
+
+class TestLifecycle:
+    """start()/stop() thread + state management."""
+
+    def test_url_property(self) -> None:
+        proxy = ProxyServer(backend_url="http://localhost:8000", host="0.0.0.0", port=9000)
+        assert proxy.url == "http://0.0.0.0:9000"
+
+    def test_stop_before_start_noop(self) -> None:
+        ProxyServer(backend_url="http://localhost:8000").stop()  # should not raise
+
+    def test_start_twice_idempotent(self) -> None:
+        proxy = ProxyServer(backend_url="http://localhost:8000")
+        proxy._started = True
+        proxy.start()  # returns immediately without spawning a thread
+        assert proxy._thread is None

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -71,7 +71,7 @@ class TestServerManagerStart:
             patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", "/models/llama3.gguf")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf")
 
         args = mock_popen.call_args[0][0]
         assert "llama-server" in args
@@ -89,7 +89,7 @@ class TestServerManagerStart:
             patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", "/models/llama3.gguf", mode="native")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", mode="native")
 
         args = mock_popen.call_args[0][0]
         assert "--jinja" in args
@@ -101,7 +101,7 @@ class TestServerManagerStart:
             patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", "/models/llama3.gguf", mode="prompt")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", mode="prompt")
 
         args = mock_popen.call_args[0][0]
         assert "--jinja" not in args
@@ -114,7 +114,7 @@ class TestServerManagerStart:
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
             await sm.start(
-                "qwen3", "/models/qwen3.gguf",
+                "qwen3", gguf_path="/models/qwen3.gguf",
                 extra_flags=["--reasoning-format", "auto"],
             )
 
@@ -129,7 +129,7 @@ class TestServerManagerStart:
             patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", "/models/llama3.gguf", ctx_override=8000)
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", ctx_override=8000)
 
         args = mock_popen.call_args[0][0]
         assert "-c" in args
@@ -142,8 +142,8 @@ class TestServerManagerStart:
             patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", "/models/llama3.gguf", mode="native")
-            await sm.start("llama3", "/models/llama3.gguf", mode="native")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", mode="native")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", mode="native")
 
         assert mock_popen.call_count == 1
 
@@ -156,14 +156,14 @@ class TestServerManagerStart:
             patch.object(sm, "stop", new_callable=AsyncMock) as mock_stop,
         ):
             # First start — stop is called but nothing to stop
-            await sm.start("llama3", "/models/llama3.gguf", mode="native")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", mode="native")
             # Simulate state after first start
             sm._current_model = "llama3"
             sm._current_mode = "native"
             sm._current_ctx = None
 
             # Second start with different mode — should restart
-            await sm.start("llama3", "/models/llama3.gguf", mode="prompt")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", mode="prompt")
 
         assert mock_popen.call_count == 2
         # stop() called before each start
@@ -177,12 +177,12 @@ class TestServerManagerStart:
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
             patch.object(sm, "stop", new_callable=AsyncMock) as mock_stop,
         ):
-            await sm.start("llama3", "/models/llama3.gguf")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf")
             sm._current_model = "llama3"
             sm._current_mode = "native"
             sm._current_ctx = None
 
-            await sm.start("llama3", "/models/llama3.gguf", ctx_override=8000)
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", ctx_override=8000)
 
         assert mock_popen.call_count == 2
 
@@ -194,14 +194,14 @@ class TestServerManagerStart:
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
             patch.object(sm, "stop", new_callable=AsyncMock) as mock_stop,
         ):
-            await sm.start("llama3", "/models/llama3.gguf", mode="native")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", mode="native")
             sm._current_model = "llama3"
             sm._current_mode = "native"
             sm._current_ctx = None
 
             # Same model/mode/ctx but different extra_flags — should restart
             await sm.start(
-                "llama3", "/models/llama3.gguf", mode="native",
+                "llama3", gguf_path="/models/llama3.gguf", mode="native",
                 extra_flags=["--reasoning-format", "auto"],
             )
 
@@ -215,11 +215,11 @@ class TestServerManagerStart:
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
             await sm.start(
-                "llama3", "/models/llama3.gguf", mode="native",
+                "llama3", gguf_path="/models/llama3.gguf", mode="native",
                 extra_flags=["--reasoning-format", "auto"],
             )
             await sm.start(
-                "llama3", "/models/llama3.gguf", mode="native",
+                "llama3", gguf_path="/models/llama3.gguf", mode="native",
                 extra_flags=["--reasoning-format", "auto"],
             )
 
@@ -229,7 +229,7 @@ class TestServerManagerStart:
     async def test_start_noop_for_ollama(self) -> None:
         sm = ServerManager(backend="ollama")
         with patch("forge.server.subprocess.Popen") as mock_popen:
-            await sm.start("llama3", "/models/llama3.gguf")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf")
 
         mock_popen.assert_not_called()
 
@@ -247,7 +247,7 @@ class TestServerManagerStart:
             patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", str(model_path), mode="prompt")
+            await sm.start("llama3", gguf_path=str(model_path), mode="prompt")
 
         args = mock_popen.call_args[0][0]
         assert str(runtime) in args
@@ -264,7 +264,7 @@ class TestServerManagerStart:
         model_path.touch()
         # No llamafile-* runtime in tmp_path
         with pytest.raises(FileNotFoundError, match="No llamafile runtime"):
-            await sm.start("llama3", str(model_path), mode="prompt")
+            await sm.start("llama3", gguf_path=str(model_path), mode="prompt")
 
     @pytest.mark.asyncio
     async def test_start_llamafile_picks_highest_version(self, tmp_path: Path) -> None:
@@ -281,7 +281,7 @@ class TestServerManagerStart:
             patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", str(model_path), mode="prompt")
+            await sm.start("llama3", gguf_path=str(model_path), mode="prompt")
 
         args = mock_popen.call_args[0][0]
         assert str(tmp_path / "llamafile-0.9.2.exe") in args
@@ -295,7 +295,7 @@ class TestServerManagerStart:
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
             await sm.start(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 cache_type_k="q8_0", cache_type_v="q8_0",
             )
 
@@ -317,7 +317,7 @@ class TestServerManagerStart:
             patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", "/models/llama3.gguf")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf")
 
         cmd = mock_popen.call_args[0][0]
         assert "--cache-type-k" not in cmd
@@ -332,14 +332,14 @@ class TestServerManagerStart:
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
             patch("forge.server.asyncio.sleep", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", "/models/llama3.gguf", cache_type_k="q8_0")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", cache_type_k="q8_0")
             assert sm._current_cache_type_k == "q8_0"
 
             # Same config — should reuse (no restart)
-            await sm.start("llama3", "/models/llama3.gguf", cache_type_k="q8_0")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", cache_type_k="q8_0")
 
             # Different cache type — should restart
-            await sm.start("llama3", "/models/llama3.gguf", cache_type_k="q4_0")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", cache_type_k="q4_0")
             assert sm._current_cache_type_k == "q4_0"
 
     @pytest.mark.asyncio
@@ -350,7 +350,7 @@ class TestServerManagerStart:
             patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", "/models/llama3.gguf", n_slots=2)
+            await sm.start("llama3", gguf_path="/models/llama3.gguf", n_slots=2)
 
         cmd = mock_popen.call_args[0][0]
         assert "--parallel" in cmd
@@ -366,10 +366,143 @@ class TestServerManagerStart:
             patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
         ):
-            await sm.start("llama3", "/models/llama3.gguf")
+            await sm.start("llama3", gguf_path="/models/llama3.gguf")
 
         cmd = mock_popen.call_args[0][0]
         assert "--parallel" not in cmd
+
+
+# ── ServerManager.start() — vllm backend ────────────────────────
+
+
+class TestServerManagerStartVllm:
+    """start() vLLM-specific path: cmd build, validation, /v1/models discovery."""
+
+    @pytest.fixture()
+    def sm(self) -> ServerManager:
+        return ServerManager(backend="vllm", port=8000)
+
+    @pytest.mark.asyncio
+    async def test_start_launches_vllm_serve(self, sm: ServerManager) -> None:
+        mock_proc = MagicMock()
+        with (
+            patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
+        ):
+            await sm.start(
+                "gemma-4-AWQ",
+                model_path="/models/gemma-4-26B-A4B-it-AWQ-4bit",
+            )
+
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[0] == "vllm"
+        assert cmd[1] == "serve"
+        assert "/models/gemma-4-26B-A4B-it-AWQ-4bit" in cmd
+        assert "--port" in cmd
+        assert "8000" in cmd
+
+    @pytest.mark.asyncio
+    async def test_start_does_not_pass_llamacpp_flags(self, sm: ServerManager) -> None:
+        """vLLM should never receive llama.cpp-specific flags like --jinja."""
+        mock_proc = MagicMock()
+        with (
+            patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
+        ):
+            await sm.start(
+                "gemma-4-AWQ",
+                model_path="/models/gemma",
+                mode="native",
+            )
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--jinja" not in cmd
+        assert "-c" not in cmd  # llama.cpp ctx flag
+        assert "-m" not in cmd  # llama.cpp model flag
+
+    @pytest.mark.asyncio
+    async def test_ctx_override_passes_max_model_len(self, sm: ServerManager) -> None:
+        mock_proc = MagicMock()
+        with (
+            patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
+        ):
+            await sm.start(
+                "gemma-4-AWQ",
+                model_path="/models/gemma",
+                ctx_override=113000,
+            )
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--max-model-len" in cmd
+        idx = cmd.index("--max-model-len")
+        assert cmd[idx + 1] == "113000"
+
+    @pytest.mark.asyncio
+    async def test_extra_flags_appended(self, sm: ServerManager) -> None:
+        mock_proc = MagicMock()
+        with (
+            patch("forge.server.subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch.object(sm, "_wait_healthy", new_callable=AsyncMock),
+        ):
+            await sm.start(
+                "gemma-4-AWQ",
+                model_path="/models/gemma",
+                extra_flags=[
+                    "--tensor-parallel-size", "2",
+                    "--reasoning-parser", "gemma4",
+                    "--tool-call-parser", "gemma4",
+                    "--enable-auto-tool-choice",
+                ],
+            )
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--tensor-parallel-size" in cmd
+        assert "--reasoning-parser" in cmd
+        assert "gemma4" in cmd
+
+    @pytest.mark.asyncio
+    async def test_rejects_gguf_path(self, sm: ServerManager) -> None:
+        with pytest.raises(ValueError, match="does not accept gguf_path"):
+            await sm.start("x", gguf_path="/models/x.gguf")
+
+    @pytest.mark.asyncio
+    async def test_requires_model_path(self, sm: ServerManager) -> None:
+        with pytest.raises(ValueError, match="requires model_path"):
+            await sm.start("x")
+
+    @pytest.mark.asyncio
+    async def test_rejects_cache_type_k(self, sm: ServerManager) -> None:
+        with pytest.raises(ValueError, match="does not support cache_type"):
+            await sm.start("x", model_path="/m", cache_type_k="q8_0")
+
+    @pytest.mark.asyncio
+    async def test_rejects_cache_type_v(self, sm: ServerManager) -> None:
+        with pytest.raises(ValueError, match="does not support cache_type"):
+            await sm.start("x", model_path="/m", cache_type_v="q8_0")
+
+    @pytest.mark.asyncio
+    async def test_rejects_n_slots(self, sm: ServerManager) -> None:
+        with pytest.raises(ValueError, match="does not support n_slots"):
+            await sm.start("x", model_path="/m", n_slots=2)
+
+    @pytest.mark.asyncio
+    async def test_rejects_kv_unified(self, sm: ServerManager) -> None:
+        with pytest.raises(ValueError, match="does not support n_slots"):
+            await sm.start("x", model_path="/m", kv_unified=True)
+
+    @pytest.mark.asyncio
+    async def test_llamaserver_rejects_model_path(self) -> None:
+        """Symmetry: llamaserver should reject model_path (it's a vllm-only param)."""
+        sm = ServerManager(backend="llamaserver")
+        with pytest.raises(ValueError, match="does not accept model_path"):
+            await sm.start("x", model_path="/models/x")
+
+    @pytest.mark.asyncio
+    async def test_unknown_backend_raises(self) -> None:
+        sm = ServerManager(backend="bogus")
+        with pytest.raises(ValueError, match="unsupported backend"):
+            await sm.start("x", gguf_path="/models/x.gguf")
 
 
 # ── ServerManager.stop() ────────────────────────────────────────
@@ -478,6 +611,76 @@ class TestGetServerContext:
             with pytest.raises(BudgetResolutionError) as exc_info:
                 await sm.get_server_context()
             assert exc_info.value.__cause__ is not None
+
+
+# ── ServerManager.get_server_context() — vllm backend ───────────
+
+
+class TestGetServerContextVllm:
+    """get_server_context() vllm path: parses max_model_len from /v1/models."""
+
+    @pytest.mark.asyncio
+    async def test_reads_max_model_len_from_models_endpoint(self) -> None:
+        sm = ServerManager(backend="vllm", port=8000)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "data": [{"id": "/models/x", "max_model_len": 113000}],
+        }
+        with patch("forge.server.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            result = await sm.get_server_context()
+
+        assert result == 113000
+
+    @pytest.mark.asyncio
+    async def test_raises_on_empty_data(self) -> None:
+        sm = ServerManager(backend="vllm", port=8000)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": []}
+        with patch("forge.server.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(BudgetResolutionError):
+                await sm.get_server_context()
+
+    @pytest.mark.asyncio
+    async def test_raises_on_missing_max_model_len(self) -> None:
+        sm = ServerManager(backend="vllm", port=8000)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": [{"id": "/models/x"}]}
+        with patch("forge.server.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(BudgetResolutionError):
+                await sm.get_server_context()
+
+    @pytest.mark.asyncio
+    async def test_raises_on_non_200(self) -> None:
+        sm = ServerManager(backend="vllm", port=8000)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_resp.text = "service unavailable"
+        with patch("forge.server.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(BudgetResolutionError):
+                await sm.get_server_context()
 
 
 # ── ServerManager.resolve_budget() ──────────────────────────────
@@ -612,12 +815,13 @@ class TestStartWithBudget:
             patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=13568),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.BACKEND,
             )
 
         mock_start.assert_called_once_with(
-            "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
+            "llama3", gguf_path="/models/llama3.gguf", model_path=None,
+            mode="native", extra_flags=None, ctx_override=None,
             cache_type_k=None, cache_type_v=None, n_slots=None, kv_unified=False,
         )
         assert result == 13568
@@ -630,13 +834,14 @@ class TestStartWithBudget:
             patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=8000),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.MANUAL,
                 manual_tokens=8000,
             )
 
         mock_start.assert_called_once_with(
-            "llama3", "/models/llama3.gguf", "native", None, ctx_override=8000,
+            "llama3", gguf_path="/models/llama3.gguf", model_path=None,
+            mode="native", extra_flags=None, ctx_override=8000,
             cache_type_k=None, cache_type_v=None, n_slots=None, kv_unified=False,
         )
         assert result == 8000
@@ -646,7 +851,7 @@ class TestStartWithBudget:
         sm = ServerManager(backend="llamaserver")
         with pytest.raises(ValueError, match="manual mode requires manual_tokens"):
             await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.MANUAL,
             )
 
@@ -658,12 +863,13 @@ class TestStartWithBudget:
             patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=13568),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FULL,
             )
 
         mock_start.assert_called_once_with(
-            "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
+            "llama3", gguf_path="/models/llama3.gguf", model_path=None,
+            mode="native", extra_flags=None, ctx_override=None,
             cache_type_k=None, cache_type_v=None, n_slots=None, kv_unified=False,
         )
         assert result == 13568
@@ -682,19 +888,21 @@ class TestStartWithBudget:
             ),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FAST,
             )
 
         assert mock_start.call_count == 2
         # Phase 1: start without -c
         mock_start.assert_any_call(
-            "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
+            "llama3", gguf_path="/models/llama3.gguf", model_path=None,
+            mode="native", extra_flags=None, ctx_override=None,
             cache_type_k=None, cache_type_v=None, n_slots=None, kv_unified=False,
         )
         # Phase 2: restart with half (13568 // 2 = 6784)
         mock_start.assert_any_call(
-            "llama3", "/models/llama3.gguf", "native", None, ctx_override=6784,
+            "llama3", gguf_path="/models/llama3.gguf", model_path=None,
+            mode="native", extra_flags=None, ctx_override=6784,
             cache_type_k=None, cache_type_v=None, n_slots=None, kv_unified=False,
         )
         assert result == 6784
@@ -708,7 +916,7 @@ class TestStartWithBudget:
         ):
             with pytest.raises(BudgetResolutionError):
                 await sm.start_with_budget(
-                    "llama3", "/models/llama3.gguf",
+                    "llama3", gguf_path="/models/llama3.gguf",
                     budget_mode=BudgetMode.FORGE_FAST,
                 )
 
@@ -718,7 +926,7 @@ class TestStartWithBudget:
         hw = MagicMock(vram_total_gb=12.0)
         with patch("forge.server.detect_hardware", return_value=hw):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.BACKEND,
             )
         assert result == 4096
@@ -731,7 +939,7 @@ class TestStartWithBudget:
         hw = MagicMock(vram_total_gb=12.0)
         with patch("forge.server.detect_hardware", return_value=hw):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FAST,
             )
         assert result == 2048  # half of 4096 tier for <24 GB
@@ -750,7 +958,7 @@ class TestStartWithBudget:
             ),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FAST,
                 n_slots=2,
             )
@@ -758,7 +966,8 @@ class TestStartWithBudget:
         assert mock_start.call_count == 2
         # Phase 2: -c should be 35000 (half of 70K total), NOT 17500 (half of per-slot)
         mock_start.assert_any_call(
-            "llama3", "/models/llama3.gguf", "native", None, ctx_override=35000,
+            "llama3", gguf_path="/models/llama3.gguf", model_path=None,
+            mode="native", extra_flags=None, ctx_override=35000,
             cache_type_k=None, cache_type_v=None, n_slots=2, kv_unified=False,
         )
         # Budget returned is per-slot (non-unified): 17500
@@ -776,13 +985,14 @@ class TestStartWithBudget:
             ),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FAST,
                 n_slots=1,
             )
 
         mock_start.assert_any_call(
-            "llama3", "/models/llama3.gguf", "native", None, ctx_override=6784,
+            "llama3", gguf_path="/models/llama3.gguf", model_path=None,
+            mode="native", extra_flags=None, ctx_override=6784,
             cache_type_k=None, cache_type_v=None, n_slots=1, kv_unified=False,
         )
         assert result == 6784
@@ -802,7 +1012,7 @@ class TestStartWithBudget:
             patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=70000),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FULL,
                 n_slots=2,
                 kv_unified=True,
@@ -821,7 +1031,7 @@ class TestStartWithBudget:
             patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=70000),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FULL,
                 n_slots=1,
                 kv_unified=True,
@@ -838,7 +1048,7 @@ class TestStartWithBudget:
             patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=35000),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FULL,
                 n_slots=2,
                 kv_unified=False,
@@ -856,14 +1066,15 @@ class TestStartWithBudget:
             patch.object(sm, "get_server_context", new_callable=AsyncMock, return_value=35000),
         ):
             await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FULL,
                 n_slots=2,
                 kv_unified=True,
             )
 
         mock_start.assert_called_once_with(
-            "llama3", "/models/llama3.gguf", "native", None, ctx_override=None,
+            "llama3", gguf_path="/models/llama3.gguf", model_path=None,
+            mode="native", extra_flags=None, ctx_override=None,
             cache_type_k=None, cache_type_v=None, n_slots=2, kv_unified=True,
         )
 
@@ -883,7 +1094,7 @@ class TestStartWithBudget:
             ),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FAST,
                 n_slots=2,
                 kv_unified=True,
@@ -903,14 +1114,15 @@ class TestStartWithBudget:
             ),
         ):
             result = await sm.start_with_budget(
-                "llama3", "/models/llama3.gguf",
+                "llama3", gguf_path="/models/llama3.gguf",
                 budget_mode=BudgetMode.FORGE_FAST,
                 n_slots=1,
                 kv_unified=True,
             )
 
         mock_start.assert_any_call(
-            "llama3", "/models/llama3.gguf", "native", None, ctx_override=35000,
+            "llama3", gguf_path="/models/llama3.gguf", model_path=None,
+            mode="native", extra_flags=None, ctx_override=35000,
             cache_type_k=None, cache_type_v=None, n_slots=1, kv_unified=True,
         )
         assert result == 35000
@@ -1061,6 +1273,55 @@ class TestSetupBackend:
         """llamaserver/llamafile must have a gguf_path."""
         with pytest.raises(ValueError, match="requires gguf_path"):
             await setup_backend(backend="llamaserver")
+
+    # ── vllm identity rules ────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_vllm_requires_model_path(self) -> None:
+        with pytest.raises(ValueError, match="requires model_path"):
+            await setup_backend(backend="vllm")
+
+    @pytest.mark.asyncio
+    async def test_vllm_rejects_gguf_path(self) -> None:
+        with pytest.raises(ValueError, match="does not accept gguf_path"):
+            await setup_backend(backend="vllm", model_path="/m", gguf_path="/x")
+
+    @pytest.mark.asyncio
+    async def test_vllm_rejects_model(self) -> None:
+        with pytest.raises(ValueError, match="does not accept model"):
+            await setup_backend(backend="vllm", model_path="/m", model="ollama-tag")
+
+    @pytest.mark.asyncio
+    async def test_ollama_rejects_model_path(self) -> None:
+        with pytest.raises(ValueError, match="does not accept model_path"):
+            await setup_backend(backend="ollama", model="tag", model_path="/x")
+
+    @pytest.mark.asyncio
+    async def test_llamaserver_rejects_model_path(self) -> None:
+        with pytest.raises(ValueError, match="does not accept model_path"):
+            await setup_backend(backend="llamaserver", gguf_path="/x", model_path="/y")
+
+    @pytest.mark.asyncio
+    async def test_unknown_backend_raises(self) -> None:
+        with pytest.raises(ValueError, match="unsupported backend"):
+            await setup_backend(backend="bogus")
+
+    @pytest.mark.asyncio
+    async def test_vllm_setup_returns_manager_and_ctx(self) -> None:
+        with (
+            patch.object(
+                ServerManager, "start_with_budget",
+                new_callable=AsyncMock, return_value=113000,
+            ),
+        ):
+            server, ctx = await setup_backend(
+                backend="vllm",
+                model_path="/models/gemma-4-AWQ",
+            )
+
+        assert isinstance(server, ServerManager)
+        assert isinstance(ctx, ContextManager)
+        assert ctx.budget_tokens == 113000
 
 
 # ── Full workflow wiring (integration-style, mocked) ─────────────

--- a/tests/unit/test_vllm_client.py
+++ b/tests/unit/test_vllm_client.py
@@ -1,0 +1,488 @@
+"""Tests for forge.clients.vllm — VLLMClient with mocked HTTP."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from pydantic import BaseModel, Field
+
+from forge.clients.base import ChunkType
+from forge.clients.vllm import VLLMClient
+from forge.core.workflow import TextResponse, ToolCall, ToolSpec
+from forge.errors import BackendError
+
+
+# ── helpers ────────────────────────────────────────────────────
+
+
+class CityParams(BaseModel):
+    city: str = Field(description="City name")
+
+
+def _make_spec(name: str = "get_weather") -> ToolSpec:
+    return ToolSpec(name=name, description=f"Get {name}", parameters=CityParams)
+
+
+def _make_client(*, think: bool = True) -> VLLMClient:
+    client = VLLMClient(
+        model_path="/models/gemma-4-26B-A4B-it-AWQ-4bit",
+        base_url="http://test:8000/v1",
+        think=think,
+    )
+    mock_http = AsyncMock()
+    mock_http.stream = MagicMock()
+    client._http = mock_http
+    return client
+
+
+def _mock_response(data: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = data
+    resp.text = json.dumps(data)
+    resp.status_code = status_code
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp,
+        )
+    else:
+        resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _tool_call_response(
+    name: str = "get_weather",
+    args: str = '{"city": "Paris"}',
+    reasoning: str | None = None,
+    content: str | None = None,
+    usage: dict | None = None,
+) -> dict:
+    message = {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": name, "arguments": args},
+            }
+        ],
+    }
+    if reasoning is not None:
+        message["reasoning"] = reasoning
+    return {
+        "choices": [{"index": 0, "message": message, "finish_reason": "tool_calls"}],
+        "usage": usage or {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+def _text_response(content: str = "hi", reasoning: str | None = None) -> dict:
+    message = {"role": "assistant", "content": content, "tool_calls": []}
+    if reasoning is not None:
+        message["reasoning"] = reasoning
+    return {
+        "choices": [{"index": 0, "message": message, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 8, "completion_tokens": 2, "total_tokens": 10},
+    }
+
+
+# ── constructor / identity derivation ──────────────────────────
+
+
+class TestConstructor:
+    def test_directory_path_derives_model_from_dirname(self) -> None:
+        c = VLLMClient(model_path="/models/gemma-4-26B-A4B-it-AWQ-4bit")
+        assert c.model == "gemma-4-26B-A4B-it-AWQ-4bit"
+        assert c.model_path == "/models/gemma-4-26B-A4B-it-AWQ-4bit"
+
+    def test_hf_repo_id_derives_model_from_trailing_segment(self) -> None:
+        c = VLLMClient(model_path="google/gemma-4-26B-A4B-it")
+        assert c.model == "gemma-4-26B-A4B-it"
+        assert c.model_path == "google/gemma-4-26B-A4B-it"
+
+    def test_single_token_model_path(self) -> None:
+        c = VLLMClient(model_path="some-local-name")
+        assert c.model == "some-local-name"
+
+    def test_api_format_is_openai(self) -> None:
+        c = VLLMClient(model_path="/models/x")
+        assert c.api_format == "openai"
+
+    def test_kwarg_only_after_model_path(self) -> None:
+        """All params after model_path must be keyword-only."""
+        with pytest.raises(TypeError):
+            VLLMClient("/models/x", "http://other:8000")  # type: ignore[misc]
+
+
+# ── send (non-streaming) ──────────────────────────────────────
+
+
+class TestSend:
+    @pytest.mark.asyncio
+    async def test_returns_tool_call(self) -> None:
+        client = _make_client()
+        client._http.post.return_value = _mock_response(_tool_call_response())
+        result = await client.send(
+            [{"role": "user", "content": "weather in paris?"}],
+            tools=[_make_spec()],
+        )
+        assert isinstance(result, list)
+        assert result[0].tool == "get_weather"
+        assert result[0].args == {"city": "Paris"}
+        assert result[0].reasoning is None
+
+    @pytest.mark.asyncio
+    async def test_returns_text_response(self) -> None:
+        client = _make_client()
+        client._http.post.return_value = _mock_response(_text_response("PONG"))
+        result = await client.send([{"role": "user", "content": "ping"}])
+        assert isinstance(result, TextResponse)
+        assert result.content == "PONG"
+
+    @pytest.mark.asyncio
+    async def test_arguments_parsed_from_json_string(self) -> None:
+        """vLLM tool_calls.function.arguments arrives as a JSON-encoded string."""
+        client = _make_client()
+        client._http.post.return_value = _mock_response(
+            _tool_call_response(args='{"city": "Paris", "units": "metric"}'),
+        )
+        result = await client.send(
+            [{"role": "user", "content": "x"}], tools=[_make_spec()],
+        )
+        assert isinstance(result, list)
+        assert result[0].args == {"city": "Paris", "units": "metric"}
+
+    @pytest.mark.asyncio
+    async def test_reasoning_field_captured(self) -> None:
+        """vLLM 0.21 returns reasoning in `reasoning` field, not reasoning_content."""
+        client = _make_client(think=True)
+        client._http.post.return_value = _mock_response(
+            _tool_call_response(reasoning="I should check the weather first."),
+        )
+        result = await client.send(
+            [{"role": "user", "content": "x"}], tools=[_make_spec()],
+        )
+        assert isinstance(result, list)
+        assert result[0].reasoning == "I should check the weather first."
+
+    @pytest.mark.asyncio
+    async def test_think_false_discards_reasoning(self) -> None:
+        client = _make_client(think=False)
+        client._http.post.return_value = _mock_response(
+            _tool_call_response(reasoning="thought"),
+        )
+        result = await client.send(
+            [{"role": "user", "content": "x"}], tools=[_make_spec()],
+        )
+        assert isinstance(result, list)
+        assert result[0].reasoning is None
+
+    @pytest.mark.asyncio
+    async def test_usage_recorded(self) -> None:
+        client = _make_client()
+        client._http.post.return_value = _mock_response(
+            _tool_call_response(
+                usage={"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120},
+            ),
+        )
+        await client.send([{"role": "user", "content": "x"}], tools=[_make_spec()])
+        usage = client.last_usage[0]
+        assert usage.prompt_tokens == 100
+        assert usage.completion_tokens == 20
+        assert usage.total_tokens == 120
+
+    @pytest.mark.asyncio
+    async def test_sampling_overrides_applied_per_call(self) -> None:
+        client = _make_client()
+        client.temperature = 1.0  # instance default
+        client._http.post.return_value = _mock_response(_text_response())
+        await client.send(
+            [{"role": "user", "content": "x"}],
+            sampling={"temperature": 0.0, "seed": 42},
+        )
+        body = client._http.post.call_args.kwargs["json"]
+        assert body["temperature"] == 0.0
+        assert body["seed"] == 42
+        # Instance value not mutated
+        assert client.temperature == 1.0
+
+    @pytest.mark.asyncio
+    async def test_non_200_raises_backend_error(self) -> None:
+        client = _make_client()
+        client._http.post.return_value = _mock_response({"error": "bad"}, status_code=500)
+        with pytest.raises(BackendError):
+            await client.send([{"role": "user", "content": "x"}])
+
+    @pytest.mark.asyncio
+    async def test_read_timeout_raises_backend_error(self) -> None:
+        client = _make_client()
+        client._http.post.side_effect = httpx.ReadTimeout("timeout")
+        with pytest.raises(BackendError):
+            await client.send([{"role": "user", "content": "x"}])
+
+    @pytest.mark.asyncio
+    async def test_empty_choices_raises_backend_error(self) -> None:
+        """Empty choices list — fail loud."""
+        client = _make_client()
+        client._http.post.return_value = _mock_response({"choices": [], "usage": {}})
+        with pytest.raises(BackendError, match="no choices"):
+            await client.send([{"role": "user", "content": "x"}])
+
+    @pytest.mark.asyncio
+    async def test_tools_send_with_auto_tool_choice(self) -> None:
+        client = _make_client()
+        client._http.post.return_value = _mock_response(_tool_call_response())
+        await client.send(
+            [{"role": "user", "content": "x"}], tools=[_make_spec()],
+        )
+        body = client._http.post.call_args.kwargs["json"]
+        assert body["tool_choice"] == "auto"
+        assert len(body["tools"]) == 1
+        assert body["tools"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_no_tools_omits_tools_param(self) -> None:
+        client = _make_client()
+        client._http.post.return_value = _mock_response(_text_response())
+        await client.send([{"role": "user", "content": "x"}])
+        body = client._http.post.call_args.kwargs["json"]
+        assert "tools" not in body
+        assert "tool_choice" not in body
+
+
+# ── send_stream ──────────────────────────────────────────────
+
+
+class _MockStreamResponse:
+    """Mocks the async context manager returned by httpx.AsyncClient.stream()."""
+
+    def __init__(self, lines: list[str], status_code: int = 200) -> None:
+        self._lines = lines
+        self.status_code = status_code
+
+    async def __aenter__(self) -> "_MockStreamResponse":
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        pass
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+
+def _sse(payload: dict) -> str:
+    return f"data: {json.dumps(payload)}"
+
+
+class TestSendStream:
+    @pytest.mark.asyncio
+    async def test_yields_text_delta_then_final(self) -> None:
+        client = _make_client()
+        client._http.stream.return_value = _MockStreamResponse([
+            _sse({"choices": [{"delta": {"content": "PO"}}]}),
+            _sse({"choices": [{"delta": {"content": "NG"}}]}),
+            "data: [DONE]",
+        ])
+        chunks = []
+        async for chunk in client.send_stream([{"role": "user", "content": "x"}]):
+            chunks.append(chunk)
+        deltas = [c for c in chunks if c.type == ChunkType.TEXT_DELTA]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert [c.content for c in deltas] == ["PO", "NG"]
+        assert len(finals) == 1
+        assert isinstance(finals[0].response, TextResponse)
+        assert finals[0].response.content == "PONG"
+
+    @pytest.mark.asyncio
+    async def test_yields_tool_call_delta_then_final(self) -> None:
+        client = _make_client()
+        client._http.stream.return_value = _MockStreamResponse([
+            _sse({"choices": [{"delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "function": {"name": "get_weather", "arguments": '{"city": '}
+                }],
+            }}]}),
+            _sse({"choices": [{"delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "function": {"arguments": '"Paris"}'}
+                }],
+            }}]}),
+            "data: [DONE]",
+        ])
+        chunks = []
+        async for chunk in client.send_stream(
+            [{"role": "user", "content": "x"}], tools=[_make_spec()],
+        ):
+            chunks.append(chunk)
+        tc_deltas = [c for c in chunks if c.type == ChunkType.TOOL_CALL_DELTA]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(tc_deltas) == 2
+        assert len(finals) == 1
+        result = finals[0].response
+        assert isinstance(result, list)
+        assert result[0].tool == "get_weather"
+        assert result[0].args == {"city": "Paris"}
+
+    @pytest.mark.asyncio
+    async def test_accumulates_reasoning_across_deltas(self) -> None:
+        client = _make_client(think=True)
+        client._http.stream.return_value = _MockStreamResponse([
+            _sse({"choices": [{"delta": {"reasoning": "Let me "}}]}),
+            _sse({"choices": [{"delta": {"reasoning": "think... "}}]}),
+            _sse({"choices": [{"delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "function": {"name": "get_weather", "arguments": '{"city": "P"}'}
+                }],
+            }}]}),
+            "data: [DONE]",
+        ])
+        chunks = []
+        async for chunk in client.send_stream(
+            [{"role": "user", "content": "x"}], tools=[_make_spec()],
+        ):
+            chunks.append(chunk)
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        result = finals[0].response
+        assert isinstance(result, list)
+        assert result[0].reasoning == "Let me think... "
+
+    @pytest.mark.asyncio
+    async def test_non_200_raises_backend_error(self) -> None:
+        client = _make_client()
+        client._http.stream.return_value = _MockStreamResponse(
+            ["bad gateway"], status_code=502,
+        )
+        with pytest.raises(BackendError):
+            async for _ in client.send_stream([{"role": "user", "content": "x"}]):
+                pass
+
+
+# ── get_context_length ─────────────────────────────────────────
+
+
+class TestGetContextLength:
+    @pytest.mark.asyncio
+    async def test_reads_max_model_len_from_models_endpoint(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "/models/x", "max_model_len": 113000}],
+        })
+        ctx = await client.get_context_length()
+        assert ctx == 113000
+
+    @pytest.mark.asyncio
+    async def test_empty_data_raises(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({"data": []})
+        with pytest.raises(BackendError, match="no entries"):
+            await client.get_context_length()
+
+    @pytest.mark.asyncio
+    async def test_missing_max_model_len_raises(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "/models/x"}],  # no max_model_len
+        })
+        with pytest.raises(BackendError, match="missing max_model_len"):
+            await client.get_context_length()
+
+
+# ── get_served_model_name ──────────────────────────────────────
+
+
+class TestGetServedModelName:
+    @pytest.mark.asyncio
+    async def test_returns_first_model_id(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "local-primary", "max_model_len": 262144}],
+        })
+        assert await client.get_served_model_name() == "local-primary"
+
+    @pytest.mark.asyncio
+    async def test_empty_data_returns_none(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({"data": []})
+        assert await client.get_served_model_name() is None
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_none(self) -> None:
+        client = _make_client()
+        client._http.get.side_effect = httpx.ConnectError("refused")
+        assert await client.get_served_model_name() is None
+
+
+# ── edge cases ─────────────────────────────────────────────────
+
+
+class TestSendInstanceSampling:
+    @pytest.mark.asyncio
+    async def test_instance_sampling_applied_without_override(self) -> None:
+        """Instance-level sampling fields flow into the request body."""
+        client = _make_client()
+        client.temperature = 0.5
+        client.top_p = 0.85
+        client._http.post.return_value = _mock_response(_text_response())
+        await client.send([{"role": "user", "content": "x"}])
+        body = client._http.post.call_args.kwargs["json"]
+        assert body["temperature"] == 0.5
+        assert body["top_p"] == 0.85
+
+
+class TestSendStreamEdgeCases:
+    @pytest.mark.asyncio
+    async def test_ignores_comment_and_empty_lines(self) -> None:
+        """SSE comment lines (`:keepalive`) and empty lines are skipped."""
+        client = _make_client()
+        client._http.stream.return_value = _MockStreamResponse([
+            "",
+            ":keepalive",
+            _sse({"choices": [{"delta": {"content": "OK"}}]}),
+            "",
+            "data: [DONE]",
+        ])
+        chunks = []
+        async for chunk in client.send_stream([{"role": "user", "content": "x"}]):
+            chunks.append(chunk)
+        deltas = [c for c in chunks if c.type == ChunkType.TEXT_DELTA]
+        assert [c.content for c in deltas] == ["OK"]
+
+    @pytest.mark.asyncio
+    async def test_usage_only_chunk_records_usage_and_continues(self) -> None:
+        """When stream_options.include_usage=True, vLLM emits a final chunk
+        with `choices: []` and a `usage` block."""
+        client = _make_client()
+        client._http.stream.return_value = _MockStreamResponse([
+            _sse({"choices": [{"delta": {"content": "hi"}}]}),
+            _sse({
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 50, "completion_tokens": 3, "total_tokens": 53,
+                },
+            }),
+            "data: [DONE]",
+        ])
+        async for _ in client.send_stream([{"role": "user", "content": "x"}]):
+            pass
+        usage = client.last_usage[0]
+        assert usage.prompt_tokens == 50
+        assert usage.completion_tokens == 3
+
+
+class TestParseToolArgs:
+    def test_dict_passed_through(self) -> None:
+        """Some downstream wrappers send dict args directly — pass through."""
+        assert VLLMClient._parse_tool_args({"city": "Paris"}) == {"city": "Paris"}
+
+    def test_empty_string_returns_empty_dict(self) -> None:
+        """No-arg tool calls — empty string args is valid."""
+        assert VLLMClient._parse_tool_args("") == {}
+
+    def test_unexpected_type_raises(self) -> None:
+        """Unknown shape (list, int, etc.) — fail loud."""
+        with pytest.raises(BackendError, match="unexpected tool args shape"):
+            VLLMClient._parse_tool_args(123)  # type: ignore[arg-type]


### PR DESCRIPTION
## What

Adds vLLM as a first-class backend — in both proxy modes and via
`WorkflowRunner` / `setup_backend()`. Forward-ported onto current `main`
(v0.7.1) so it composes with the Anthropic Messages proxy and `--mode`
work that shipped after this code was first written.

## Changes

- **`VLLMClient`** — OpenAI-compatible client for a vLLM server, consuming
  vLLM's server-side `tool_calls` and `reasoning` (vLLM 0.21) fields. Native
  function calling only (vLLM parses tools server-side via
  `--enable-auto-tool-choice --tool-call-parser`), so no prompt-injection
  mode. Exported from `forge` and `forge.clients`.
- **`model_path` identity** threaded through `ServerManager.start` /
  `start_with_budget` / `setup_backend` (distinct from `gguf_path`), plus the
  `vllm serve` command build, `/v1/models` context detection, and readiness
  polling.
- **Proxy: vLLM in managed and external modes.** Managed mode now delegates to
  `setup_backend()` rather than reimplementing the server-start/budget dance,
  so every backend shares one path. **No public API change** — `ProxyServer`
  and the `forge.proxy` CLI keep their v0.7.1 signatures; `model_path` /
  `--model-path` and the `vllm` backend are added.
- **Served-model-name discovery** (external mode): vLLM validates the request
  `model` field against `--served-model-name` and 404s on a mismatch (unlike
  llama.cpp). The proxy discovers the served name from `/v1/models`. #74
  (thanks @srinathh).
- **Fail-fast budget**: external mode now errors when a backend reports no
  context length and no `--budget-tokens` is set, instead of silently using an
  8192-token budget.

## Docs

vLLM added to the README backend list + a new Backend Setup section (server
flags, `VLLMClient` usage); CHANGELOG `0.7.2`; version bumped to `0.7.2`.

## Validation

- **1020 unit tests** pass (vLLM client + proxy construction/wiring + server
  vLLM paths).
- **Mock smoke** — all 3 proxy scenarios (OpenAI, Anthropic→OpenAI, Anthropic
  passthrough).
- **Real-backend integration** against llama.cpp — external + managed phases,
  OpenAI + Anthropic protocols, tool round-trips, streaming, multi-turn
  convergence, **5/5 each**. Exercises the `setup_backend()` managed-mode
  refactor end-to-end.
- ⚠️ **The vLLM path itself was not re-run against a live vLLM server in this
  cycle** — it's unit-validated and shape-matched, and the proxy's protocol
  translation is backend-agnostic (verified via llama.cpp).
  `scripts/integration_test_proxy.py --vllm-url <url>` runs the full battery
  against a real vLLM server when one is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)