### PR TITLE
chore: generalize eval-results LFS rule to catch versioned dumps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,5 @@
 *.toml text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
-eval_results.jsonl filter=lfs diff=lfs merge=lfs -text
-eval_results_rig*.jsonl filter=lfs diff=lfs merge=lfs -text
+# Eval result dumps (any variant: bare, rig-tagged, version-tagged) go to LFS.
+eval_results*.jsonl filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## What
Generalize the eval-results Git LFS rule so every result-dump naming variant is captured.

```
- eval_results.jsonl       filter=lfs ...
- eval_results_rig*.jsonl   filter=lfs ...
+ eval_results*.jsonl        filter=lfs ...
```

## Why
The two old patterns matched only the bare `eval_results.jsonl` and the now-retired rig-tagged naming (`eval_results_rig*.jsonl`). The current scheme is **version-tagged** — `eval_results_v0.6.0.jsonl`, `eval_results_v0.7.0.jsonl` — which **neither pattern matched**:

```
$ git check-attr filter eval_results_v0.7.0.jsonl
eval_results_v0.7.0.jsonl: filter: unspecified
```

The two existing v-files are already in LFS (added when a matching `git lfs track` pattern still existed), but the rule protecting them is gone. So the **next release dump (`eval_results_v0.7.3.jsonl`) would have committed as a plain ~67MB git blob** baked permanently into history — the "accidental regular-git churn" this cleans up.

## The fix
One glob — `eval_results*.jsonl` — subsumes bare, rig-tagged, and version-tagged forms, so no future variant slips through.

## Verification
- `git check-attr filter` now returns `lfs` for `eval_results_v0.7.0.jsonl` **and** the future `eval_results_v0.7.3.jsonl`.
- Existing v-file pointers unchanged (LF, same OIDs/sizes: 67MB + 45MB); `git lfs fsck --pointers` = OK.
- Diff is `.gitattributes` only — no code, no proxy overlap.
