### PR TITLE
Post-review fixes: proxy input hardening, non-blocking Ollama stop, client shutdown, loud arg decode

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -134,6 +134,8 @@ execute(result.tool_calls)
 done = guardrails.record([tc.tool for tc in result.tool_calls])
 ```
 
+The `Guardrails` facade covers validation, retry nudges, and step enforcement. It does **not** enforce tool prerequisites — for those, use the Granular API (`StepEnforcer.check_prerequisites`) shown next.
+
 **Granular API** (individual components for custom control):
 
 ```python

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -68,6 +68,10 @@ class AnthropicClient:
         # same convention as OllamaClient.
         self.last_usage: dict[int, TokenUsage] = {}
 
+    async def aclose(self) -> None:
+        """Close the underlying Anthropic SDK client (and its httpx pool)."""
+        await self._client.close()
+
     # ── Tool schema conversion ───────────────────────────────────
 
     @staticmethod
@@ -120,7 +124,13 @@ class AnthropicClient:
                         func = tc["function"]
                         args = func.get("arguments", "{}")
                         if isinstance(args, str):
-                            args = json.loads(args)
+                            try:
+                                args = json.loads(args)
+                            except json.JSONDecodeError as exc:
+                                raise ValueError(
+                                    f"Malformed JSON in tool_call arguments for "
+                                    f"{func.get('name', '?')!r}: {args!r}"
+                                ) from exc
                         tc_id = tc.get("id", f"toolu_{len(converted)}")
                         blocks.append({
                             "type": "tool_use",

--- a/src/forge/clients/base.py
+++ b/src/forge/clients/base.py
@@ -149,3 +149,7 @@ class LLMClient(Protocol):
     async def get_context_length(self) -> int | None:
         """Query the backend for its configured context window size."""
         ...
+
+    async def aclose(self) -> None:
+        """Release held network resources (e.g. the httpx connection pool)."""
+        ...

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -186,6 +186,10 @@ class LlamafileClient:
         else:
             self.resolved_mode = None
 
+    async def aclose(self) -> None:
+        """Close the underlying httpx connection pool."""
+        await self._http.aclose()
+
     def _apply_slot_id(self, body: dict[str, Any]) -> None:
         """Inject slot_id into a request body if configured."""
         if self._slot_id is not None:

--- a/src/forge/clients/ollama.py
+++ b/src/forge/clients/ollama.py
@@ -78,6 +78,10 @@ class OllamaClient:
         self._think_resolved: bool = think is not None
         self.last_usage: dict[int, TokenUsage] = {}
 
+    async def aclose(self) -> None:
+        """Close the underlying httpx connection pool."""
+        await self._http.aclose()
+
     # Sampling fields recognized in per-call overrides. ``seed`` is
     # accepted only as a per-call override (not an instance field).
     _SAMPLING_FIELDS = (

--- a/src/forge/clients/vllm.py
+++ b/src/forge/clients/vllm.py
@@ -99,6 +99,10 @@ class VLLMClient:
         self._think: bool = think
         self.last_usage: dict[int, TokenUsage] = {}
 
+    async def aclose(self) -> None:
+        """Close the underlying httpx connection pool."""
+        await self._http.aclose()
+
     # Sampling fields recognized in per-call overrides. ``seed`` is
     # accepted only as a per-call override (not an instance field).
     # ``chat_template_kwargs`` is a nested dict of Jinja template variables

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -161,6 +161,7 @@ class ProxyServer:
 
         self._server_manager: ServerManager | None = None
         self._http_server: HTTPServer | None = None
+        self._client: LLMClient | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
         self._started = False
@@ -219,6 +220,7 @@ class ProxyServer:
         else:
             client, context_manager = await self._setup_managed()
 
+        self._client = client
         self._http_server = HTTPServer(
             client=client,
             context_manager=context_manager,
@@ -367,3 +369,5 @@ class ProxyServer:
             await self._http_server.stop()
         if self._server_manager is not None:
             await self._server_manager.stop()
+        if self._client is not None:
+            await self._client.aclose()

--- a/src/forge/server.py
+++ b/src/forge/server.py
@@ -255,7 +255,10 @@ class ServerManager:
         """Stop the current server / unload the Ollama model."""
         if self._backend == "ollama":
             if self._current_model is not None:
-                wombat = subprocess.run(["ollama", "stop", self._current_model])
+                wombat = await asyncio.create_subprocess_exec(
+                    "ollama", "stop", self._current_model
+                )
+                await wombat.wait()
                 self._current_model = None
             return
 

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -219,6 +219,36 @@ class TestChatCompletions:
             writer.close()
             await writer.wait_closed()
 
+    @pytest.mark.asyncio
+    async def test_invalid_content_length_returns_400(self, server_factory):
+        srv, port = await server_factory(TextResponse(content=""))
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            request = (
+                f"POST /v1/chat/completions HTTP/1.1\r\n"
+                f"Host: 127.0.0.1:{port}\r\n"
+                f"Content-Type: application/json\r\n"
+                f"Content-Length: abc\r\n"
+                f"\r\n"
+            ).encode()
+            writer.write(request)
+            await writer.drain()
+            response_data = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+            assert b"400" in response_data
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    @pytest.mark.asyncio
+    async def test_non_object_body_returns_400(self, server_factory):
+        srv, port = await server_factory(TextResponse(content=""))
+        # Valid JSON but not an object (array) must be rejected before the
+        # handler calls body.get(...), which would otherwise raise.
+        status, _ = await _http_request(
+            port, "POST", "/v1/chat/completions", body=[1, 2, 3]
+        )
+        assert status == 400
+
 
 # ── SSE Streaming ───────────────────────────────────────────
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -541,10 +541,15 @@ class TestServerManagerStop:
         sm = ServerManager(backend="ollama")
         sm._current_model = "ministral:14b"
 
-        with patch("forge.server.subprocess.run") as mock_run:
+        proc = AsyncMock()
+        with patch(
+            "forge.server.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=proc),
+        ) as mock_exec:
             await sm.stop()
 
-        mock_run.assert_called_once_with(["ollama", "stop", "ministral:14b"])
+        mock_exec.assert_called_once_with("ollama", "stop", "ministral:14b")
+        proc.wait.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_stop_ollama_noop_when_no_model(self) -> None:


### PR DESCRIPTION
Follow-ups from reviewing the AI-generated PR batch (#65–#73). Reimplements the keepers cleanly and backfills missing tests.

- **#66** — `ollama stop` no longer blocks the event loop (async subprocess; stderr surfaces instead of being suppressed).
- **#67** — `aclose()` on all clients + the `LLMClient` protocol, wired into proxy `_async_stop` so the httpx pool is closed on shutdown. The original added the method but wired no caller.
- **#69** — clear `ValueError` (naming the tool + offending payload) on malformed tool-call argument JSON, instead of an opaque `JSONDecodeError`. Kept loud rather than swallowing to an empty dict.
- **#71** — backfilled the 400-path tests (bad `Content-Length`, non-object body) the merge landed without.
- **Docs** — made explicit that the `Guardrails` facade does not enforce tool prerequisites; that's a granular-API feature (`StepEnforcer.check_prerequisites`).

No version bump / CHANGELOG entry — changelog tracks formal releases only; this rides into the next one. 1022 unit tests pass.

Supersedes #66 (still open — close on merge). Ideas from #67/#69 credited via co-author trailers. Thanks @hobostay.