### PR TITLE
fix(clients): normalize OpenAI-wire messages for Ollama native /api/chat

### DIFF
--- a/src/forge/clients/base.py
+++ b/src/forge/clients/base.py
@@ -55,6 +55,28 @@ def format_tool(spec: ToolSpec) -> dict[str, Any]:
     }
 
 
+def flatten_content_to_text(content: Any) -> str:
+    """Flatten OpenAI multi-part ``content`` blocks into a plain string.
+
+    OpenAI allows ``content`` as a list of parts (e.g.
+    ``[{"type": "text", "text": "..."}]``). Text parts and bare-string parts
+    are joined with newlines; non-text dict blocks (images, audio, …) are
+    dropped — forge is text-only on this path today. A string passes through
+    unchanged; ``None`` (and any other shape) degrades to ``""``/``str()``.
+    """
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+            elif isinstance(block, str):
+                parts.append(block)
+        return "\n".join(parts)
+    if content is None:
+        return ""
+    return content if isinstance(content, str) else str(content)
+
+
 def decode_tool_args(raw: Any) -> Any:
     """Decode a tool-call ``arguments`` payload, fail-loud.
 

--- a/src/forge/clients/ollama.py
+++ b/src/forge/clients/ollama.py
@@ -8,13 +8,64 @@ from typing import Any
 
 import httpx
 
-from forge.clients.base import ChunkType, StreamChunk, TokenUsage, format_tool
+from forge.clients.base import (
+    ChunkType,
+    StreamChunk,
+    TokenUsage,
+    decode_tool_args,
+    flatten_content_to_text,
+    format_tool,
+)
 from forge.clients.sampling_defaults import apply_sampling_defaults
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
 from forge.errors import BackendError, ThinkingNotSupportedError
 from forge.prompts.think_tags import extract_think_tags
 
 _THINK_HEURISTIC_KEYWORDS = ("reason", "think")
+
+
+def _normalize_messages_for_ollama(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Coerce OpenAI-wire messages into Ollama's native /api/chat schema.
+
+    Ollama's native endpoint is stricter than the OpenAI wire format the proxy
+    forwards verbatim on the native-passthrough path (issues #111/#115):
+
+      - ``content`` must be a plain string, not a multi-part array. Multi-part
+        arrays are flattened text-only (images dropped, matching the converted
+        path's long-standing behavior).
+      - tool-call ``arguments`` must be a dict, not the JSON string OpenAI
+        clients replay in assistant history. Only a value that decodes to a
+        dict is rewritten; a malformed / non-object payload is left untouched
+        (it rides the validator's tool-error lane rather than being coerced).
+
+    Returns a new list; the input messages and their nested dicts are not
+    mutated (direct callers may reuse their list).
+    """
+    normalized: list[dict[str, Any]] = []
+    for msg in messages:
+        new_msg = dict(msg)
+        if isinstance(new_msg.get("content"), list):
+            new_msg["content"] = flatten_content_to_text(new_msg["content"])
+
+        tool_calls = new_msg.get("tool_calls")
+        if isinstance(tool_calls, list):
+            new_calls: list[Any] = []
+            for tc in tool_calls:
+                new_tc = dict(tc) if isinstance(tc, dict) else tc
+                func = new_tc.get("function") if isinstance(new_tc, dict) else None
+                if isinstance(func, dict) and "arguments" in func:
+                    decoded = decode_tool_args(func["arguments"])
+                    if isinstance(decoded, dict):
+                        new_func = dict(func)
+                        new_func["arguments"] = decoded
+                        new_tc["function"] = new_func
+                new_calls.append(new_tc)
+            new_msg["tool_calls"] = new_calls
+
+        normalized.append(new_msg)
+    return normalized
 
 
 def _is_think_unsupported_error(status_code: int, body: str) -> bool:
