### PR TITLE
chore: scope sdist to exclude eval datasets and dashboard node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ htmlcov/
 # Claude Code
 .claude/
 
-# Eval results (scratch files only — eval_results.jsonl + eval_results_rig*.jsonl tracked via LFS)
+# Eval results (scratch files only — versioned eval_results_v*.jsonl tracked via LFS)
 eval_tight*.jsonl
 eval_vram*.jsonl
 ablation_progress.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,15 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/forge"]
 
+[tool.hatch.build.targets.sdist]
+# Without scoping, hatchling sweeps the whole tree into the sdist — pulling in
+# the LFS eval datasets (~112 MB) and the eval dashboard's node_modules (~97 MB,
+# incl. platform .exe/.node binaries). Ship only what builds + tests from source.
+exclude = [
+    "eval_results*.jsonl",
+    "tests/eval/dashboard/node_modules",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [


### PR DESCRIPTION
## What
Scope the sdist build so it stops bundling non-source artifacts.

## Why
The wheel target is scoped (`packages = ["src/forge"]` → clean 115 KB), but there was **no `[tool.hatch.build.targets.sdist]`** config. With no scoping, hatchling sweeps the whole working tree into the sdist:

| Uncompressed | Files | What |
|---|---|---|
| 112 MB | 2 | `eval_results_v*.jsonl` — LFS benchmark datasets |
| 97 MB | 4,572 | `tests/eval/dashboard/node_modules/` — incl. Windows `.exe`/`.node` binaries |
| 347 KB | 41 | `src/forge` — the actual package |

So 96% of the file count and ~99.7% of the bytes were non-source artifacts — including platform binaries — in a Python library's PyPI source distribution. (`node_modules` is gitignored + untracked; hatchling's unscoped sdist sweep doesn't honor `.gitignore`, so it got vacuumed in anyway.)

## Fix
Add a scoped sdist target excluding the two offenders. Nothing load-bearing is lost:
- `report.py` rebuilds the dashboard via `npm install` + `npm run build` on demand, so the committed `node_modules` (Windows-only binaries) was never used by the report workflow.
- The eval datasets remain in the repo via Git LFS; the dashboard **source** and the prebuilt `docs/results/dashboard.html` stay in the sdist.

Also refreshes a stale `.gitignore` comment to the versioned `eval_results_v*.jsonl` naming (post #96).

## Verification
- sdist **26 MB → 690 KB**; entries **4,739 → 165**.
- `node_modules` and `eval_results*.jsonl`: **0** entries in the new sdist.
- `src/forge` (41 files), README/LICENSE/CHANGELOG/pyproject, dashboard source, results HTML: all present.
- `twine check`: **PASSED** on both wheel and sdist.
- Wheel unchanged (115 KB).
