### PR TITLE
fix: exclude stream_options from proxy passthrough

### DIFF
--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -46,7 +46,7 @@ _SAMPLING_FIELDS = (
 )
 
 # Body fields forge owns and reasons about — never go into passthrough.
-_FORGE_OWNED = frozenset({"messages", "tools", "stream", "system"})
+_FORGE_OWNED = frozenset({"messages", "tools", "stream", "stream_options", "system"})
 
 
 def _extract_sampling(body: dict[str, Any]) -> dict[str, Any] | None:

--- a/tests/unit/test_proxy_handler.py
+++ b/tests/unit/test_proxy_handler.py
@@ -341,6 +341,27 @@ class TestSamplingPlumbing:
         }
 
 
+    @pytest.mark.asyncio
+    async def test_stream_options_excluded_from_passthrough(self):
+        """stream_options must not leak into passthrough.
+
+        Forge controls streaming independently — when it makes non-streaming
+        calls to the backend, a leaked stream_options causes validation
+        errors on strict backends (e.g. vLLM rejects stream_options when
+        stream is not True).
+        """
+        client = _mock_client(TextResponse(content="ok"))
+        body = _body(messages=[{"role": "user", "content": "hi"}])
+        body["stream"] = True
+        body["stream_options"] = {"include_usage": True}
+        body["max_tokens"] = 256
+
+        await handle_chat_completions(body, client, _context_manager(), max_retries=1)
+
+        passthrough = client.send.call_args.kwargs["passthrough"]
+        assert "stream_options" not in passthrough
+        assert passthrough == {"model": "test", "max_tokens": 256}
+
 # ── Anthropic protocol routing ───────────────────────────────
 
 


### PR DESCRIPTION
## Problem

When a client sends `stream_options` in the request body (e.g. `{"stream_options": {"include_usage": true}}`), the proxy's `_extract_passthrough` lets it through to the backend. But Forge makes non-streaming calls internally for guardrail validation (`stream=False`), so the backend receives `stream_options` without `stream=True`.

Strict OpenAI-compatible backends reject this combination:

```
ValidationError: 1 validation error for ChatCompletionRequest
  Value error, Stream options can only be defined when `stream=True`.
```

This triggers on every request from clients like Zed editor, which always send `stream_options`.

## Fix

Add `stream_options` to `_FORGE_OWNED` in `handler.py`, alongside the existing `stream` entry. Forge's own clients already inject `stream_options` when needed in their `send_stream()` paths (e.g. `VLLMClient`, `LlamafileClient`), so stripping it from passthrough is safe.

## Changes

- `src/forge/proxy/handler.py`: Add `stream_options` to `_FORGE_OWNED` frozenset
- `tests/unit/test_proxy_handler.py`: Add regression test

## Testing

All 27 proxy handler tests pass, including the new one.