@@ -168,7 +219,7 @@ class OllamaClient:
         """
         body: dict[str, Any] = {
             "model": self.model,
-            "messages": messages,
+            "messages": _normalize_messages_for_ollama(messages),
             "stream": False,
             "options": self._build_options(sampling),
         }
@@ -241,7 +292,7 @@ class OllamaClient:
         """
         body: dict[str, Any] = {
             "model": self.model,
-            "messages": messages,
+            "messages": _normalize_messages_for_ollama(messages),
             "stream": True,
             "options": self._build_options(sampling),
         }

--- a/src/forge/proxy/convert.py
+++ b/src/forge/proxy/convert.py
@@ -6,9 +6,10 @@ import json
 import uuid
 from typing import Any
 
+from forge.clients.base import flatten_content_to_text
 from forge.core.messages import Message, MessageMeta, MessageRole, MessageType, ToolCallInfo
 from forge.core.reasoning import DEFAULT_REASONING_REPLAY, ReasoningReplay, validate_reasoning_replay
-from forge.core.workflow import ToolCall, TextResponse
+from forge.core.workflow import ToolCall
 
 
 # ── Inbound: OpenAI request → forge Messages ─────────────────────
@@ -23,17 +24,9 @@ def openai_to_messages(openai_messages: list[dict[str, Any]]) -> list[Message]:
 
     for msg in openai_messages:
         role_str = msg.get("role", "user")
-        content = msg.get("content", "") or ""
         # Normalize list-style content blocks to a plain string.
         # OpenAI format allows content as [{"type": "text", "text": "..."}].
