### PR TITLE
Post-merge cleanup for OpenAICompatClient (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to forge are documented here.
 
-## [Unreleased]
-
-### Added
-- **OpenAI-compatible hosted-provider client (`OpenAICompatClient`).** Adapter for any backend exposing `/v1/chat/completions` with optional bearer auth — covers Cloudflare Workers AI, Fireworks, OpenRouter, OpenAI itself, and similar. Native function calling, SSE streaming, full `LLMClient` protocol surface. Supports `extra_headers` for provider quirks (e.g. OpenRouter's `HTTP-Referer` / `X-Title`) without a per-provider registry. Exported from `forge` and `forge.clients`. #88.
-- **Hosted-providers section in [Backend Setup](docs/BACKEND_SETUP.md)** covering bearer-auth setup, the `get_context_length() → None` contract, and the per-model nature of function-calling support on hosted providers.
-
 ## [0.7.2] — 2026-05-24
 
 vLLM backend support — serve AWQ/GPTQ and other vLLM-hosted models behind forge's guardrails, in both proxy modes and via `WorkflowRunner`.

--- a/docs/BACKEND_SETUP.md
+++ b/docs/BACKEND_SETUP.md
@@ -1,12 +1,14 @@
 # Backend Setup
 
-How to point forge at a backend. Forge supports four:
+How to point forge at a backend. Forge supports six:
 
 | Backend | Forge client | Native FC | Default port | Best for |
 |---|---|---|---|---|
 | llama-server | `LlamafileClient` | Yes (with `--jinja`) | 8080 | Recommended — top-10 eval configs |
 | llamafile | `LlamafileClient` | No (prompt-injected fallback) | 8080 | Single binary, zero setup |
 | Ollama | `OllamaClient` | Yes | 11434 | Easiest model management |
+| vLLM | `VLLMClient` | Yes (server-side parser) | 8000 | AWQ/GPTQ, high-throughput serving |
+| OpenAI-compatible | `OpenAICompatClient` | Per-model | (caller URL) | Hosted providers (Cloudflare, OpenRouter, …) |
 | Anthropic | `AnthropicClient` | Yes | (API) | Frontier baseline |
 
 Install instructions for each backend live with the upstream project. Below is what forge expects once a backend is running.


### PR DESCRIPTION
Remove the changelog entry that landed with #89 — this project does not keep an [Unreleased] section; entries are added under the version that ships them.

Fix the backend table in BACKEND_SETUP.md, which said "four" and was missing two clients: vLLM (added in 0.7.2) and the new OpenAI-compatible client. Now lists all six.