-        if isinstance(content, list):
-            parts = []
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    parts.append(block.get("text", ""))
-                elif isinstance(block, str):
-                    parts.append(block)
-            content = "\n".join(parts)
+        content = flatten_content_to_text(msg.get("content", "") or "")
 
         if role_str == "system":
             messages.append(Message(

--- a/tests/unit/test_ollama_client.py
+++ b/tests/unit/test_ollama_client.py
@@ -763,6 +763,117 @@ class TestOllamaSendStream:
         assert "timeout" in str(exc_info.value).lower()
 
 
+# ── outbound message normalization (#111 / #115) ─────────────────
+
+
+def _sent_body(mock_call) -> dict:
+    return mock_call.kwargs.get("json") or mock_call[1].get("json")
+
+
+class TestNormalizeMessagesForOllama:
+    """Outbound coercion of OpenAI-wire messages to Ollama's native schema."""
+
+    def test_flattens_multipart_content(self) -> None:
+        from forge.clients.ollama import _normalize_messages_for_ollama
+        out = _normalize_messages_for_ollama([
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+        ])
+        assert out[0]["content"] == "hello"
+
+    def test_joins_multiple_text_parts_and_drops_images(self) -> None:
+        from forge.clients.ollama import _normalize_messages_for_ollama
+        out = _normalize_messages_for_ollama([
+            {"role": "user", "content": [
+                {"type": "text", "text": "a"},
+                {"type": "image_url", "image_url": {"url": "data:..."}},
+                {"type": "text", "text": "b"},
+            ]},
+        ])
+        assert out[0]["content"] == "a\nb"
+
+    def test_coerces_json_string_tool_args_to_dict(self) -> None:
+        from forge.clients.ollama import _normalize_messages_for_ollama
+        out = _normalize_messages_for_ollama([
+            {"role": "assistant", "tool_calls": [
+                {"function": {"name": "t", "arguments": '{"x": "1"}'}}
+            ]},
+        ])
+        assert out[0]["tool_calls"][0]["function"]["arguments"] == {"x": "1"}
+
+    def test_preserves_already_dict_tool_args(self) -> None:
+        from forge.clients.ollama import _normalize_messages_for_ollama
+        out = _normalize_messages_for_ollama([
+            {"role": "assistant", "tool_calls": [
+                {"function": {"name": "t", "arguments": {"x": "1"}}}
+            ]},
+        ])
+        assert out[0]["tool_calls"][0]["function"]["arguments"] == {"x": "1"}
+
+    def test_leaves_malformed_tool_args_untouched(self) -> None:
+        """A non-object/malformed args payload is not coerced to {}."""
+        from forge.clients.ollama import _normalize_messages_for_ollama
+        out = _normalize_messages_for_ollama([
+            {"role": "assistant", "tool_calls": [
+                {"function": {"name": "t", "arguments": "not json"}}
+            ]},
+        ])
+        assert out[0]["tool_calls"][0]["function"]["arguments"] == "not json"
+
+    def test_does_not_mutate_input(self) -> None:
+        from forge.clients.ollama import _normalize_messages_for_ollama
+        original = [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {"role": "assistant", "tool_calls": [
+                {"function": {"name": "t", "arguments": '{"x": "1"}'}}
+            ]},
+        ]
+        _normalize_messages_for_ollama(original)
+        assert original[0]["content"] == [{"type": "text", "text": "hi"}]
+        assert original[1]["tool_calls"][0]["function"]["arguments"] == '{"x": "1"}'
+
+    def test_plain_string_content_unchanged(self) -> None:
+        from forge.clients.ollama import _normalize_messages_for_ollama
+        out = _normalize_messages_for_ollama([{"role": "user", "content": "hi"}])
+        assert out[0]["content"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_send_normalizes_body(self) -> None:
+        """#115 + #111 on the non-streaming wire body."""
+        client = _make_client()
+        client._http.post.return_value = _mock_response({
+            "message": {"role": "assistant", "content": "ok"}
+        })
+        await client.send([
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {"role": "assistant", "tool_calls": [
+                {"function": {"name": "t", "arguments": '{"x": "1"}'}}
+            ]},
+            {"role": "tool", "content": "ok"},
+        ])
+        body = _sent_body(client._http.post.call_args)
+        assert body["messages"][0]["content"] == "hi"
+        assert body["messages"][1]["tool_calls"][0]["function"]["arguments"] == {"x": "1"}
+
+    @pytest.mark.asyncio
+    async def test_send_stream_normalizes_body(self) -> None:
+        """send_stream gets identical treatment (WorkflowRunner stream path)."""
+        client = _make_client()
+        lines = [
+            json.dumps({"message": {"role": "assistant", "content": ""}, "done": True}),
+        ]
+        client._http.stream.return_value = _MockStreamResponse(lines)
+        async for _ in client.send_stream([
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {"role": "assistant", "tool_calls": [
+                {"function": {"name": "t", "arguments": '{"x": "1"}'}}
+            ]},
+        ]):
+            pass
+        body = _sent_body(client._http.stream.call_args)
+        assert body["messages"][0]["content"] == "hi"
+        assert body["messages"][1]["tool_calls"][0]["function"]["arguments"] == {"x": "1"}
+
+
 # ── get_context_length + set_num_ctx ─────────────────────────────
 
 

--- a/tests/unit/test_proxy_handler.py
+++ b/tests/unit/test_proxy_handler.py
@@ -1,8 +1,11 @@
 """Tests for proxy request handler."""
 
-import pytest
-from unittest.mock import AsyncMock
+import json
 
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from forge.clients.ollama import OllamaClient
 from forge.context.manager import ContextManager
 from forge.context.strategies import NoCompact
 from forge.core.workflow import TextResponse, ToolCall
@@ -614,6 +617,65 @@ class TestNativePassthrough:
         sent = client.send.call_args.kwargs["raw_openai_tools"]
         names = [t["function"]["name"] for t in sent]
         assert names == ["search", "respond"]
+
+
+class TestOllamaProxyIntegration:
+    """Proxy → REAL OllamaClient (mocked transport): the seam that let #111/#115
+    ship. Every other handler test mocks the client, so it asserts what reaches
+    the client, not what the client actually POSTs to /api/chat. These assert the
+    on-the-wire body on the raw-passthrough first attempt."""
+
+    def _real_ollama(self, response_data):
+        client = OllamaClient(base_url="http://test:11434", model="m", think=False)
+        mock_http = AsyncMock()
+        mock_http.stream = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = response_data
+        resp.text = json.dumps(response_data)
+        mock_http.post.return_value = resp
+        client._http = mock_http
+        return client
+
+    @pytest.mark.asyncio
+    async def test_no_tools_array_content_normalized(self):
+        """#115 on the no-tools chat path (also raw-passthrough)."""
+        client = self._real_ollama({"message": {"role": "assistant", "content": "ok"}})
+        messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        await handle_chat_completions(
+            _body(messages=messages), client, _context_manager(),
+        )
+        body = client._http.post.call_args.kwargs["json"]
+        assert body["messages"][0]["content"] == "hi"
+
+    @pytest.mark.asyncio
+    async def test_tool_history_string_args_normalized(self):
+        """#111: a replayed assistant tool_calls turn with JSON-string args is
+        coerced to a dict on the wire (the multi-turn 400)."""
+        client = self._real_ollama({
+            "message": {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "search", "arguments": {"q": "ok"}}}
+                ],
+            }
+        })
+        messages = [
+            {"role": "user", "content": "x"},
+            {"role": "assistant", "tool_calls": [
+                {"id": "c1", "type": "function",
+                 "function": {"name": "search", "arguments": '{"q": "1"}'}}
+            ]},
+            {"role": "tool", "tool_call_id": "c1", "content": "result"},
+        ]
+        await handle_chat_completions(
+            _body(messages=messages, tools=[_tool_def("search")]),
+            client, _context_manager(),
+        )
+        # First attempt is the raw-passthrough path where the bug lived.
+        body = client._http.post.call_args_list[0].kwargs["json"]
+        tc_msg = [m for m in body["messages"] if m.get("tool_calls")][0]
+        assert tc_msg["tool_calls"][0]["function"]["arguments"] == {"q": "1"}
 
 
 # ── Prompt capability handoff ───────────────────────────────


### PR DESCRIPTION
## What

Fixes two Ollama proxy bugs (#111, #115) of the same class. OllamaClient runs
native passthrough, so the client's verbatim OpenAI-wire messages reach
Ollama's native `/api/chat`, whose schema is stricter than the OpenAI wire format:

- **#115** — multi-part array `content` → `400 cannot unmarshal array ... of type string`
- **#111** — assistant `tool_calls[].function.arguments` as a JSON string →
  `400 Value looks like object, but can't find closing '}'` (every multi-turn
  tool session, from the 2nd turn on)

## How

An Ollama-local outbound normalizer applied in **both** `send` and `send_stream`
before building the request body:
- flatten multi-part `content` arrays to text (text-only — images dropped,
  consistent with the existing converted path; full multi-modal support is #116)
- coerce `tool_calls[].function.arguments` from JSON string to dict, only when
  it decodes to an object (malformed/non-object payloads pass through untouched)

Native `/api/chat` is kept — switching to Ollama's `/v1` compat shim would force
a rewrite of the native response parsing (thinking field, dict args, NDJSON).

The content-flatten primitive is extracted to `clients/base.py` and reused in
`proxy/convert.py` (behavior-preserving); `base.decode_tool_args` is reused for
argument coercion.

## Testing

- Unit: normalizer + on-the-wire body for `send`/`send_stream`; arg edge cases,
  image-drop, no-mutation.
- Integration: proxy → real `OllamaClient` (mocked transport), asserting the
  raw-passthrough first-attempt body — the seam that let both bugs ship.
- Full suite: 1178 passed.
- Live end-to-end against a real Ollama server: both raw shapes 400 today; both
  succeed through forge's normalizer.

## Known limitation

Images in multi-part content are dropped (text-only), matching prior behavior.
Real multi-modal support is tracked separately in #116.

Closes #111
Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
