### PR TITLE
v0.8.0: first-class authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to forge are documented here.
 
+## [0.8.0] — 2026-06-27
+
+First-class authentication across all proxy modes and backends. forge now forwards exactly one credential to the backend — a static `--backend-api-key` or a single inbound auth header — relocating it across protocols (`x-api-key` ↔ `Authorization: Bearer`) when the frontend and backend differ. Gated OpenAI-compatible backends (LM Studio, hosted vLLM, service accounts) work without monkey-patching. Closes #119.
+
+### Added
+- **`--backend-api-key` / `FORGE_BACKEND_API_KEY`** — a static credential forge sends to the backend in its native auth slot (LM Studio, hosted providers, service accounts — the case where the caller sends nothing). Baked into the backend client at startup and relocated to the backend's protocol slot. When set, an inbound auth header is refused as a second credential.
+- **Cross-protocol credential relocation** — an inbound `x-api-key` ↔ `Authorization: Bearer` is rewritten to the backend's protocol when frontend and backend differ (the SSO/forwarded-token case). Frontend protocol is by path (`/v1/chat/completions` = openai, `/v1/messages` = anthropic); backend by `--backend-protocol`. See the auth section in [Backend Setup](docs/BACKEND_SETUP.md).
+- **Deferred backend discovery for gated external backends.** The context-length / served-model-name probe (llama.cpp `/props`, vLLM `/v1/models`) now runs on the **first request**, authenticated by that request's credential, instead of unauthenticated at startup — which previously 401'd and crashed boot against a gated backend. Managed mode and the Anthropic external path are unaffected. New `LLMClient.discover_backend_metadata(extra_headers)`; vLLM collapses its two `/v1/models` round-trips into one.
+
+### Changed
+- **BREAKING — credential handling for auth-required backends.** This only affects backends that *require* auth. **Ungated local backends are unchanged — leave `--backend-api-key` unset and send no auth header, exactly as before; zero credentials is the normal local path and still works.** What changed: when a backend *does* require a credential, a request carrying **zero** now fails loud (401) instead of sending an empty/garbage header that produced an opaque downstream error; and **two** credentials at once (static + inbound, or two inbound auth headers) are refused with **400** rather than one silently winning. Migration: nothing to do for local/ungated backends. For gated backends, supply exactly one credential — set `--backend-api-key` (or `FORGE_BACKEND_API_KEY`), *or* forward an inbound auth header, not both.
+- **Removed the silent `extra_headers`-overrides-`api_key` merge.** A per-call auth header in `extra_headers` no longer shadows a client's configured `api_key`; that combination is now a two-credential conflict (400). Migration: pass the credential one way only. (Undocumented prior behavior, unlikely to be relied on.)
+
 ## [0.7.6] — 2026-06-20
 
 A bug-fix release for the Ollama backend and inline reasoning capture. Multi-turn tool sessions and multi-part message content no longer 400 against Ollama's native API, and chain-of-thought emitted inline in `content` is now captured on vLLM and Ollama as it already was on the structured-field path.

--- a/docs/BACKEND_SETUP.md
+++ b/docs/BACKEND_SETUP.md
@@ -59,10 +59,12 @@ The proxy gets its one credential from one of two sources — never both:
 If an inbound auth header **and** `--backend-api-key` are both present, or a
 single request carries **two** auth headers, the proxy refuses it with **HTTP
 400** (a client error — the message names the conflicting slots, never a secret).
-For a **streaming** request the `200 OK` and SSE headers are already flushed
-before the backend call, so the conflict surfaces as an error *event* inside the
-stream rather than an HTTP 400 — the same way every other proxy streaming error
-is reported.
+This holds for **streaming** requests too: the credential is resolved (and a
+gated backend's context discovered) *before* the `200 OK` / SSE headers are
+flushed, so a credential or discovery failure returns the real status (400/401)
+rather than a stream that opens `200 OK` and then carries an error event. Only a
+failure that happens *after* streaming has begun (the backend faulting
+mid-generation) is reported as an error event inside the already-open stream.
 
 **Cross-protocol relocation.** forge moves the one credential into the target
 backend's canonical auth slot (it never reads the secret value):

--- a/docs/BACKEND_SETUP.md
+++ b/docs/BACKEND_SETUP.md
@@ -15,6 +15,93 @@ Install instructions for each backend live with the upstream project. Below is w
 
 ---
 
+## Authentication
+
+forge carries **exactly one credential** to the backend, placed in the backend's
+native auth header. forge does not validate the credential, manage its lifecycle
+(expiry/refresh), or form any opinion on its value — it only relocates it into
+the correct header slot for the target backend. Auth failures therefore surface
+as the backend's own error (401/403), not a forge error.
+
+**The one rule:** exactly one credential reaches the backend. If two are present
+anywhere, forge **refuses the request** — it never merges, never picks a winner,
+never silently drops one. (Design Principle #1: fail fast, fail loud.)
+
+### WorkflowRunner (library use)
+
+Supply the credential at construction, or per call for a rotating token:
+
+```python
+# Static credential (API key, service account): set once at construction.
+client = OpenAICompatClient(model=..., base_url=..., api_key=API_KEY)
+
+# Rotating credential (e.g. an SSO token refreshed out of band): per call.
+await client.send(messages, extra_headers={"Authorization": f"Bearer {token()}"})
+```
+
+A construction credential **and** a per-call auth header on the same call is two
+credentials → raises `MultipleCredentialsError`. Pass auth through one channel.
+
+For a non-Bearer scheme, pass `extra_headers` alone (omit `api_key`); supplying
+both `api_key` and an auth header at construction is also refused.
+
+### Proxy
+
+The proxy gets its one credential from one of two sources — never both:
+
+1. **Inbound passthrough.** The caller's request already carries a credential;
+   forge forwards it, relocating the header to the backend's protocol when they
+   differ (see the table below). This is the SSO/forwarded-token case.
+2. **Static `--backend-api-key`** (or the `FORGE_BACKEND_API_KEY` env var) for
+   backends where the caller sends nothing — LM Studio, hosted providers,
+   service accounts. Baked into the backend client at startup.
+
+If an inbound auth header **and** `--backend-api-key` are both present, or a
+single request carries **two** auth headers, the proxy refuses it with **HTTP
+400** (a client error — the message names the conflicting slots, never a secret).
+For a **streaming** request the `200 OK` and SSE headers are already flushed
+before the backend call, so the conflict surfaces as an error *event* inside the
+stream rather than an HTTP 400 — the same way every other proxy streaming error
+is reported.
+
+**Cross-protocol relocation.** forge moves the one credential into the target
+backend's canonical auth slot (it never reads the secret value):
+
+| Target backend | forge writes |
+|---|---|
+| OpenAI-wire (llama.cpp, vLLM, Ollama, hosted) | `Authorization: Bearer <token>` |
+| Anthropic-wire | `x-api-key: <token>` (forge pins its own `anthropic-version`) |
+
+Same protocol both ends → forwarded verbatim. Cross-protocol → the token is
+normalized (a leading `Bearer ` is stripped/added as needed) and written to the
+target slot. The common case — Claude Code (Anthropic-wire) in front of an
+OpenAI backend — relocates `x-api-key` → `Authorization: Bearer` unambiguously.
+
+> **One documented limitation:** an Anthropic *OAuth* token (which must ride
+> `Authorization: Bearer`, not `x-api-key`) pushed through forge's *OpenAI*
+> endpoint to an Anthropic backend is relocated to `x-api-key` and rejected by
+> Anthropic. Coherent setups never hit this — OAuth callers use the Anthropic
+> endpoint (`/v1/messages`), which is same-protocol passthrough.
+
+forge forwards **only** the one credential header; it does not forward the rest
+of the inbound header set (so client-set `anthropic-beta`, `OpenAI-Organization`,
+etc. do not reach the backend — a future `--backend-header` may add this).
+
+### Notes
+
+- **Ambient `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`** are read by the
+  Anthropic SDK only for *direct* `AnthropicClient()` use (the eval path) — your
+  deliberate single credential. The **proxy** neutralizes these env vars at
+  construction so an ambient value can't become a hidden second credential.
+- **Keyless passthrough to an auth-required backend:** the proxy discovers the
+  backend's context length at startup, before any inbound credential exists. If
+  that endpoint requires auth, pass `--budget-tokens` so startup doesn't need to
+  call it.
+- **DEBUG logging** (proxy `-v`) emits the forwarded credential's header *name*
+  with the value redacted (`x-api-key: ***`). A raw secret is never logged.
+
+---
+
 ## llama-server (recommended)
 
 Upstream: [llama.cpp releases](https://github.com/ggml-org/llama.cpp/releases)

--- a/docs/BACKEND_SETUP.md
+++ b/docs/BACKEND_SETUP.md
@@ -61,10 +61,18 @@ single request carries **two** auth headers, the proxy refuses it with **HTTP
 400** (a client error — the message names the conflicting slots, never a secret).
 This holds for **streaming** requests too: the credential is resolved (and a
 gated backend's context discovered) *before* the `200 OK` / SSE headers are
-flushed, so a credential or discovery failure returns the real status (400/401)
-rather than a stream that opens `200 OK` and then carries an error event. Only a
-failure that happens *after* streaming has begun (the backend faulting
-mid-generation) is reported as an error event inside the already-open stream.
+flushed, so a *conflict* (two credentials) or a discovery failure returns the
+real status (400/401) rather than a stream that opens `200 OK` and then carries
+an error event.
+
+One streaming case is unavoidable today: an error that surfaces only when the
+backend is actually called — the backend **rejecting the credential** (401), or
+refusing a request with no credential — happens *after* the SSE headers are
+flushed, because the proxy buffers the response rather than streaming it
+incrementally. Such failures arrive as an error *event* inside the already-open
+`200` stream, not as a `401` status. (Non-streaming requests always get the real
+status; and the direct `WorkflowRunner` library path streams incrementally, so
+this is specific to the buffered proxy.)
 
 **Cross-protocol relocation.** forge moves the one credential into the target
 backend's canonical auth slot (it never reads the secret value):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forge-guardrails"
-version = "0.7.6"
+version = "0.8.0"
 description = "A reliability layer for self-hosted LLM tool-calling. Guardrails, context management, and backend adapters for multi-step agentic workflows."
 requires-python = ">=3.12"
 license = "MIT"

--- a/scripts/integration_test_proxy.py
+++ b/scripts/integration_test_proxy.py
@@ -395,7 +395,7 @@ async def phase_external(
         proxy = ProxyServer(
             backend_url=f"http://127.0.0.1:{EXTERNAL_BACKEND_PORT}",
             port=EXTERNAL_PROXY_PORT,
-            mode=mode,
+            backend_capability=mode,
             backend_protocol="openai",
         )
         proxy.start()
@@ -430,7 +430,7 @@ async def phase_managed(
         backend_port=MANAGED_BACKEND_PORT,
         port=MANAGED_PROXY_PORT,
         budget_mode=BudgetMode.BACKEND,
-        mode=mode,
+        backend_capability=mode,
         extra_flags=extra_flags,
     )
     proxy.start()
@@ -462,7 +462,7 @@ async def phase_external_vllm(vllm_url: str) -> list[tuple[str, str, str]]:
         backend_url=vllm_url,
         backend="vllm",
         port=VLLM_PROXY_PORT,
-        mode="native",
+        backend_capability="native",
         backend_protocol="openai",
     )
     proxy.start()

--- a/scripts/smoke_test_proxy.py
+++ b/scripts/smoke_test_proxy.py
@@ -59,13 +59,26 @@ async def _read_request(
 
 
 def _write_json_response(body: str) -> bytes:
+    return _write_response(200, "OK", body)
+
+
+def _write_response(status: int, reason: str, body: str) -> bytes:
+    # Connection: close — these mocks serve one request per connection and close
+    # it, so tell the client not to pool it. The deferred-discovery flow makes
+    # two backend hits (/props then /v1/chat/completions); without this, httpx
+    # may reuse the just-closed keep-alive connection and the second hit flakes.
     return (
-        "HTTP/1.1 200 OK\r\n"
+        f"HTTP/1.1 {status} {reason}\r\n"
         "Content-Type: application/json\r\n"
         f"Content-Length: {len(body)}\r\n"
+        "Connection: close\r\n"
         "\r\n"
         f"{body}"
     ).encode()
+
+
+# Credential a gated backend (test 4) requires — mirrors `llama-server --api-key`.
+GATED_KEY = "TESTKEY"
 
 
 # ── Mock backends ─────────────────────────────────────────────────────
@@ -100,6 +113,48 @@ async def openai_mock_backend(
                 "finish_reason": "tool_calls",
             }],
             "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        })
+
+    writer.write(_write_json_response(body))
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
+
+
+async def gated_openai_mock_backend(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter,
+) -> None:
+    """OpenAI-shape mock that GATES on ``Authorization: Bearer TESTKEY``.
+
+    Mirrors ``llama-server --api-key``: a missing/wrong credential gets 401 on
+    *every* path — crucially including the ``/props`` context-length probe. This
+    lets the deferred-discovery path (finding #2) be exercised without a real
+    gated backend: the proxy can't probe at startup (it has no credential then),
+    so it must defer to the first request and use that request's inbound key.
+    """
+    path, headers, _body = await _read_request(reader)
+
+    if headers.get("authorization") != f"Bearer {GATED_KEY}":
+        body = json.dumps({"error": {"message": "missing/invalid api key", "type": "auth"}})
+        writer.write(_write_response(401, "Unauthorized", body))
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+        return
+
+    if "/props" in path:
+        body = json.dumps({"default_generation_settings": {"n_ctx": 8192}})
+    else:
+        body = json.dumps({
+            "id": "chatcmpl-gated",
+            "object": "chat.completion",
+            "model": "mock",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "OK"},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
         })
 
     writer.write(_write_json_response(body))
@@ -255,6 +310,61 @@ async def test_openai() -> None:
         await mock.wait_closed()
 
 
+# ── Test 1b: Gated passthrough → deferred discovery (finding #2) ─────
+
+async def test_gated_passthrough_deferred_discovery() -> None:
+    print("\n=== test_gated_passthrough_deferred_discovery (deferred probe vs gated backend) ===")
+    mock = await asyncio.start_server(gated_openai_mock_backend, "127.0.0.1", 18090)
+    # Pure passthrough: no --backend-api-key, no --budget-tokens → discovery is
+    # deferred to the first request. Against a GATED backend this used to crash
+    # at startup (the unauthenticated /props probe); now the proxy must just start.
+    proxy = _start_proxy(backend_url="http://127.0.0.1:18090", port=18091)
+    print("[setup] gated mock=:18090 proxy=:18091 (no backend_api_key, no budget_tokens)")
+    print("[ok] proxy started against a gated backend (deferred — no startup probe/crash)")
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            # Negative: no inbound credential → the deferred /props probe is
+            # unauthenticated → backend 401 → clean 401, discovery NOT latched.
+            r0 = await client.post(
+                "http://127.0.0.1:18091/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": False,
+                },
+            )
+            assert r0.status_code == 401, (
+                f"no-cred: expected 401, got {r0.status_code} {r0.text[:200]}"
+            )
+            print("[ok] no-credential first request → 401 (probe rejected, not latched)")
+
+            # Positive: same request WITH the credential → the deferred probe
+            # authenticates with the inbound key, context is discovered, request
+            # completes. Also proves no-latch-on-failure: the prior 401 didn't
+            # poison discovery — this retry succeeds.
+            r1 = await client.post(
+                "http://127.0.0.1:18091/v1/chat/completions",
+                headers={"Authorization": f"Bearer {GATED_KEY}"},
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": False,
+                },
+            )
+            assert r1.status_code == 200, (
+                f"with-cred: expected 200, got {r1.status_code} {r1.text[:200]}"
+            )
+            assert r1.json()["choices"][0]["message"]["content"] == "OK"
+            print("[ok] credentialed request → deferred discovery succeeded, 200 "
+                  "(retry after the 401 works → no-latch-on-failure)")
+
+    finally:
+        proxy.stop()
+        mock.close()
+        await mock.wait_closed()
+
+
 # ── Test 2: Path 2 (Anthropic inbound → OpenAI backend) ──────────────
 
 async def test_path2_anthropic_to_openai() -> None:
@@ -388,6 +498,12 @@ async def test_path1_anthropic_passthrough() -> None:
             cache_marker = {"type": "ephemeral"}
             resp = await client.post(
                 "http://127.0.0.1:18085/v1/messages",
+                # v0.8.0 one-credential rule: this proxy is pure passthrough (no
+                # --backend-api-key), so the request must carry a credential —
+                # forge relocates this single inbound x-api-key to the Anthropic
+                # backend's native slot. Without it forge fails loud (401), which
+                # is correct: you can't reach an Anthropic backend with no key.
+                headers={"x-api-key": "smoke-anthropic-key"},
                 json={
                     "model": "claude-mock",
                     "max_tokens": 1024,
@@ -459,6 +575,7 @@ async def test_path1_anthropic_passthrough() -> None:
 
 async def main() -> None:
     await test_openai()
+    await test_gated_passthrough_deferred_discovery()
     await test_path2_anthropic_to_openai()
     await test_path1_anthropic_passthrough()
     print("\n[PASS] All proxy smoke tests passed.")

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -13,11 +13,57 @@ from typing import Any
 
 import anthropic
 
-from forge.clients.base import ChunkType, StreamChunk, TokenUsage, decode_tool_args
+from forge.clients.base import (
+    ChunkType,
+    StreamChunk,
+    TokenUsage,
+    decode_tool_args,
+    resolve_request_headers,
+    static_auth_present,
+)
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
 from forge.errors import BackendError
 
 log = logging.getLogger(__name__)
+
+# The Anthropic SDK pins these headers itself — ``anthropic-version`` is part
+# of its wire contract. A forwarded inbound value must not clobber them, so we
+# drop them from any forge-forwarded header set.
+_ANTHROPIC_PINNED_HEADERS = frozenset({"anthropic-version", "anthropic-beta"})
+
+# The SDK's auth preflight (``_validate_headers``) reads these keys
+# case-SENSITIVELY from a plain dict before the request goes out. The proxy
+# lowercases all inbound header keys, so a relocated ``x-api-key`` would fail
+# the preflight ("Could not resolve authentication method") unless re-cased to
+# exactly what the SDK expects. forge never inspects the credential value.
+_SDK_AUTH_CASING = {"authorization": "Authorization", "x-api-key": "X-Api-Key"}
+
+# SDK request-control kwargs that must never be sourced from an inbound body or
+# passthrough — they are client-side controls (headers/query/timeout), not
+# Anthropic Messages API fields. In particular a body-supplied ``extra_headers``
+# would smuggle an auth header into ``messages.create`` past the one-credential
+# gate, so these are stripped before forge sets its own per-call credential.
+_SDK_CONTROL_KWARGS = ("extra_headers", "extra_body", "extra_query", "timeout")
+
+
+def _prepare_anthropic_headers(
+    headers: dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Canonicalize auth-header casing for the SDK and drop SDK-pinned headers.
+
+    Returns a new dict (or None). Auth headers are re-cased to the SDK's
+    case-sensitive expectation; ``anthropic-version``/``anthropic-beta`` are
+    dropped so the SDK's own pinned version wins.
+    """
+    if not headers:
+        return None
+    prepared: dict[str, str] = {}
+    for k, v in headers.items():
+        kl = k.lower()
+        if kl in _ANTHROPIC_PINNED_HEADERS:
+            continue
+        prepared[_SDK_AUTH_CASING.get(kl, k)] = v
+    return prepared or None
 
 
 class AnthropicClient:
@@ -42,6 +88,7 @@ class AnthropicClient:
         base_url: str | None = None,
         prompt_caching: bool = False,
         thinking: dict[str, Any] | None = None,
+        default_headers: dict[str, str] | None = None,
     ) -> None:
         self.model = model
         self.max_tokens = max_tokens
@@ -65,11 +112,25 @@ class AnthropicClient:
             log.debug(
                 "AnthropicClient ignores recommended_sampling=True — no sampling kwargs are exposed."
             )
+        # One credential per request. ``static_auth`` reflects an explicitly
+        # configured static credential (an ``api_key`` argument or an auth
+        # header in ``default_headers``); a per-call auth header is then refused
+        # as a second source. NOTE: ``api_key=None`` lets the SDK fall back to
+        # ``ANTHROPIC_API_KEY`` from the environment — that is a deliberate
+        # single credential for direct (WorkflowRunner) use and is NOT tracked
+        # here. The proxy, which forwards inbound credentials, must construct
+        # this client with an explicit ``api_key`` (the resolved
+        # ``--backend-api-key`` or ``""``) so an ambient env key can't become a
+        # silent second credential.
+        self._static_auth = static_auth_present(api_key, default_headers)
         sdk_kwargs: dict[str, Any] = {
             "api_key": api_key,
             "timeout": timeout,
             "max_retries": max_retries,
         }
+        prepared_default_headers = _prepare_anthropic_headers(default_headers)
+        if prepared_default_headers:
+            sdk_kwargs["default_headers"] = prepared_default_headers
         # base_url retargets the SDK at an Anthropic-shape downstream
         # (LiteLLM, a self-hosted proxy, etc.) — proxy path 1.
         if base_url is not None:
@@ -85,6 +146,22 @@ class AnthropicClient:
     async def aclose(self) -> None:
         """Close the underlying Anthropic SDK client (and its httpx pool)."""
         await self._client.close()
+
+    def _sdk_extra_headers(
+        self, extra_headers: dict[str, str] | None,
+    ) -> dict[str, str] | None:
+        """Per-call SDK headers, enforcing the one-credential rule.
+
+        Validates against a static construction credential (raises on a second
+        source), then re-cases auth headers to the SDK's case-sensitive
+        expectation and drops SDK-pinned version headers. Passed via the SDK's
+        per-call ``extra_headers=`` — never set as ``default_headers`` (the
+        proxy shares one client instance, so a per-request credential must not
+        leak into later requests).
+        """
+        return _prepare_anthropic_headers(
+            resolve_request_headers(self._static_auth, extra_headers)
+        )
 
     # ── Tool schema conversion ───────────────────────────────────
 
@@ -340,6 +417,7 @@ class AnthropicClient:
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
         raw_openai_tools: list[dict[str, Any]] | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> LLMResponse:
         """Send messages via the Anthropic Messages API.
 
@@ -349,7 +427,9 @@ class AnthropicClient:
         ``inbound_anthropic_body`` (path 1) triggers verbatim emit — see
         ADR-015 for the cache_control preservation rationale.
         ``raw_openai_tools`` accepted for protocol symmetry, ignored
-        (Anthropic uses its own tool conversion).
+        (Anthropic uses its own tool conversion). ``extra_headers`` carries the
+        per-call credential, re-cased for the SDK and forwarded via the SDK's
+        per-call ``extra_headers=``.
         """
         if sampling:
             log.debug(
@@ -359,6 +439,13 @@ class AnthropicClient:
         kwargs = self._build_kwargs(
             messages, tools, passthrough, inbound_anthropic_body,
         )
+        # Strip SDK control kwargs that a verbatim/passthrough body could carry
+        # before forge installs its own per-call credential.
+        for control_kwarg in _SDK_CONTROL_KWARGS:
+            kwargs.pop(control_kwarg, None)
+        sdk_headers = self._sdk_extra_headers(extra_headers)
+        if sdk_headers:
+            kwargs["extra_headers"] = sdk_headers
         try:
             response = await self._client.messages.create(**kwargs)
         except anthropic.APIError as exc:
@@ -388,6 +475,7 @@ class AnthropicClient:
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
         raw_openai_tools: list[dict[str, Any]] | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Stream via the Anthropic Messages API.
 
@@ -395,6 +483,7 @@ class AnthropicClient:
         ``passthrough`` merges inbound-body extras into the SDK call.
         ``inbound_anthropic_body`` (path 1) triggers verbatim emit; see ADR-015.
         ``raw_openai_tools`` accepted for protocol symmetry, ignored.
+        ``extra_headers`` carries the per-call credential (see :meth:`send`).
         """
         if sampling:
             log.debug(
@@ -404,6 +493,13 @@ class AnthropicClient:
         kwargs = self._build_kwargs(
             messages, tools, passthrough, inbound_anthropic_body,
         )
+        # Strip SDK control kwargs that a verbatim/passthrough body could carry
+        # before forge installs its own per-call credential.
+        for control_kwarg in _SDK_CONTROL_KWARGS:
+            kwargs.pop(control_kwarg, None)
+        sdk_headers = self._sdk_extra_headers(extra_headers)
+        if sdk_headers:
+            kwargs["extra_headers"] = sdk_headers
 
         accumulated_text = ""
         # Track multiple tool_use blocks by index.

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -630,3 +630,14 @@ class AnthropicClient:
     async def get_context_length(self) -> int | None:
         """Claude models have 200K context."""
         return 200_000
+
+    async def discover_backend_metadata(
+        self, extra_headers: dict[str, str] | None = None,
+    ) -> int | None:
+        """Static 200K context, no probe and no identity to adopt.
+
+        The Anthropic path reports a known context length without a network
+        call, so it is never deferred — this exists for Protocol uniformity and
+        ignores ``extra_headers``.
+        """
+        return 200_000

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -6,9 +6,11 @@ produces) and Anthropic's native Messages API format internally.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
-from collections.abc import AsyncIterator
+import os
+from collections.abc import AsyncIterator, Iterator
 from typing import Any
 
 import anthropic
@@ -44,6 +46,29 @@ _SDK_AUTH_CASING = {"authorization": "Authorization", "x-api-key": "X-Api-Key"}
 # would smuggle an auth header into ``messages.create`` past the one-credential
 # gate, so these are stripped before forge sets its own per-call credential.
 _SDK_CONTROL_KWARGS = ("extra_headers", "extra_body", "extra_query", "timeout")
+
+# Env vars the Anthropic SDK reads for auth when api_key/auth_token are unset.
+# Suppressed while forge constructs a client it owns the credential for, so an
+# ambient value can't inject a hidden second credential the per-request gate
+# never sees.
+_AMBIENT_ANTHROPIC_ENV = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+
+
+@contextlib.contextmanager
+def _suppressed_ambient_credentials() -> Iterator[None]:
+    """Temporarily clear Anthropic credential env vars, then restore them.
+
+    Used only around SDK construction for forge-owned-credential clients (the
+    proxy). forge may itself run evals that rely on these env vars in another
+    client/process, so they are restored immediately after construction.
+    """
+    saved = {k: os.environ.pop(k, None) for k in _AMBIENT_ANTHROPIC_ENV}
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is not None:
+                os.environ[key] = value
 
 
 def _prepare_anthropic_headers(
@@ -115,16 +140,26 @@ class AnthropicClient:
         # One credential per request. ``static_auth`` reflects an explicitly
         # configured static credential (an ``api_key`` argument or an auth
         # header in ``default_headers``); a per-call auth header is then refused
-        # as a second source. NOTE: ``api_key=None`` lets the SDK fall back to
-        # ``ANTHROPIC_API_KEY`` from the environment — that is a deliberate
-        # single credential for direct (WorkflowRunner) use and is NOT tracked
-        # here. The proxy, which forwards inbound credentials, must construct
-        # this client with an explicit ``api_key`` (the resolved
-        # ``--backend-api-key`` or ``""``) so an ambient env key can't become a
-        # silent second credential.
+        # as a second source.
         self._static_auth = static_auth_present(api_key, default_headers)
+        # Credential ownership has three modes, keyed on ``api_key``:
+        #   None  — WorkflowRunner direct use: defer to the SDK's own env-based
+        #           auth (ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN), the dev's
+        #           deliberate single credential. forge stays out of it.
+        #   ""    — proxy pure passthrough: forge holds NO static credential and
+        #           the per-call forwarded header is the sole auth. Map to None
+        #           so the SDK emits no auth header at all (api_key="" would emit
+        #           a spurious empty X-Api-Key that collides with a per-call
+        #           Authorization on the OAuth path).
+        #   "key" — explicit static credential (proxy --backend-api-key, or an
+        #           explicit WR key).
+        # Whenever forge owns the credential (api_key is not None, including
+        # ""), suppress ambient ANTHROPIC_* env during construction so a stray
+        # ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN can't become a silent second
+        # credential the per-request gate never sees.
+        forge_owns_credential = api_key is not None
         sdk_kwargs: dict[str, Any] = {
-            "api_key": api_key,
+            "api_key": api_key or None,
             "timeout": timeout,
             "max_retries": max_retries,
         }
@@ -135,7 +170,11 @@ class AnthropicClient:
         # (LiteLLM, a self-hosted proxy, etc.) — proxy path 1.
         if base_url is not None:
             sdk_kwargs["base_url"] = base_url
-        self._client = anthropic.AsyncAnthropic(**sdk_kwargs)
+        if forge_owns_credential:
+            with _suppressed_ambient_credentials():
+                self._client = anthropic.AsyncAnthropic(**sdk_kwargs)
+        else:
+            self._client = anthropic.AsyncAnthropic(**sdk_kwargs)
         # Populated after each send()/send_stream() call. Slot-keyed
         # ``{slot_id: TokenUsage}`` to match LlamafileClient / OllamaClient so
         # ``inference._get_usage`` reads every client uniformly. The Anthropic

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -20,11 +20,12 @@ from forge.clients.base import (
     StreamChunk,
     TokenUsage,
     decode_tool_args,
+    has_auth_header,
     resolve_request_headers,
     static_auth_present,
 )
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
-from forge.errors import BackendError
+from forge.errors import BackendError, MissingCredentialError
 
 log = logging.getLogger(__name__)
 
@@ -201,6 +202,23 @@ class AnthropicClient:
         return _prepare_anthropic_headers(
             resolve_request_headers(self._static_auth, extra_headers)
         )
+
+    def _ensure_credential(self, sdk_headers: dict[str, str] | None) -> None:
+        """Fail loud if this request would reach the backend with no credential.
+
+        A credential is present iff the SDK client resolved a construction key
+        (``api_key`` or ``auth_token``, incl. ambient env at build time) or this
+        call carries a per-call auth header. With none, the Anthropic SDK refuses
+        the request with an opaque error surfaced as HTTP 502; forge raises a
+        clear MissingCredentialError (mapped to 401) instead. Never inspects the
+        secret value.
+        """
+        if (
+            self._client.api_key is None
+            and self._client.auth_token is None
+            and not has_auth_header(sdk_headers)
+        ):
+            raise MissingCredentialError("Anthropic backend")
 
     # ── Tool schema conversion ───────────────────────────────────
 
@@ -483,6 +501,7 @@ class AnthropicClient:
         for control_kwarg in _SDK_CONTROL_KWARGS:
             kwargs.pop(control_kwarg, None)
         sdk_headers = self._sdk_extra_headers(extra_headers)
+        self._ensure_credential(sdk_headers)
         if sdk_headers:
             kwargs["extra_headers"] = sdk_headers
         try:
@@ -537,6 +556,7 @@ class AnthropicClient:
         for control_kwarg in _SDK_CONTROL_KWARGS:
             kwargs.pop(control_kwarg, None)
         sdk_headers = self._sdk_extra_headers(extra_headers)
+        self._ensure_credential(sdk_headers)
         if sdk_headers:
             kwargs["extra_headers"] = sdk_headers
 

--- a/src/forge/clients/base.py
+++ b/src/forge/clients/base.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
 from enum import Enum
@@ -46,18 +45,22 @@ def static_auth_present(
 ) -> bool:
     """Whether a static credential was configured, refusing two static sources.
 
-    A construction ``api_key`` AND a construction auth header is itself two
-    credentials — both would ride on every request. Refuse it at construction
-    (fail loud, Design Principle #1) rather than silently sending both. Returns
-    True when exactly one static credential source is present, False when none.
+    A construction ``api_key`` AND a construction auth header — or two auth
+    headers in the construction set — is more than one credential, all of which
+    would ride on every request. Refuse it at construction (fail loud, Design
+    Principle #1) rather than silently sending several. A blank/whitespace
+    ``api_key`` (or scheme-only auth header) is not a credential and is ignored.
+    Returns True when exactly one static credential is present, False when none.
     """
-    has_key = bool(api_key)
-    has_header = has_auth_header(construction_headers)
-    if has_key and has_header:
+    count = (1 if (api_key and api_key.strip()) else 0) + count_auth_credentials(
+        construction_headers,
+    )
+    if count > 1:
         raise MultipleCredentialsError(
-            "construction api_key + construction auth header"
+            "more than one static credential at construction "
+            "(api_key and/or auth headers)"
         )
-    return has_key or has_header
+    return count == 1
 
 
 def resolve_request_headers(
@@ -79,7 +82,10 @@ def resolve_request_headers(
     """
     if not extra_headers:
         return None
-    if static_auth_present and has_auth_header(extra_headers):
+    per_call = count_auth_credentials(extra_headers)
+    if per_call > 1:
+        raise MultipleCredentialsError("more than one per-call auth header")
+    if static_auth_present and per_call >= 1:
         raise MultipleCredentialsError(
             "client construction credential + per-call auth header"
         )
@@ -101,36 +107,35 @@ def redact_auth_headers(headers: Mapping[str, str] | None) -> dict[str, str]:
     }
 
 
-# Best-effort credential scrubbing for FREE TEXT that forge did not author and
-# may echo a secret — a backend's error body, or a traceback containing one. The
-# proxy passes such text to logs and back to the caller; a debug/gateway backend
-# that reflects request headers could otherwise leak `Authorization: Bearer ...`
-# or an `x-api-key` value. Heuristic (covers the auth shapes forge handles plus
-# common key prefixes), NOT a guarantee — the real defense is never authoring a
-# secret into a message; this is the safety net for text we don't control.
-_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    # Authorization: Bearer <token>  (header or echoed in a body)
-    (re.compile(r"(?i)(bearer\s+)([A-Za-z0-9._\-]+)"), r"\1[REDACTED]"),
-    # x-api-key: <token>  /  "x-api-key": "<token>"  (header- or JSON-shaped)
-    (re.compile(r"""(?i)(x-api-key["']?\s*[:=]\s*["']?)([A-Za-z0-9._\-]+)"""),
-     r"\1[REDACTED]"),
-    # Provider key prefixes that are self-evidently secret anywhere they appear.
-    (re.compile(r"\bsk-[A-Za-z0-9._\-]{6,}"), "[REDACTED]"),
-)
+BEARER_PREFIX = "bearer "
 
 
-def redact_secrets(text: str) -> str:
-    """Scrub credential-looking substrings from free text before logging/returning.
+def auth_credential_token(name: str, value: str) -> str:
+    """The secret token carried by an auth header value (``''`` if none).
 
-    Use on backend error bodies and tracebacks at the proxy boundary, where a
-    backend may have echoed an inbound auth header. Best-effort: redacts Bearer
-    tokens, x-api-key values, and ``sk-`` key prefixes. Not exhaustive — do not
-    rely on it to sanitize text forge itself controls (don't author secrets into
-    messages in the first place).
+    Strips a ``Bearer `` scheme from an ``Authorization`` value; ``x-api-key`` is
+    already the raw token. A scheme-only ``Bearer `` or a blank/whitespace value
+    yields ``''`` — i.e. the header is present but carries no credential, so it
+    must not be counted or forwarded as one.
     """
-    for pattern, replacement in _SECRET_PATTERNS:
-        text = pattern.sub(replacement, text)
-    return text
+    if name.lower() == "authorization" and value[: len(BEARER_PREFIX)].lower() == BEARER_PREFIX:
+        return value[len(BEARER_PREFIX):].strip()
+    return value.strip()
+
+
+def count_auth_credentials(headers: Mapping[str, str] | None) -> int:
+    """Number of headers that actually carry an auth credential.
+
+    Counts recognized auth headers whose value resolves to a non-empty token;
+    blank or scheme-only auth headers do not count. forge carries exactly one
+    credential, so callers refuse a bag that yields more than one.
+    """
+    if not headers:
+        return 0
+    return sum(
+        1 for name, value in headers.items()
+        if name.lower() in AUTH_HEADER_NAMES and value and auth_credential_token(name, value)
+    )
 
 
 @dataclass(frozen=True)

--- a/src/forge/clients/base.py
+++ b/src/forge/clients/base.py
@@ -319,6 +319,21 @@ class LLMClient(Protocol):
         """Query the backend for its configured context window size."""
         ...
 
+    async def discover_backend_metadata(
+        self, extra_headers: dict[str, str] | None = None,
+    ) -> int | None:
+        """Probe the backend once, credentialed by ``extra_headers``.
+
+        The deferred counterpart to startup discovery: adopt any backend-owned
+        wire identity into this client (e.g. vLLM's served model name) as a
+        side effect, and return the discovered context budget — or None when the
+        backend exposes no context length. Carrying ``extra_headers`` lets the
+        proxy run this lazily on the first request so it authenticates with that
+        request's inbound credential (external passthrough mode). Raises
+        ``BackendError`` if the probe is rejected or returns an unusable shape.
+        """
+        ...
+
     async def aclose(self) -> None:
         """Release held network resources (e.g. the httpx connection pool)."""
         ...

--- a/src/forge/clients/base.py
+++ b/src/forge/clients/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
 from enum import Enum
@@ -98,6 +99,38 @@ def redact_auth_headers(headers: Mapping[str, str] | None) -> dict[str, str]:
         k: ("***" if k.lower() in AUTH_HEADER_NAMES else v)
         for k, v in headers.items()
     }
+
+
+# Best-effort credential scrubbing for FREE TEXT that forge did not author and
+# may echo a secret — a backend's error body, or a traceback containing one. The
+# proxy passes such text to logs and back to the caller; a debug/gateway backend
+# that reflects request headers could otherwise leak `Authorization: Bearer ...`
+# or an `x-api-key` value. Heuristic (covers the auth shapes forge handles plus
+# common key prefixes), NOT a guarantee — the real defense is never authoring a
+# secret into a message; this is the safety net for text we don't control.
+_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    # Authorization: Bearer <token>  (header or echoed in a body)
+    (re.compile(r"(?i)(bearer\s+)([A-Za-z0-9._\-]+)"), r"\1[REDACTED]"),
+    # x-api-key: <token>  /  "x-api-key": "<token>"  (header- or JSON-shaped)
+    (re.compile(r"""(?i)(x-api-key["']?\s*[:=]\s*["']?)([A-Za-z0-9._\-]+)"""),
+     r"\1[REDACTED]"),
+    # Provider key prefixes that are self-evidently secret anywhere they appear.
+    (re.compile(r"\bsk-[A-Za-z0-9._\-]{6,}"), "[REDACTED]"),
+)
+
+
+def redact_secrets(text: str) -> str:
+    """Scrub credential-looking substrings from free text before logging/returning.
+
+    Use on backend error bodies and tracebacks at the proxy boundary, where a
+    backend may have echoed an inbound auth header. Best-effort: redacts Bearer
+    tokens, x-api-key values, and ``sk-`` key prefixes. Not exhaustive — do not
+    rely on it to sanitize text forge itself controls (don't author secrets into
+    messages in the first place).
+    """
+    for pattern, replacement in _SECRET_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
 
 
 @dataclass(frozen=True)

--- a/src/forge/clients/base.py
+++ b/src/forge/clients/base.py
@@ -3,18 +3,101 @@
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Protocol, runtime_checkable
 
 from forge.core.workflow import LLMResponse, ToolSpec
+from forge.errors import MultipleCredentialsError
 
 # Verbatim OpenAI-shape payloads forwarded by the proxy. The proxy hands the
 # client the user's original ``tools`` array so the backend sees the exact
 # schema the client authored, instead of forge's reconstructed ToolSpec.
 RawOpenAITools = list[dict[str, Any]]
 RawOpenAIMessages = list[dict[str, Any]]
+
+
+# ── Auth credential helpers ──────────────────────────────────────────
+#
+# forge carries exactly ONE credential to the backend, placed in the
+# backend's native auth header. It does not validate the credential, manage
+# its lifecycle, or form any opinion on its value — it only detects presence
+# and relocates the header to the target protocol's canonical slot. Two
+# credentials present anywhere is a hard error (Design Principle #1: fail
+# loud, never silently merge or pick a winner).
+
+# Header names that carry a backend credential (lowercased for
+# case-insensitive comparison).
+AUTH_HEADER_NAMES = frozenset({"authorization", "x-api-key"})
+
+
+def has_auth_header(headers: Mapping[str, str] | None) -> bool:
+    """True if any key in ``headers`` is a recognized auth header."""
+    if not headers:
+        return False
+    return any(name.lower() in AUTH_HEADER_NAMES for name in headers)
+
+
+def static_auth_present(
+    api_key: str | None,
+    construction_headers: Mapping[str, str] | None,
+) -> bool:
+    """Whether a static credential was configured, refusing two static sources.
+
+    A construction ``api_key`` AND a construction auth header is itself two
+    credentials — both would ride on every request. Refuse it at construction
+    (fail loud, Design Principle #1) rather than silently sending both. Returns
+    True when exactly one static credential source is present, False when none.
+    """
+    has_key = bool(api_key)
+    has_header = has_auth_header(construction_headers)
+    if has_key and has_header:
+        raise MultipleCredentialsError(
+            "construction api_key + construction auth header"
+        )
+    return has_key or has_header
+
+
+def resolve_request_headers(
+    static_auth_present: bool,
+    extra_headers: Mapping[str, str] | None,
+) -> dict[str, str] | None:
+    """Validate the one-credential rule and return per-call headers to apply.
+
+    If the client already holds a static auth credential (set at
+    construction) AND this call supplies its own auth header, that is two
+    credentials — refuse it (fail loud; never merge, never pick a winner).
+
+    Returns a plain-dict copy of ``extra_headers`` to pass as the per-call
+    ``headers=`` (httpx merges it over the construction headers, request
+    winning), or ``None`` when there are no per-call headers. Callers MUST
+    pass these per call and MUST NOT mutate the shared client's construction
+    headers — the proxy reuses one client instance across serialized
+    requests, so a mutated credential would leak into later calls.
+    """
+    if not extra_headers:
+        return None
+    if static_auth_present and has_auth_header(extra_headers):
+        raise MultipleCredentialsError(
+            "client construction credential + per-call auth header"
+        )
+    return dict(extra_headers)
+
+
+def redact_auth_headers(headers: Mapping[str, str] | None) -> dict[str, str]:
+    """Return a copy of ``headers`` with auth values masked for logging.
+
+    Never log a raw secret — not even a prefix of an opaque token. The header
+    *name* is preserved (so logs show which slot carried the credential); the
+    value is replaced wholesale with ``***``.
+    """
+    if not headers:
+        return {}
+    return {
+        k: ("***" if k.lower() in AUTH_HEADER_NAMES else v)
+        for k, v in headers.items()
+    }
 
 
 @dataclass(frozen=True)
@@ -155,6 +238,7 @@ class LLMClient(Protocol):
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
         raw_openai_tools: RawOpenAITools | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> LLMResponse:
         """Send messages and return a parsed response.
 
@@ -190,6 +274,13 @@ class LLMClient(Protocol):
                 it as-is instead of re-emitting ``format_tool(spec)``, so the
                 backend sees the original schema (no name/schema drift). Other
                 clients accept and ignore.
+            extra_headers: Per-call HTTP headers, primarily the one credential
+                forge forwards to the backend (proxy: a relocated inbound auth
+                header; WorkflowRunner: a rotating SSO token). Applied per call
+                over the construction headers (request wins). If the client
+                already holds a static auth credential, supplying an auth
+                header here raises ``MultipleCredentialsError`` — exactly one
+                credential reaches the backend. None = no per-call headers.
         """
         ...
 
@@ -201,6 +292,7 @@ class LLMClient(Protocol):
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
         raw_openai_tools: RawOpenAITools | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Send messages and yield streaming chunks.
 
@@ -219,6 +311,7 @@ class LLMClient(Protocol):
             passthrough: Optional inbound-body extras dict (see ``send``).
             inbound_anthropic_body: Optional path-1 verbatim body (see ``send``).
             raw_openai_tools: Optional verbatim OpenAI tools array (see ``send``).
+            extra_headers: Optional per-call credential header (see ``send``).
         """
         ...
 

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -17,6 +17,8 @@ from forge.clients.base import (
     TokenUsage,
     decode_tool_args,
     format_tool,
+    resolve_request_headers,
+    static_auth_present,
 )
 from forge.clients.sampling_defaults import apply_sampling_defaults
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
@@ -143,6 +145,8 @@ class LlamafileClient:
         cache_prompt: bool = True,
         slot_id: int | None = None,
         recommended_sampling: bool = False,
+        api_key: str = "",
+        extra_headers: dict[str, str] | None = None,
     ) -> None:
         if mode not in ("native", "prompt"):
             raise ValueError(
@@ -178,7 +182,19 @@ class LlamafileClient:
             else defaults.get("chat_template_kwargs")
         )
         self.mode = mode
-        self._http = httpx.AsyncClient(timeout=timeout)
+        # Optional backend auth (api_key → Authorization: Bearer; extra_headers
+        # ride on top). This is the proxy's OpenAI-shape external client, so a
+        # gateway in front of llama.cpp may require a credential. One credential
+        # per request: validate the static config (raises on api_key + a
+        # construction auth header) BEFORE opening the pool so a conflict fails
+        # fast; a per-call auth header is later refused when a static one is set.
+        self._static_auth = static_auth_present(api_key, extra_headers)
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        if extra_headers:
+            headers.update(extra_headers)
+        self._http = httpx.AsyncClient(headers=headers, timeout=timeout)
         self._think: bool = think if think is not None else True  # think=None → capture
         self._cache_prompt = cache_prompt
         self._slot_id = slot_id
@@ -188,6 +204,17 @@ class LlamafileClient:
     async def aclose(self) -> None:
         """Close the underlying httpx connection pool."""
         await self._http.aclose()
+
+    def _request_headers(
+        self, extra_headers: dict[str, str] | None,
+    ) -> dict[str, str] | None:
+        """Per-call headers to apply, enforcing the one-credential rule.
+
+        Returns the dict to pass as httpx ``headers=`` (merged over the
+        construction headers, request winning), or None. Never mutates the
+        shared client's construction headers.
+        """
+        return resolve_request_headers(self._static_auth, extra_headers)
 
     def _apply_slot_id(self, body: dict[str, Any]) -> None:
         """Inject slot_id into a request body if configured."""
@@ -270,6 +297,7 @@ class LlamafileClient:
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
         raw_openai_tools: RawOpenAITools | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> LLMResponse:
         """Dispatch to the native or prompt-injected path per the declared mode.
 
@@ -279,12 +307,18 @@ class LlamafileClient:
         ``raw_openai_tools`` (proxy use) is forwarded verbatim as the
         backend's ``tools`` array on the native path; the prompt path
         accepts and ignores it (it keeps forge's prompt-injection format).
+
+        ``extra_headers`` carries the per-call credential and is forwarded to
+        both the native and prompt paths.
         """
         if self.mode == "native":
             return await self._send_native(
                 messages, tools, sampling, passthrough, raw_openai_tools,
+                extra_headers,
             )
-        return await self._send_prompt(messages, tools, sampling, passthrough)
+        return await self._send_prompt(
+            messages, tools, sampling, passthrough, extra_headers,
+        )
 
     async def send_stream(
         self,
@@ -294,12 +328,14 @@ class LlamafileClient:
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
         raw_openai_tools: RawOpenAITools | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Stream via SSE, handling both native FC and prompt-injected paths.
 
         ``inbound_anthropic_body`` accepted for protocol symmetry, ignored.
         ``raw_openai_tools`` (proxy use) is forwarded verbatim on the native
-        path; ignored on the prompt path.
+        path; ignored on the prompt path. ``extra_headers`` carries the
+        per-call credential.
         """
         mode = self.mode
 
@@ -341,7 +377,10 @@ class LlamafileClient:
         tool_call_parts: dict[int, dict[str, str]] = {}  # idx -> {name, args}
 
         async with self._http.stream(
-            "POST", f"{self.base_url}/chat/completions", json=body
+            "POST",
+            f"{self.base_url}/chat/completions",
+            json=body,
+            headers=self._request_headers(extra_headers),
         ) as response:
             if response.status_code == 500:
                 error_body = ""
@@ -451,12 +490,14 @@ class LlamafileClient:
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
         raw_openai_tools: RawOpenAITools | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> LLMResponse:
         """Send using native function calling (OpenAI tools parameter).
 
         When ``raw_openai_tools`` is supplied (proxy native passthrough), it is
         sent as the ``tools`` array verbatim so the backend sees the client's
         original schema instead of forge's re-emitted ``format_tool(spec)``.
+        ``extra_headers`` carries the per-call credential.
         """
         merged = _merge_consecutive(messages)
         body: dict[str, Any] = dict(passthrough or {})
@@ -473,7 +514,9 @@ class LlamafileClient:
             body["tools"] = [format_tool(t) for t in tools]
 
         resp = await self._http.post(
-            f"{self.base_url}/chat/completions", json=body
+            f"{self.base_url}/chat/completions",
+            json=body,
+            headers=self._request_headers(extra_headers),
         )
         if resp.status_code == 500:
             return TextResponse(content=resp.text)
@@ -515,8 +558,12 @@ class LlamafileClient:
         tools: list[ToolSpec] | None,
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> LLMResponse:
-        """Send using prompt-injected tool calling."""
+        """Send using prompt-injected tool calling.
+
+        ``extra_headers`` carries the per-call credential.
+        """
         prepared = _merge_consecutive(_downgrade_messages(messages))
         if tools:
             tool_prompt = build_tool_prompt(tools)
@@ -535,7 +582,9 @@ class LlamafileClient:
         self._apply_sampling(body, sampling)
 
         resp = await self._http.post(
-            f"{self.base_url}/chat/completions", json=body
+            f"{self.base_url}/chat/completions",
+            json=body,
+            headers=self._request_headers(extra_headers),
         )
         resp.raise_for_status()
         data = resp.json()

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -190,7 +190,7 @@ class LlamafileClient:
         # fast; a per-call auth header is later refused when a static one is set.
         self._static_auth = static_auth_present(api_key, extra_headers)
         headers: dict[str, str] = {}
-        if api_key:
+        if api_key and api_key.strip():
             headers["Authorization"] = f"Bearer {api_key}"
         if extra_headers:
             headers.update(extra_headers)
@@ -507,7 +507,7 @@ class LlamafileClient:
         except httpx.HTTPError as exc:
             raise BackendError(502, f"llama.cpp /props unreachable: {exc}") from exc
         if resp.status_code != 200:
-            raise BackendError(resp.status_code, resp.text)
+            raise BackendError(resp.status_code, raw_body=resp.text)
 
         try:
             body = resp.json()
@@ -560,7 +560,7 @@ class LlamafileClient:
         if resp.status_code == 500:
             return TextResponse(content=resp.text)
         if resp.status_code != 200:
-            raise BackendError(resp.status_code, resp.text)
+            raise BackendError(resp.status_code, raw_body=resp.text)
         data = resp.json()
         self._record_usage(data)
 

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -483,6 +483,45 @@ class LlamafileClient:
         except (ValueError, KeyError, TypeError) as exc:
             raise ContextDiscoveryError(exc) from exc
 
+    async def discover_backend_metadata(
+        self, extra_headers: dict[str, str] | None = None,
+    ) -> int | None:
+        """Probe /props once for the context budget, credentialed.
+
+        llama.cpp ignores the wire ``model`` field, so there is no identity to
+        adopt — this returns the context length (``n_ctx``) and nothing else.
+        Carries ``extra_headers`` so a gateway in front of llama.cpp can
+        authenticate the probe on the first request. Raises ``BackendError`` on
+        a rejected, unreachable, or unparseable probe (so the proxy maps it to a
+        clean status); returns None when /props reports no ``n_ctx`` (the caller
+        fails loud rather than guessing a budget).
+        """
+        base = self.base_url.rstrip("/")
+        if base.endswith("/v1"):
+            base = base[:-3]
+
+        try:
+            resp = await self._http.get(
+                f"{base}/props", headers=self._request_headers(extra_headers),
+            )
+        except httpx.HTTPError as exc:
+            raise BackendError(502, f"llama.cpp /props unreachable: {exc}") from exc
+        if resp.status_code != 200:
+            raise BackendError(resp.status_code, resp.text)
+
+        try:
+            body = resp.json()
+        except ValueError as exc:
+            raise BackendError(502, f"llama.cpp /props returned non-JSON: {exc}") from exc
+        settings = body.get("default_generation_settings", {}) if isinstance(body, dict) else {}
+        n_ctx = settings.get("n_ctx") if isinstance(settings, dict) else None
+        if n_ctx is None:
+            return None
+        try:
+            return int(n_ctx)
+        except (ValueError, TypeError) as exc:
+            raise BackendError(502, f"llama.cpp /props n_ctx not an integer: {exc}") from exc
+
     async def _send_native(
         self,
         messages: list[dict[str, str]],

--- a/src/forge/clients/ollama.py
+++ b/src/forge/clients/ollama.py
@@ -133,7 +133,7 @@ class OllamaClient:
         # auth header is later refused when a static one is set here.
         self._static_auth = static_auth_present(api_key, extra_headers)
         headers: dict[str, str] = {}
-        if api_key:
+        if api_key and api_key.strip():
             headers["Authorization"] = f"Bearer {api_key}"
         if extra_headers:
             headers.update(extra_headers)
@@ -281,7 +281,7 @@ class OllamaClient:
         if resp.status_code == 500:
             return TextResponse(content=resp.text)
         if resp.status_code != 200:
-            raise BackendError(resp.status_code, resp.text)
+            raise BackendError(resp.status_code, raw_body=resp.text)
         data = resp.json()
         self._record_usage(data)
 
@@ -358,7 +358,7 @@ class OllamaClient:
                     del body["think"]
                     # Fall through to retry below
                 else:
-                    raise BackendError(400, error_body)
+                    raise BackendError(400, raw_body=error_body)
 
             if not self._think_resolved:
                 self._think_resolved = True

--- a/src/forge/clients/ollama.py
+++ b/src/forge/clients/ollama.py
@@ -455,3 +455,14 @@ class OllamaClient:
         Budget resolution lives in ServerManager, not here.
         """
         return self._num_ctx
+
+    async def discover_backend_metadata(
+        self, extra_headers: dict[str, str] | None = None,
+    ) -> int | None:
+        """Return the configured num_ctx, no probe and no identity to adopt.
+
+        Ollama runs managed (forge owns the local backend), so it is never on
+        the proxy's deferred external path; this exists for Protocol uniformity
+        and ignores ``extra_headers``.
+        """
+        return self._num_ctx

--- a/src/forge/clients/ollama.py
+++ b/src/forge/clients/ollama.py
@@ -15,6 +15,8 @@ from forge.clients.base import (
     decode_tool_args,
     flatten_content_to_text,
     format_tool,
+    resolve_request_headers,
+    static_auth_present,
 )
 from forge.clients.sampling_defaults import apply_sampling_defaults
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
@@ -106,6 +108,8 @@ class OllamaClient:
         timeout: float = 300.0,
         think: bool | None = None,
         recommended_sampling: bool = False,
+        api_key: str = "",
+        extra_headers: dict[str, str] | None = None,
     ) -> None:
         self.base_url = base_url
         self.model = model
@@ -121,7 +125,19 @@ class OllamaClient:
         self.min_p = min_p if min_p is not None else defaults.get("min_p")
         self.repeat_penalty = repeat_penalty if repeat_penalty is not None else defaults.get("repeat_penalty")
         self.presence_penalty = presence_penalty if presence_penalty is not None else defaults.get("presence_penalty")
-        self._http = httpx.AsyncClient(timeout=timeout)
+        # Optional backend auth (api_key → Authorization: Bearer; extra_headers
+        # ride on top). Local Ollama is usually unauthenticated, but a gateway
+        # in front of it may require a credential. One credential per request:
+        # validate the static config (raises on api_key + a construction auth
+        # header) BEFORE opening the pool so a conflict fails fast; a per-call
+        # auth header is later refused when a static one is set here.
+        self._static_auth = static_auth_present(api_key, extra_headers)
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        if extra_headers:
+            headers.update(extra_headers)
+        self._http = httpx.AsyncClient(headers=headers, timeout=timeout)
         self._num_ctx: int | None = None
 
         if think is not None:
@@ -136,6 +152,17 @@ class OllamaClient:
     async def aclose(self) -> None:
         """Close the underlying httpx connection pool."""
         await self._http.aclose()
+
+    def _request_headers(
+        self, extra_headers: dict[str, str] | None,
+    ) -> dict[str, str] | None:
+        """Per-call headers to apply, enforcing the one-credential rule.
+
+        Returns the dict to pass as httpx ``headers=`` (merged over the
+        construction headers, request winning), or None. Never mutates the
+        shared client's construction headers.
+        """
+        return resolve_request_headers(self._static_auth, extra_headers)
 
     # Sampling fields recognized in per-call overrides. ``seed`` is
     # accepted only as a per-call override (not an instance field).
@@ -206,6 +233,7 @@ class OllamaClient:
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
         raw_openai_tools: list[dict[str, Any]] | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> LLMResponse:
         """Send messages via /api/chat and parse the response.
 
@@ -215,7 +243,9 @@ class OllamaClient:
         Ollama passthrough is a follow-up.
 
         ``inbound_anthropic_body`` / ``raw_openai_tools`` accepted for protocol
-        symmetry, ignored (Ollama is OpenAI-shape only).
+        symmetry, ignored (Ollama is OpenAI-shape only). ``extra_headers``
+        carries the per-call credential, applied over the construction headers
+        on every request (including the think-unsupported retry).
         """
         body: dict[str, Any] = {
             "model": self.model,
@@ -228,8 +258,12 @@ class OllamaClient:
         if tools:
             body["tools"] = [format_tool(t) for t in tools]
 
+        # One credential per request: resolve once and reuse for the retry.
+        req_headers = self._request_headers(extra_headers)
         try:
-            resp = await self._http.post(f"{self.base_url}/api/chat", json=body)
+            resp = await self._http.post(
+                f"{self.base_url}/api/chat", json=body, headers=req_headers,
+            )
         except httpx.ReadTimeout as exc:
             raise BackendError(408, "Read timeout") from exc
 
@@ -240,7 +274,9 @@ class OllamaClient:
             self._think = False
             self._think_resolved = True
             del body["think"]
-            resp = await self._http.post(f"{self.base_url}/api/chat", json=body)
+            resp = await self._http.post(
+                f"{self.base_url}/api/chat", json=body, headers=req_headers,
+            )
 
         if resp.status_code == 500:
             return TextResponse(content=resp.text)
@@ -284,11 +320,14 @@ class OllamaClient:
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
         raw_openai_tools: list[dict[str, Any]] | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Stream via NDJSON from /api/chat.
 
         ``passthrough`` / ``inbound_anthropic_body`` / ``raw_openai_tools``
-        accepted for protocol symmetry; see ``send`` notes.
+        accepted for protocol symmetry; see ``send`` notes. ``extra_headers``
+        carries the per-call credential, applied on both the initial stream
+        and the think-unsupported retry stream.
         """
         body: dict[str, Any] = {
             "model": self.model,
@@ -301,8 +340,10 @@ class OllamaClient:
         if tools:
             body["tools"] = [format_tool(t) for t in tools]
 
+        # One credential per request: resolve once and reuse for the retry.
+        req_headers = self._request_headers(extra_headers)
         async with self._http.stream(
-            "POST", f"{self.base_url}/api/chat", json=body
+            "POST", f"{self.base_url}/api/chat", json=body, headers=req_headers,
         ) as response:
             # Think unsupported: fail fast if explicit, fall back if auto-detected
             if response.status_code == 400:
@@ -332,7 +373,7 @@ class OllamaClient:
 
         # Retry stream without think
         async with self._http.stream(
-            "POST", f"{self.base_url}/api/chat", json=body
+            "POST", f"{self.base_url}/api/chat", json=body, headers=req_headers,
         ) as response:
             async for chunk in self._iter_stream(response):
                 yield chunk

--- a/src/forge/clients/openai_compat.py
+++ b/src/forge/clients/openai_compat.py
@@ -101,7 +101,7 @@ class OpenAICompatClient:
         # (e.g. OpenRouter's HTTP-Referer) ride on top. For a non-Bearer auth
         # scheme, pass extra_headers alone and omit api_key.
         headers: dict[str, str] = {}
-        if api_key:
+        if api_key and api_key.strip():
             headers["Authorization"] = f"Bearer {api_key}"
         if extra_headers:
             headers.update(extra_headers)
@@ -227,7 +227,7 @@ class OpenAICompatClient:
             raise BackendError(408, "Read timeout") from exc
 
         if resp.status_code != 200:
-            raise BackendError(resp.status_code, resp.text)
+            raise BackendError(resp.status_code, raw_body=resp.text)
 
         data = resp.json()
         self._record_usage(data)
@@ -273,7 +273,7 @@ class OpenAICompatClient:
         ) as response:
             if response.status_code != 200:
                 error_body = await response.aread()
-                raise BackendError(response.status_code, error_body.decode(errors="replace"))
+                raise BackendError(response.status_code, raw_body=error_body.decode(errors="replace"))
 
             async for line in response.aiter_lines():
                 if not line.startswith("data: "):

--- a/src/forge/clients/openai_compat.py
+++ b/src/forge/clients/openai_compat.py
@@ -334,3 +334,12 @@ class OpenAICompatClient:
     async def get_context_length(self) -> int | None:
         """OpenAI-compatible endpoints don't expose context length. Returns None."""
         return None
+
+    async def discover_backend_metadata(
+        self, extra_headers: dict[str, str] | None = None,
+    ) -> int | None:
+        """OpenAI-compatible endpoints expose neither context length nor a
+        discoverable identity. Returns None (Protocol uniformity); not wired
+        into the proxy's deferred external path.
+        """
+        return None

--- a/src/forge/clients/openai_compat.py
+++ b/src/forge/clients/openai_compat.py
@@ -18,7 +18,15 @@ from typing import Any
 
 import httpx
 
-from forge.clients.base import ChunkType, StreamChunk, TokenUsage, decode_tool_args, format_tool
+from forge.clients.base import (
+    ChunkType,
+    StreamChunk,
+    TokenUsage,
+    decode_tool_args,
+    format_tool,
+    resolve_request_headers,
+    static_auth_present,
+)
 from forge.clients.sampling_defaults import apply_sampling_defaults
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
 from forge.errors import BackendError
@@ -83,9 +91,15 @@ class OpenAICompatClient:
             else defaults.get("chat_template_kwargs")
         )
 
-        # Auth header is set when api_key is provided; extra_headers ride
-        # on top and can override (kept open so a provider with a different
-        # scheme doesn't need a new constructor kwarg).
+        # One credential per request: validate the static config BEFORE opening
+        # the connection pool, so a double-credential conflict (api_key AND a
+        # construction auth header) fails fast without leaking an unclosed
+        # client. The returned bool records whether a static credential is set,
+        # so a per-call auth header is later refused as a second source.
+        self._static_auth = static_auth_present(api_key, extra_headers)
+        # Auth header is set when api_key is provided. Non-auth extra_headers
+        # (e.g. OpenRouter's HTTP-Referer) ride on top. For a non-Bearer auth
+        # scheme, pass extra_headers alone and omit api_key.
         headers: dict[str, str] = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
@@ -97,6 +111,17 @@ class OpenAICompatClient:
     async def aclose(self) -> None:
         """Close the underlying httpx connection pool."""
         await self._http.aclose()
+
+    def _request_headers(
+        self, extra_headers: dict[str, str] | None,
+    ) -> dict[str, str] | None:
+        """Per-call headers to apply, enforcing the one-credential rule.
+
+        Returns the dict to pass as httpx ``headers=`` (merged over the
+        construction headers, request winning), or None. Never mutates the
+        shared client's construction headers.
+        """
+        return resolve_request_headers(self._static_auth, extra_headers)
 
     # ── request building ─────────────────────────────────────────────
 
@@ -180,17 +205,24 @@ class OpenAICompatClient:
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> LLMResponse:
         """Send messages via /chat/completions and parse the response.
 
         ``inbound_anthropic_body`` is accepted to satisfy the LLMClient
         protocol but ignored — Path-1 Anthropic forwarding doesn't apply
-        to OpenAI-shape clients.
+        to OpenAI-shape clients. ``extra_headers`` carries the per-call
+        credential (relocated inbound auth or a rotating token), applied over
+        the construction headers; a second auth source raises.
         """
         del inbound_anthropic_body  # protocol-only, never read here
         body = self._build_body(messages, tools, sampling, stream=False, passthrough=passthrough)
         try:
-            resp = await self._http.post(f"{self.base_url}/chat/completions", json=body)
+            resp = await self._http.post(
+                f"{self.base_url}/chat/completions",
+                json=body,
+                headers=self._request_headers(extra_headers),
+            )
         except httpx.ReadTimeout as exc:
             raise BackendError(408, "Read timeout") from exc
 
@@ -218,11 +250,13 @@ class OpenAICompatClient:
         sampling: dict[str, Any] | None = None,
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Stream via SSE from /chat/completions.
 
         ``inbound_anthropic_body`` is accepted to satisfy the LLMClient
-        protocol but ignored — see :meth:`send`.
+        protocol but ignored — see :meth:`send`. ``extra_headers`` carries
+        the per-call credential (see :meth:`send`).
         """
         del inbound_anthropic_body  # protocol-only, never read here
         body = self._build_body(messages, tools, sampling, stream=True, passthrough=passthrough)
@@ -232,7 +266,10 @@ class OpenAICompatClient:
         usage: dict[str, Any] | None = None
 
         async with self._http.stream(
-            "POST", f"{self.base_url}/chat/completions", json=body
+            "POST",
+            f"{self.base_url}/chat/completions",
+            json=body,
+            headers=self._request_headers(extra_headers),
         ) as response:
             if response.status_code != 200:
                 error_body = await response.aread()

--- a/src/forge/clients/vllm.py
+++ b/src/forge/clients/vllm.py
@@ -108,7 +108,7 @@ class VLLMClient:
         # is set here.
         self._static_auth = static_auth_present(api_key, extra_headers)
         headers: dict[str, str] = {}
-        if api_key:
+        if api_key and api_key.strip():
             headers["Authorization"] = f"Bearer {api_key}"
         if extra_headers:
             headers.update(extra_headers)
@@ -258,7 +258,7 @@ class VLLMClient:
             raise BackendError(408, "Read timeout") from exc
 
         if resp.status_code != 200:
-            raise BackendError(resp.status_code, resp.text)
+            raise BackendError(resp.status_code, raw_body=resp.text)
         data = resp.json()
         self._record_usage(data)
 
@@ -325,7 +325,7 @@ class VLLMClient:
                 error_body = ""
                 async for line in response.aiter_lines():
                     error_body += line
-                raise BackendError(response.status_code, error_body)
+                raise BackendError(response.status_code, raw_body=error_body)
 
             async for line in response.aiter_lines():
                 line = line.strip()
@@ -488,7 +488,7 @@ class VLLMClient:
         except httpx.HTTPError as exc:
             raise BackendError(502, f"vLLM /v1/models unreachable: {exc}") from exc
         if resp.status_code != 200:
-            raise BackendError(resp.status_code, resp.text)
+            raise BackendError(resp.status_code, raw_body=resp.text)
 
         models = resp.json().get("data") or []
         if not models:

--- a/src/forge/clients/vllm.py
+++ b/src/forge/clients/vllm.py
@@ -19,6 +19,7 @@ Differences from LlamafileClient:
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -38,6 +39,8 @@ from forge.clients.sampling_defaults import apply_sampling_defaults
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
 from forge.errors import BackendError
 from forge.prompts.think_tags import extract_think_tags
+
+logger = logging.getLogger("forge.clients.vllm")
 
 
 class VLLMClient:
@@ -460,3 +463,47 @@ class VLLMClient:
         if not models:
             return None
         return models[0].get("id")
+
+    async def discover_backend_metadata(
+        self, extra_headers: dict[str, str] | None = None,
+    ) -> int | None:
+        """Probe /v1/models once for both budget and served identity.
+
+        vLLM exposes ``max_model_len`` (context budget) and the served model
+        ``id`` (the wire ``model`` field it validates) on the same endpoint, so
+        one credentialed GET yields both — collapsing the two separate startup
+        round-trips. The served id is adopted into this client immediately
+        (``_set_model_identity``), and the budget is returned for the caller to
+        apply to the context manager.
+
+        Both fields are required: vLLM 404s every request without a valid served
+        id, and a missing ``max_model_len`` leaves the budget undiscoverable —
+        either is a loud failure (no silent ``"default"`` / no guessed budget).
+        """
+        try:
+            resp = await self._http.get(
+                f"{self.base_url}/models",
+                headers=self._request_headers(extra_headers),
+            )
+        except httpx.HTTPError as exc:
+            raise BackendError(502, f"vLLM /v1/models unreachable: {exc}") from exc
+        if resp.status_code != 200:
+            raise BackendError(resp.status_code, resp.text)
+
+        models = resp.json().get("data") or []
+        if not models:
+            raise BackendError(500, "vLLM /v1/models returned no entries")
+        entry = models[0]
+
+        served = entry.get("id")
+        if not served:
+            raise BackendError(500, f"vLLM /v1/models entry missing id: {entry}")
+        logger.info("Discovered vLLM served model name: %s", served)
+        self._set_model_identity(served)
+
+        max_model_len = entry.get("max_model_len")
+        if max_model_len is None:
+            raise BackendError(
+                500, f"vLLM /v1/models entry missing max_model_len: {entry}",
+            )
+        return int(max_model_len)

--- a/src/forge/clients/vllm.py
+++ b/src/forge/clients/vllm.py
@@ -25,7 +25,15 @@ from typing import Any
 
 import httpx
 
-from forge.clients.base import ChunkType, StreamChunk, TokenUsage, decode_tool_args, format_tool
+from forge.clients.base import (
+    ChunkType,
+    StreamChunk,
+    TokenUsage,
+    decode_tool_args,
+    format_tool,
+    resolve_request_headers,
+    static_auth_present,
+)
 from forge.clients.sampling_defaults import apply_sampling_defaults
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
 from forge.errors import BackendError
@@ -59,6 +67,8 @@ class VLLMClient:
         timeout: float = 300.0,
         think: bool = True,
         recommended_sampling: bool = False,
+        api_key: str = "",
+        extra_headers: dict[str, str] | None = None,
     ) -> None:
         self.base_url = base_url
         # Two identity roles, set together (see _set_model_identity):
@@ -87,13 +97,36 @@ class VLLMClient:
             chat_template_kwargs if chat_template_kwargs is not None
             else defaults.get("chat_template_kwargs")
         )
-        self._http = httpx.AsyncClient(timeout=timeout)
+        # Optional backend auth (api_key → Authorization: Bearer; extra_headers
+        # ride on top). vLLM servers may be started with --api-key. One
+        # credential per request: validate the static config (raises on api_key
+        # + a construction auth header) BEFORE opening the pool so a conflict
+        # fails fast; a per-call auth header is later refused when a static one
+        # is set here.
+        self._static_auth = static_auth_present(api_key, extra_headers)
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        if extra_headers:
+            headers.update(extra_headers)
+        self._http = httpx.AsyncClient(headers=headers, timeout=timeout)
         self._think: bool = think
         self.last_usage: dict[int, TokenUsage] = {}
 
     async def aclose(self) -> None:
         """Close the underlying httpx connection pool."""
         await self._http.aclose()
+
+    def _request_headers(
+        self, extra_headers: dict[str, str] | None,
+    ) -> dict[str, str] | None:
+        """Per-call headers to apply, enforcing the one-credential rule.
+
+        Returns the dict to pass as httpx ``headers=`` (merged over the
+        construction headers, request winning), or None. Never mutates the
+        shared client's construction headers.
+        """
+        return resolve_request_headers(self._static_auth, extra_headers)
 
     @staticmethod
     def _derive_sampling_key(wire_id: str) -> str:
@@ -193,12 +226,14 @@ class VLLMClient:
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
         raw_openai_tools: list[dict[str, Any]] | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> LLMResponse:
         """Send messages via /v1/chat/completions and parse the response.
 
         ``passthrough`` / ``inbound_anthropic_body`` / ``raw_openai_tools`` are
         accepted for protocol symmetry and ignored — vLLM parses tools and
-        reasoning server-side and is native-only.
+        reasoning server-side and is native-only. ``extra_headers`` carries the
+        per-call credential, applied over the construction headers.
         """
         body: dict[str, Any] = {
             "model": self.model,
@@ -212,7 +247,9 @@ class VLLMClient:
 
         try:
             resp = await self._http.post(
-                f"{self.base_url}/chat/completions", json=body,
+                f"{self.base_url}/chat/completions",
+                json=body,
+                headers=self._request_headers(extra_headers),
             )
         except httpx.ReadTimeout as exc:
             raise BackendError(408, "Read timeout") from exc
@@ -250,11 +287,13 @@ class VLLMClient:
         passthrough: dict[str, Any] | None = None,
         inbound_anthropic_body: dict[str, Any] | None = None,
         raw_openai_tools: list[dict[str, Any]] | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Stream via SSE from /v1/chat/completions.
 
         ``passthrough`` / ``inbound_anthropic_body`` / ``raw_openai_tools``
         accepted for protocol symmetry and ignored (see ``send``).
+        ``extra_headers`` carries the per-call credential.
         """
         body: dict[str, Any] = {
             "model": self.model,
@@ -274,7 +313,10 @@ class VLLMClient:
         tool_call_parts: dict[int, dict[str, str]] = {}
 
         async with self._http.stream(
-            "POST", f"{self.base_url}/chat/completions", json=body,
+            "POST",
+            f"{self.base_url}/chat/completions",
+            json=body,
+            headers=self._request_headers(extra_headers),
         ) as response:
             if response.status_code != 200:
                 error_body = ""

--- a/src/forge/core/inference.py
+++ b/src/forge/core/inference.py
@@ -180,6 +180,7 @@ async def run_inference(
     inbound_anthropic_body: dict[str, Any] | None = None,
     raw_openai_messages: RawOpenAIMessages | None = None,
     raw_openai_tools: RawOpenAITools | None = None,
+    extra_headers: dict[str, str] | None = None,
     reasoning_replay: ReasoningReplay = DEFAULT_REASONING_REPLAY,
 ) -> InferenceResult | None:
     """Send messages to the LLM with compaction, folding, validation, and retry.
@@ -209,6 +210,10 @@ async def run_inference(
             max_iterations.
         stream: If True, use send_stream() instead of send().
         on_chunk: Async callback for streaming chunks.
+        extra_headers: Optional per-call credential header forwarded to the
+            client's send/send_stream (proxy: a relocated inbound auth header).
+            Passed only when set, so clients/test doubles that omit the kwarg
+            keep their original signature.
 
     Returns:
         InferenceResult with validated tool calls, new messages, and
@@ -293,18 +298,27 @@ async def run_inference(
         if raw_openai_tools is not None and _attempt == 0:
             raw_tools_kwarg["raw_openai_tools"] = raw_openai_tools
 
+        # Forward the per-call credential only when set, so clients/test
+        # doubles that omit the kwarg keep their original signature (same
+        # pattern as raw_openai_tools above).
+        extra_headers_kwarg: dict[str, Any] = {}
+        if extra_headers is not None:
+            extra_headers_kwarg["extra_headers"] = extra_headers
+
         # Send
         if stream:
             response = await _send_streaming(
                 client, api_messages, tool_specs, on_chunk, sampling, passthrough,
                 inbound_anthropic_body=verbatim_body,
                 **raw_tools_kwarg,
+                **extra_headers_kwarg,
             )
         else:
             response = await client.send(
                 api_messages, tools=tool_specs, sampling=sampling, passthrough=passthrough,
                 inbound_anthropic_body=verbatim_body,
                 **raw_tools_kwarg,
+                **extra_headers_kwarg,
             )
         # Subsequent attempts (retries) are mutations regardless of outcome.
         verbatim_body = None
@@ -429,16 +443,21 @@ async def _send_streaming(
     passthrough: dict[str, Any] | None = None,
     inbound_anthropic_body: dict[str, Any] | None = None,
     raw_openai_tools: RawOpenAITools | None = None,
+    extra_headers: dict[str, str] | None = None,
 ) -> LLMResponse:
     """Send via streaming, forwarding chunks to on_chunk callback."""
     response = None
     raw_tools_kwarg: dict[str, Any] = {}
     if raw_openai_tools is not None:
         raw_tools_kwarg["raw_openai_tools"] = raw_openai_tools
+    extra_headers_kwarg: dict[str, Any] = {}
+    if extra_headers is not None:
+        extra_headers_kwarg["extra_headers"] = extra_headers
     async for chunk in client.send_stream(
         api_messages, tools=tool_specs, sampling=sampling, passthrough=passthrough,
         inbound_anthropic_body=inbound_anthropic_body,
         **raw_tools_kwarg,
+        **extra_headers_kwarg,
     ):
         if on_chunk is not None:
             await on_chunk(chunk)

--- a/src/forge/errors.py
+++ b/src/forge/errors.py
@@ -212,3 +212,24 @@ class StreamError(ForgeError):
 
     def __init__(self, message: str = "Stream ended without FINAL chunk"):
         super().__init__(message)
+
+
+class MultipleCredentialsError(ForgeError):
+    """More than one auth credential was present for a single backend call.
+
+    forge carries exactly one credential to the backend (Design Principle #1:
+    fail loud, no silent merge). This is raised when a client holds a static
+    auth credential (set at construction) AND a per-call ``extra_headers``
+    also carries an auth header, or when a single inbound proxy request
+    carries two distinct auth headers. forge never picks a winner or drops
+    one — it refuses the request.
+    """
+
+    def __init__(self, sources: str):
+        super().__init__(
+            f"Multiple credentials present: {sources}. forge accepts exactly "
+            f"one credential per request — pass auth via a single source "
+            f"(the client's construction key OR a per-call/inbound auth header, "
+            f"never both)."
+        )
+        self.sources = sources

--- a/src/forge/errors.py
+++ b/src/forge/errors.py
@@ -253,3 +253,29 @@ class MissingCredentialError(ForgeError):
             f"header or a static backend key (--backend-api-key)."
         )
         self.backend = backend
+
+
+class BackendDiscoveryError(ForgeError):
+    """Deferred external-mode backend discovery failed on the first request.
+
+    In external passthrough mode the proxy defers its startup backend probe
+    (context length, and vLLM's served model identity) to the first request so
+    it can authenticate with that request's inbound credential. When that probe
+    fails — the backend rejected the credential, was unreachable, or returned a
+    shape with no usable context length — forge fails the request loud rather
+    than guessing a budget (Design Principle #1). It does not latch, so a later
+    well-credentialed request retries discovery.
+
+    ``status_code`` carries the backend's HTTP status when the failure was an
+    HTTP rejection (else None), letting the proxy distinguish an auth rejection
+    (401/403 → surfaced as 401) from a backend/connectivity fault (→ 502).
+    """
+
+    def __init__(self, status_code: int | None = None):
+        super().__init__(
+            "Could not discover the backend's context length / model identity "
+            "on the first request: the backend rejected or did not answer the "
+            "probe. Provide --backend-api-key (to authenticate discovery at "
+            "startup) or --budget-tokens (to skip context discovery entirely)."
+        )
+        self.status_code = status_code

--- a/src/forge/errors.py
+++ b/src/forge/errors.py
@@ -186,12 +186,28 @@ class BudgetResolutionError(ForgeError):
 
 
 class BackendError(ForgeError):
-    """Unexpected HTTP error from the LLM backend."""
+    """Unexpected HTTP error from the LLM backend.
 
-    def __init__(self, status_code: int, body: str):
-        super().__init__(f"Backend returned {status_code}: {body}")
+    ``detail`` is a forge-authored summary and IS part of the message — safe to
+    log (forge never writes a secret into it). A backend's RAW response body must
+    be passed as ``raw_body`` instead: a gateway could echo an inbound credential
+    into it, and the message is what gets logged and returned to callers, so the
+    raw body is kept on ``exc.body`` for debugging but never placed in the
+    message. Read ``exc.body`` when you need the raw detail — and don't log it
+    where a secret would be unwelcome.
+    """
+
+    def __init__(
+        self, status_code: int, detail: str = "", *, raw_body: str | None = None,
+    ):
+        message = f"Backend returned {status_code}"
+        if detail:
+            message = f"{message}: {detail}"
+        super().__init__(message)
         self.status_code = status_code
-        self.body = body
+        # The raw backend body when given (kept off the message); otherwise the
+        # forge-authored detail, so ``exc.body`` is always the best available text.
+        self.body = raw_body if raw_body is not None else detail
 
 
 class ThinkingNotSupportedError(BackendError):

--- a/src/forge/errors.py
+++ b/src/forge/errors.py
@@ -233,3 +233,23 @@ class MultipleCredentialsError(ForgeError):
             f"never both)."
         )
         self.sources = sources
+
+
+class MissingCredentialError(ForgeError):
+    """No credential was available for a backend that requires one.
+
+    The counterpart to MultipleCredentialsError: forge would otherwise dispatch
+    a request carrying *zero* credentials. Some backends (the Anthropic SDK in
+    particular) refuse such a request with an opaque client-side error; forge
+    fails loud with a clear one instead. The common trigger is the proxy in
+    pure-passthrough mode (no ``--backend-api-key``) receiving a request with no
+    inbound auth header, pointed at an auth-required backend.
+    """
+
+    def __init__(self, backend: str = "backend"):
+        super().__init__(
+            f"No credential available for the {backend}: forge needs exactly "
+            f"one credential and found none — provide it via an inbound auth "
+            f"header or a static backend key (--backend-api-key)."
+        )
+        self.backend = backend

--- a/src/forge/proxy/__main__.py
+++ b/src/forge/proxy/__main__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import signal
 import sys
 import time
@@ -70,6 +71,15 @@ def main() -> None:
     )
     parser.add_argument("--no-rescue", action="store_true", help="Disable rescue parsing")
     parser.add_argument(
+        "--backend-api-key",
+        default=os.environ.get("FORGE_BACKEND_API_KEY"),
+        help="Static credential forge sends to the backend in its native auth "
+             "header (LM Studio, hosted providers, service accounts). forge "
+             "relocates it to the backend's protocol slot. When set, an inbound "
+             "auth header is refused as a second credential (one credential per "
+             "request). Defaults to the FORGE_BACKEND_API_KEY env var.",
+    )
+    parser.add_argument(
         "--backend-capability",
         choices=["native", "prompt"],
         default="native",
@@ -133,6 +143,7 @@ def main() -> None:
         backend_protocol=args.backend_protocol,
         backend_timeout=args.backend_timeout,
         reasoning_replay=args.reasoning_replay,
+        backend_api_key=args.backend_api_key,
     )
 
     def _shutdown(sig: int, _frame: object) -> None:

--- a/src/forge/proxy/auth.py
+++ b/src/forge/proxy/auth.py
@@ -15,31 +15,14 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from forge.clients.base import AUTH_HEADER_NAMES
+from forge.clients.base import AUTH_HEADER_NAMES, BEARER_PREFIX, auth_credential_token
 from forge.errors import MultipleCredentialsError
-
-_BEARER_PREFIX = "bearer "
 
 # Marker the proxy's header reader injects when a single auth header NAME
 # appears more than once on the inbound request. A plain header dict collapses
 # duplicates to last-wins, which would silently pick a credential winner — the
 # marker forces the same fail-loud refusal as two distinct auth headers.
 DUPLICATE_AUTH_MARKER = "x-forge-duplicate-auth"
-
-
-def _credential_token(slot: str, value: str) -> str:
-    """The secret token carried by an auth header value, for presence checks.
-
-    Strips a ``Bearer `` scheme from an ``Authorization`` value; ``x-api-key`` is
-    already the raw token. Used to decide whether a header actually carries a
-    credential — a value like ``Bearer `` (scheme, no token) is NOT a credential,
-    even though its raw string is non-empty.
-    """
-    # Mirror relocate_credential's scheme check exactly (on the unstripped
-    # value) so presence and relocation agree: "Bearer " -> empty token -> absent.
-    if slot == "authorization" and value[: len(_BEARER_PREFIX)].lower() == _BEARER_PREFIX:
-        return value[len(_BEARER_PREFIX):].strip()
-    return value.strip()
 
 
 def extract_inbound_credential(
@@ -63,7 +46,7 @@ def extract_inbound_credential(
     found: list[tuple[str, str]] = []
     for name, value in headers.items():
         slot = name.lower()
-        if slot in AUTH_HEADER_NAMES and value and _credential_token(slot, value):
+        if slot in AUTH_HEADER_NAMES and value and auth_credential_token(slot, value):
             found.append((slot, value))
     if len(found) > 1:
         slots = ", ".join(sorted(s for s, _ in found))
@@ -101,8 +84,8 @@ def relocate_credential(
     if source_protocol == target_protocol:
         return {slot: value}
 
-    if slot == "authorization" and value[: len(_BEARER_PREFIX)].lower() == _BEARER_PREFIX:
-        token = value[len(_BEARER_PREFIX):].strip()
+    if slot == "authorization" and value[: len(BEARER_PREFIX)].lower() == BEARER_PREFIX:
+        token = value[len(BEARER_PREFIX):].strip()
     else:
         token = value
 

--- a/src/forge/proxy/auth.py
+++ b/src/forge/proxy/auth.py
@@ -27,17 +27,33 @@ _BEARER_PREFIX = "bearer "
 DUPLICATE_AUTH_MARKER = "x-forge-duplicate-auth"
 
 
+def _credential_token(slot: str, value: str) -> str:
+    """The secret token carried by an auth header value, for presence checks.
+
+    Strips a ``Bearer `` scheme from an ``Authorization`` value; ``x-api-key`` is
+    already the raw token. Used to decide whether a header actually carries a
+    credential — a value like ``Bearer `` (scheme, no token) is NOT a credential,
+    even though its raw string is non-empty.
+    """
+    # Mirror relocate_credential's scheme check exactly (on the unstripped
+    # value) so presence and relocation agree: "Bearer " -> empty token -> absent.
+    if slot == "authorization" and value[: len(_BEARER_PREFIX)].lower() == _BEARER_PREFIX:
+        return value[len(_BEARER_PREFIX):].strip()
+    return value.strip()
+
+
 def extract_inbound_credential(
     headers: Mapping[str, str] | None,
 ) -> tuple[str | None, str | None]:
     """Return ``(slot, value)`` for the single inbound auth header.
 
     ``slot`` is the lowercased header name (``authorization`` or ``x-api-key``).
-    Returns ``(None, None)`` when no auth header is present (an empty or
-    whitespace-only auth value is treated as absent). Raises
-    ``MultipleCredentialsError`` if the request carries two distinct auth
-    headers, or the same auth header name more than once — forge never picks a
-    winner.
+    Returns ``(None, None)`` when no auth header carries a credential — an empty,
+    whitespace-only, or scheme-only value (e.g. ``Bearer `` with no token) is
+    treated as absent, so it fails loud downstream rather than forwarding an
+    empty credential. Raises ``MultipleCredentialsError`` if the request carries
+    two distinct auth headers, or the same auth header name more than once —
+    forge never picks a winner.
     """
     headers = headers or {}
     if headers.get(DUPLICATE_AUTH_MARKER):
@@ -47,7 +63,7 @@ def extract_inbound_credential(
     found: list[tuple[str, str]] = []
     for name, value in headers.items():
         slot = name.lower()
-        if slot in AUTH_HEADER_NAMES and value and value.strip():
+        if slot in AUTH_HEADER_NAMES and value and _credential_token(slot, value):
             found.append((slot, value))
     if len(found) > 1:
         slots = ", ".join(sorted(s for s, _ in found))

--- a/src/forge/proxy/auth.py
+++ b/src/forge/proxy/auth.py
@@ -1,0 +1,119 @@
+"""Inbound credential handling for the proxy (forge v0.8.0).
+
+forge forwards exactly ONE credential to the backend, in the backend's native
+auth header. The proxy either relocates a single inbound auth header into the
+target protocol's canonical slot, or (when ``--backend-api-key`` is configured)
+uses that static credential — never both. Two credentials anywhere is a hard
+error (Design Principle #1: fail loud, no silent merge).
+
+Only the single relocated credential is forwarded to the backend; the rest of
+the inbound header set is NOT forwarded (httpx recomputes transport headers for
+the re-serialized body, so there is nothing to strip).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from forge.clients.base import AUTH_HEADER_NAMES
+from forge.errors import MultipleCredentialsError
+
+_BEARER_PREFIX = "bearer "
+
+# Marker the proxy's header reader injects when a single auth header NAME
+# appears more than once on the inbound request. A plain header dict collapses
+# duplicates to last-wins, which would silently pick a credential winner — the
+# marker forces the same fail-loud refusal as two distinct auth headers.
+DUPLICATE_AUTH_MARKER = "x-forge-duplicate-auth"
+
+
+def extract_inbound_credential(
+    headers: Mapping[str, str] | None,
+) -> tuple[str | None, str | None]:
+    """Return ``(slot, value)`` for the single inbound auth header.
+
+    ``slot`` is the lowercased header name (``authorization`` or ``x-api-key``).
+    Returns ``(None, None)`` when no auth header is present (an empty or
+    whitespace-only auth value is treated as absent). Raises
+    ``MultipleCredentialsError`` if the request carries two distinct auth
+    headers, or the same auth header name more than once — forge never picks a
+    winner.
+    """
+    headers = headers or {}
+    if headers.get(DUPLICATE_AUTH_MARKER):
+        raise MultipleCredentialsError(
+            "inbound request carries the same auth header more than once"
+        )
+    found: list[tuple[str, str]] = []
+    for name, value in headers.items():
+        slot = name.lower()
+        if slot in AUTH_HEADER_NAMES and value and value.strip():
+            found.append((slot, value))
+    if len(found) > 1:
+        slots = ", ".join(sorted(s for s, _ in found))
+        raise MultipleCredentialsError(f"inbound request carries auth headers: {slots}")
+    if found:
+        return found[0]
+    return None, None
+
+
+def relocate_credential(
+    slot: str,
+    value: str,
+    source_protocol: str,
+    target_protocol: str,
+) -> dict[str, str]:
+    """Place the one credential in the target protocol's canonical auth slot.
+
+    forge never inspects the credential's secret value; it only decides which
+    slot it belongs in for the target, and (cross-protocol) normalizes the
+    scheme so the token lands correctly.
+
+    - Same protocol both ends: forwarded verbatim (the canonical slot already
+      matches; preserves non-Bearer schemes).
+    - Cross-protocol: normalize to the raw token (strip a leading ``Bearer ``
+      from an ``Authorization`` value; ``x-api-key`` is already raw), then
+      write the target's canonical slot — Anthropic ``x-api-key``, OpenAI-wire
+      ``Authorization: Bearer <token>``.
+
+    The one documented limitation (design §4): an Anthropic OAuth token (which
+    must ride ``Authorization: Bearer``) pushed through the OpenAI endpoint to
+    an Anthropic backend is relocated to ``x-api-key`` and rejected by
+    Anthropic. Coherent setups never hit this — OAuth callers use the Anthropic
+    endpoint (same-protocol, verbatim).
+    """
+    if source_protocol == target_protocol:
+        return {slot: value}
+
+    if slot == "authorization" and value[: len(_BEARER_PREFIX)].lower() == _BEARER_PREFIX:
+        token = value[len(_BEARER_PREFIX):].strip()
+    else:
+        token = value
+
+    if target_protocol == "anthropic":
+        return {"x-api-key": token}
+    return {"Authorization": f"Bearer {token}"}
+
+
+def resolve_inbound_credential(
+    headers: Mapping[str, str] | None,
+    source_protocol: str,
+    target_protocol: str,
+    backend_api_key_present: bool,
+) -> dict[str, str] | None:
+    """Resolve the per-call credential header to forward, or None.
+
+    Extracts the single inbound auth header (raising on two), enforces the
+    one-credential rule against a configured static ``--backend-api-key``, and
+    relocates the credential to the backend's canonical slot. Returns None when
+    the request carries no inbound credential (the static key, if any, is
+    already baked into the client at construction).
+    """
+    slot, value = extract_inbound_credential(headers)
+    if slot is None:
+        return None
+    if backend_api_key_present:
+        raise MultipleCredentialsError(
+            "inbound auth header + --backend-api-key (static backend credential)"
+        )
+    return relocate_credential(slot, value, source_protocol, target_protocol)

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from forge.clients.base import LLMClient, format_tool, redact_auth_headers
@@ -15,7 +16,7 @@ from forge.core.reasoning import (
     validate_reasoning_replay,
 )
 from forge.core.workflow import ToolCall, ToolSpec, TextResponse
-from forge.errors import ToolCallError
+from forge.errors import BackendDiscoveryError, BackendError, ToolCallError
 from forge.guardrails import ErrorTracker, ResponseValidator
 from forge.proxy.auth import resolve_inbound_credential
 from forge.proxy.convert import (
@@ -54,6 +55,29 @@ _SAMPLING_FIELDS = (
 
 # Body fields forge owns and reasons about — never go into passthrough.
 _FORGE_OWNED = frozenset({"messages", "tools", "stream", "stream_options", "system"})
+
+
+@dataclass
+class LazyDiscovery:
+    """Cross-request latch for deferred external-mode backend discovery.
+
+    In external passthrough mode the proxy can't probe the backend at startup
+    (the probe would be unauthenticated against a gated backend), so discovery
+    is deferred to the first request — where the inbound credential authenticates
+    it. This object, created once at setup and shared across requests, holds:
+
+    - ``deferred``: whether lazy discovery is active at all (False for managed,
+      Anthropic, and eager static-key external — those probe at startup).
+    - ``apply_budget``: whether the discovered context length should be written
+      to the context manager. False when ``--budget-tokens`` was given explicitly
+      (the discovery still runs, but only to adopt vLLM's served identity).
+    - ``done``: latched True once discovery succeeds. Only success latches; a
+      failed probe leaves it False so a later credentialed request retries.
+    """
+
+    deferred: bool
+    apply_budget: bool
+    done: bool = False
 
 
 def _extract_sampling(body: dict[str, Any]) -> dict[str, Any] | None:
@@ -135,6 +159,7 @@ async def handle_chat_completions(
     headers: dict[str, str] | None = None,
     backend_protocol: str = "openai",
     backend_api_key_present: bool = False,
+    lazy_discovery: LazyDiscovery | None = None,
 ) -> dict[str, Any] | list[dict[str, Any]]:
     """Handle an inbound completions request.
 
@@ -200,6 +225,28 @@ async def handle_chat_completions(
             "forwarding inbound credential to backend: %s",
             redact_auth_headers(extra_headers),
         )
+
+    # Deferred external-mode backend discovery (finding #2). In external
+    # passthrough mode the startup backend probe is unauthenticated, so it's
+    # deferred to here — the first request — where the inbound credential
+    # (extra_headers) authenticates it. Placed before BOTH dispatch paths: a
+    # vLLM request needs its discovered served identity on every call (not just
+    # the compacting tool path), so this can't live inside the tools branch.
+    if lazy_discovery is not None and lazy_discovery.deferred and not lazy_discovery.done:
+        try:
+            budget = await client.discover_backend_metadata(extra_headers=extra_headers)
+        except BackendError as exc:
+            # Auth rejection (401/403) vs backend/connectivity fault carried via
+            # status_code; the server maps it to the right client status.
+            raise BackendDiscoveryError(status_code=exc.status_code) from exc
+        if lazy_discovery.apply_budget:
+            if budget is None:
+                raise BackendDiscoveryError(status_code=None)
+            context_manager.budget_tokens = budget
+        # Commit + latch synchronously (no await between the probe's return and
+        # here) so concurrent first requests can't observe a torn state: the
+        # served identity was adopted inside the probe, the budget just above.
+        lazy_discovery.done = True
 
     # Inbound parse + sampling/passthrough extraction (protocol-specific)
     if protocol == "anthropic":

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -6,7 +6,7 @@ import logging
 from copy import deepcopy
 from typing import Any, Literal
 
-from forge.clients.base import LLMClient, format_tool
+from forge.clients.base import LLMClient, format_tool, redact_auth_headers
 from forge.context.manager import ContextManager
 from forge.core.inference import _get_usage, prepare_backend_messages, run_inference
 from forge.core.reasoning import (
@@ -193,6 +193,13 @@ async def handle_chat_completions(
         target_protocol=backend_protocol,
         backend_api_key_present=backend_api_key_present,
     )
+    if extra_headers:
+        # Redacted: the header NAME (which slot carried the credential) with the
+        # value masked wholesale. Never log a raw secret, not even a prefix.
+        logger.debug(
+            "forwarding inbound credential to backend: %s",
+            redact_auth_headers(extra_headers),
+        )
 
     # Inbound parse + sampling/passthrough extraction (protocol-specific)
     if protocol == "anthropic":

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -17,6 +17,7 @@ from forge.core.reasoning import (
 from forge.core.workflow import ToolCall, ToolSpec, TextResponse
 from forge.errors import ToolCallError
 from forge.guardrails import ErrorTracker, ResponseValidator
+from forge.proxy.auth import resolve_inbound_credential
 from forge.proxy.convert import (
     openai_to_messages,
     tool_calls_to_openai,
@@ -131,6 +132,9 @@ async def handle_chat_completions(
     inject_respond_tool: bool = False,
     protocol: Literal["openai", "anthropic"] = "openai",
     reasoning_replay: ReasoningReplay = DEFAULT_REASONING_REPLAY,
+    headers: dict[str, str] | None = None,
+    backend_protocol: str = "openai",
+    backend_api_key_present: bool = False,
 ) -> dict[str, Any] | list[dict[str, Any]]:
     """Handle an inbound completions request.
 
@@ -161,6 +165,14 @@ async def handle_chat_completions(
             ``/v1/chat/completions``; ``anthropic`` for ``/v1/messages``.
         reasoning_replay: How much captured reasoning to replay to the
             backend and expose to clients.
+        headers: Inbound request headers (lowercased keys). The single auth
+            header among them is relocated to the backend's canonical slot and
+            forwarded; no other inbound header is forwarded.
+        backend_protocol: Wire protocol of the backend (relocation target):
+            ``openai`` or ``anthropic``.
+        backend_api_key_present: Whether a static ``--backend-api-key`` is
+            configured. When True, an inbound auth header is a second credential
+            and the request is refused.
 
     Returns:
         If stream=false: a single response dict (protocol-shaped).
@@ -169,6 +181,18 @@ async def handle_chat_completions(
     reasoning_replay = validate_reasoning_replay(reasoning_replay)
     is_stream = body.get("stream", False)
     model_name = body.get("model", "forge")
+
+    # Resolve the single credential forge forwards to the backend: relocate an
+    # inbound auth header into the backend's canonical slot, or None when the
+    # caller sent none (a static --backend-api-key, if configured, is already
+    # baked into the client). Raises MultipleCredentialsError on two sources
+    # (two inbound auth headers, or an inbound header + a static backend key).
+    extra_headers = resolve_inbound_credential(
+        headers,
+        source_protocol=protocol,
+        target_protocol=backend_protocol,
+        backend_api_key_present=backend_api_key_present,
+    )
 
     # Inbound parse + sampling/passthrough extraction (protocol-specific)
     if protocol == "anthropic":
@@ -248,6 +272,7 @@ async def handle_chat_completions(
         response = await client.send(
             api_messages, tools=None, sampling=sampling, passthrough=passthrough,
             inbound_anthropic_body=inbound_anthropic_body,
+            extra_headers=extra_headers,
         )
         usage = _get_usage(client)
         text = response.content if isinstance(response, TextResponse) else ""
@@ -271,6 +296,7 @@ async def handle_chat_completions(
             inbound_anthropic_body=inbound_anthropic_body,
             raw_openai_messages=raw_messages_for_backend,
             raw_openai_tools=raw_tools_for_backend,
+            extra_headers=extra_headers,
             reasoning_replay=reasoning_replay,
         )
     except ToolCallError as exc:

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -232,6 +232,20 @@ async def handle_chat_completions(
     # (extra_headers) authenticates it. Placed before BOTH dispatch paths: a
     # vLLM request needs its discovered served identity on every call (not just
     # the compacting tool path), so this can't live inside the tools branch.
+    #
+    # Concurrency & a load-bearing assumption (external mode is unserialized, so
+    # two first requests can race here):
+    #   - No lock by design. The probe is idempotent and the commit below is a
+    #     single await-free block (set client identity, set budget, set done) —
+    #     asyncio runs it without interleaving, so a concurrent second probe at
+    #     worst overwrites with identical values. There is no torn state.
+    #   - This assumes the backend's metadata (served model name, context length)
+    #     is the SAME regardless of which credential probes it — i.e. one backend
+    #     URL serves one model. That holds for a single llama.cpp/vLLM server. It
+    #     does NOT hold for a multi-tenant gateway that routes to different models
+    #     per API key behind one URL; there, a single shared client identity is
+    #     the wrong model. That topology is out of scope for the proxy (one
+    #     backend, one identity); a per-credential client would be required.
     if lazy_discovery is not None and lazy_discovery.deferred and not lazy_discovery.done:
         try:
             budget = await client.discover_backend_metadata(extra_headers=extra_headers)

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -80,6 +80,56 @@ class LazyDiscovery:
     done: bool = False
 
 
+async def run_lazy_discovery(
+    client: LLMClient,
+    context_manager: ContextManager,
+    lazy_discovery: LazyDiscovery | None,
+    extra_headers: dict[str, str] | None,
+) -> None:
+    """Run deferred external-mode backend discovery once, if pending.
+
+    No-op when discovery isn't deferred or has already latched. Probes the
+    backend with the per-request credential, adopts any backend-owned identity
+    (vLLM served-model-name) into the client, applies the discovered budget to
+    the context manager (when ``apply_budget``), and latches ``done`` — on
+    SUCCESS only, so a failed probe retries on the next request. Raises
+    ``BackendDiscoveryError`` on failure (auth rejection vs fault distinguished
+    by ``status_code``).
+
+    Called before BOTH dispatch paths (a vLLM request needs its served identity
+    on every call, not just the compacting tool path), and optionally by the
+    proxy before flushing a streaming response's headers so a failure can be a
+    real HTTP status instead of an SSE error event.
+
+    Concurrency & a load-bearing assumption (external mode is unserialized, so
+    two first requests can race here):
+      - No lock by design. The probe is idempotent and the commit below is a
+        single await-free block (set client identity, set budget, set done) —
+        asyncio runs it without interleaving, so a concurrent second probe at
+        worst overwrites with identical values. There is no torn state.
+      - This assumes the backend's metadata (served model name, context length)
+        is the SAME regardless of which credential probes it — i.e. one backend
+        URL serves one model. That holds for a single llama.cpp/vLLM server. It
+        does NOT hold for a multi-tenant gateway that routes to different models
+        per API key behind one URL; there, a single shared client identity is
+        the wrong model. That topology is out of scope for the proxy (one
+        backend, one identity); a per-credential client would be required.
+    """
+    if lazy_discovery is None or not lazy_discovery.deferred or lazy_discovery.done:
+        return
+    try:
+        budget = await client.discover_backend_metadata(extra_headers=extra_headers)
+    except BackendError as exc:
+        # Auth rejection (401/403) vs backend/connectivity fault carried via
+        # status_code; the server maps it to the right client status.
+        raise BackendDiscoveryError(status_code=exc.status_code) from exc
+    if lazy_discovery.apply_budget:
+        if budget is None:
+            raise BackendDiscoveryError(status_code=None)
+        context_manager.budget_tokens = budget
+    lazy_discovery.done = True
+
+
 def _extract_sampling(body: dict[str, Any]) -> dict[str, Any] | None:
     """Pull recognized sampling fields out of the inbound request body.
 
@@ -226,41 +276,12 @@ async def handle_chat_completions(
             redact_auth_headers(extra_headers),
         )
 
-    # Deferred external-mode backend discovery (finding #2). In external
-    # passthrough mode the startup backend probe is unauthenticated, so it's
-    # deferred to here — the first request — where the inbound credential
-    # (extra_headers) authenticates it. Placed before BOTH dispatch paths: a
-    # vLLM request needs its discovered served identity on every call (not just
-    # the compacting tool path), so this can't live inside the tools branch.
-    #
-    # Concurrency & a load-bearing assumption (external mode is unserialized, so
-    # two first requests can race here):
-    #   - No lock by design. The probe is idempotent and the commit below is a
-    #     single await-free block (set client identity, set budget, set done) —
-    #     asyncio runs it without interleaving, so a concurrent second probe at
-    #     worst overwrites with identical values. There is no torn state.
-    #   - This assumes the backend's metadata (served model name, context length)
-    #     is the SAME regardless of which credential probes it — i.e. one backend
-    #     URL serves one model. That holds for a single llama.cpp/vLLM server. It
-    #     does NOT hold for a multi-tenant gateway that routes to different models
-    #     per API key behind one URL; there, a single shared client identity is
-    #     the wrong model. That topology is out of scope for the proxy (one
-    #     backend, one identity); a per-credential client would be required.
-    if lazy_discovery is not None and lazy_discovery.deferred and not lazy_discovery.done:
-        try:
-            budget = await client.discover_backend_metadata(extra_headers=extra_headers)
-        except BackendError as exc:
-            # Auth rejection (401/403) vs backend/connectivity fault carried via
-            # status_code; the server maps it to the right client status.
-            raise BackendDiscoveryError(status_code=exc.status_code) from exc
-        if lazy_discovery.apply_budget:
-            if budget is None:
-                raise BackendDiscoveryError(status_code=None)
-            context_manager.budget_tokens = budget
-        # Commit + latch synchronously (no await between the probe's return and
-        # here) so concurrent first requests can't observe a torn state: the
-        # served identity was adopted inside the probe, the budget just above.
-        lazy_discovery.done = True
+    # Deferred external-mode backend discovery (finding #2): runs once on the
+    # first request, before BOTH dispatch paths. The proxy may also run this
+    # earlier (before flushing a streaming response's headers) so a discovery
+    # failure surfaces as a real HTTP status; in that case this is a no-op
+    # (already latched).
+    await run_lazy_discovery(client, context_manager, lazy_discovery, extra_headers)
 
     # Inbound parse + sampling/passthrough extraction (protocol-specific)
     if protocol == "anthropic":

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -74,6 +74,7 @@ class ProxyServer:
         backend_protocol: Literal["openai", "anthropic"] = "openai",
         backend_timeout: float = 300.0,
         reasoning_replay: ReasoningReplay = DEFAULT_REASONING_REPLAY,
+        backend_api_key: str | None = None,
     ) -> None:
         """
         Args:
@@ -122,6 +123,12 @@ class ProxyServer:
                 the downstream backend.
             reasoning_replay: How much captured reasoning to replay to the
                 backend on later turns: ``full``, ``keep-last``, or ``none``.
+            backend_api_key: Static credential forge sends to the backend in
+                its native auth header (LM Studio / hosted providers / service
+                accounts). Baked into the backend client at construction. When
+                set, an inbound auth header is a second credential and the
+                request is refused (one credential per request). Leave None for
+                pure inbound-credential passthrough.
         """
         if backend_url is None and backend is None:
             raise ValueError("Provide either backend_url (external) or backend (managed)")
@@ -182,6 +189,7 @@ class ProxyServer:
         self._backend_protocol = backend_protocol
         self._backend_timeout = backend_timeout
         self._reasoning_replay = validate_reasoning_replay(reasoning_replay)
+        self._backend_api_key = backend_api_key
 
         # Auto-detect serialization: managed (no external url) = single local
         # GPU = serialize. External callers manage their own concurrency.
@@ -268,6 +276,8 @@ class ProxyServer:
             native_passthrough=self._backend_capability == "native",
             inject_respond_tool=self._inject_respond_tool,
             reasoning_replay=self._reasoning_replay,
+            backend_protocol=self._backend_protocol,
+            backend_api_key_present=bool(self._backend_api_key),
         )
         await self._http_server.start()
         self._started = True
@@ -297,6 +307,9 @@ class ProxyServer:
                 model=self._model or "claude",
                 base_url=self._backend_url.rstrip("/"),
                 timeout=self._backend_timeout,
+                # Explicit key (or "" for pure passthrough) so an ambient
+                # ANTHROPIC_* env var can't become a silent second credential.
+                api_key=self._backend_api_key or "",
             )
             # Anthropic models report a known context length; keep the legacy
             # 8192 fallback rather than failing the well-behaved Path-1 case.
@@ -317,6 +330,7 @@ class ProxyServer:
                 model_path="default",
                 base_url=base,
                 timeout=self._backend_timeout,
+                api_key=self._backend_api_key or "",
             )
             # Unlike llama.cpp, vLLM validates the wire `model` field against
             # its --served-model-name aliases (404 on mismatch). External mode
@@ -343,6 +357,7 @@ class ProxyServer:
                 base_url=base,
                 mode=self._backend_capability,
                 timeout=self._backend_timeout,
+                api_key=self._backend_api_key or "",
             )
 
         if self._budget_tokens is not None:
@@ -397,6 +412,7 @@ class ProxyServer:
             return OllamaClient(
                 model=self._model,
                 timeout=self._backend_timeout,
+                api_key=self._backend_api_key or "",
             )
         if self._backend in ("llamaserver", "llamafile"):
             return LlamafileClient(
@@ -404,6 +420,7 @@ class ProxyServer:
                 base_url=base_url,
                 mode=self._backend_capability,
                 timeout=self._backend_timeout,
+                api_key=self._backend_api_key or "",
             )
         if self._backend == "vllm":
             assert self._model_path is not None
@@ -411,6 +428,7 @@ class ProxyServer:
                 model_path=self._model_path,
                 base_url=base_url,
                 timeout=self._backend_timeout,
+                api_key=self._backend_api_key or "",
             )
         raise ValueError(f"unsupported backend: {self._backend!r}")
 

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -21,8 +21,16 @@ from forge.clients.vllm import VLLMClient
 from forge.context.manager import ContextManager
 from forge.context.strategies import TieredCompact
 from forge.core.reasoning import DEFAULT_REASONING_REPLAY, ReasoningReplay, validate_reasoning_replay
+from forge.proxy.handler import LazyDiscovery
 from forge.proxy.server import HTTPServer
 from forge.server import BudgetMode, ServerManager, setup_backend
+
+# Placeholder budget for a context manager whose real budget is discovered
+# lazily on the first request (external passthrough). It is never read before
+# discovery overwrites it — the discovery hook runs before any compaction —
+# but it's set large so an accidental early read degrades safe (no compaction)
+# rather than over-compacting on a tiny budget.
+_DEFERRED_BUDGET_PLACEHOLDER = 1_000_000
 
 logger = logging.getLogger("forge.proxy")
 
@@ -259,9 +267,9 @@ class ProxyServer:
     async def _async_start(self, ready: threading.Event) -> None:
         """Async startup: backend + HTTP server."""
         if self._backend_url is not None:
-            client, context_manager = await self._setup_external()
+            client, context_manager, lazy_discovery = await self._setup_external()
         else:
-            client, context_manager = await self._setup_managed()
+            client, context_manager, lazy_discovery = await self._setup_managed()
 
         self._client = client
         self._http_server = HTTPServer(
@@ -278,13 +286,21 @@ class ProxyServer:
             reasoning_replay=self._reasoning_replay,
             backend_protocol=self._backend_protocol,
             backend_api_key_present=bool(self._backend_api_key),
+            lazy_discovery=lazy_discovery,
         )
         await self._http_server.start()
         self._started = True
         ready.set()
 
-    async def _setup_external(self) -> tuple[LLMClient, ContextManager]:
-        """External mode: connect to a caller-managed backend."""
+    async def _setup_external(
+        self,
+    ) -> tuple[LLMClient, ContextManager, LazyDiscovery | None]:
+        """External mode: connect to a caller-managed backend.
+
+        Returns the client, its context manager, and an optional LazyDiscovery
+        latch — non-None only when backend discovery is deferred to the first
+        request (external passthrough; see Path 2 below).
+        """
         assert self._backend_url is not None
 
         if self._backend_protocol == "anthropic":
@@ -318,7 +334,9 @@ class ProxyServer:
                 strategy=TieredCompact(),
                 budget_tokens=budget,
             )
-            return client, context_manager
+            # Anthropic reports a static context length with no network call, so
+            # there's nothing to defer.
+            return client, context_manager, None
 
         # Path 2 / default — OpenAI-shape downstream (llama.cpp or vLLM).
         base = self._backend_url.rstrip("/")
@@ -332,21 +350,6 @@ class ProxyServer:
                 timeout=self._backend_timeout,
                 api_key=self._backend_api_key or "",
             )
-            # Unlike llama.cpp, vLLM validates the wire `model` field against
-            # its --served-model-name aliases (404 on mismatch). External mode
-            # has no model path to send, so discover the served identity from
-            # /v1/models instead of shipping the "default" placeholder.
-            served = await client.get_served_model_name()
-            if served:
-                logger.info("Discovered vLLM served model name: %s", served)
-                client._set_model_identity(served)
-            else:
-                logger.warning(
-                    "Could not discover a served model name from %s/models; "
-                    "sending placeholder 'default' (vLLM will 404 if it "
-                    "validates the model field)",
-                    base,
-                )
         else:
             # llamaserver / llamafile / unspecified — OpenAI-compatible adapter.
             # Caller manages the backend, so we don't have a GGUF path. "default"
@@ -360,24 +363,66 @@ class ProxyServer:
                 api_key=self._backend_api_key or "",
             )
 
-        if self._budget_tokens is not None:
-            budget = self._budget_tokens
+        # Decide eager vs deferred discovery. A static --backend-api-key
+        # authenticates the startup probe, so discover now and keep boot-time
+        # fail-fast. Pure passthrough (no static key) can't probe at startup —
+        # the probe would be unauthenticated against a gated backend (finding
+        # #2) — so defer it to the first request, which carries the credential.
+        # vLLM always needs deferral when passthrough (its served-identity probe
+        # is unauthenticated too); llama.cpp only needs it to discover a budget.
+        static_key = bool(self._backend_api_key)
+        defer = (not static_key) and (
+            self._budget_tokens is None or self._backend == "vllm"
+        )
+
+        if defer:
+            apply_budget = self._budget_tokens is None
+            budget = (
+                _DEFERRED_BUDGET_PLACEHOLDER
+                if apply_budget
+                else self._budget_tokens
+            )
+            lazy_discovery: LazyDiscovery | None = LazyDiscovery(
+                deferred=True, apply_budget=apply_budget,
+            )
         else:
-            ctx_len = await client.get_context_length()
-            if ctx_len is None:
-                raise RuntimeError(
-                    f"backend at {self._backend_url} did not report a context "
-                    "length; pass budget_tokens explicitly"
-                )
-            budget = ctx_len
+            lazy_discovery = None
+            if self._backend == "vllm":
+                # Unlike llama.cpp, vLLM validates the wire `model` field against
+                # its --served-model-name aliases (404 on mismatch). External
+                # mode has no model path to send, so discover the served identity
+                # from /v1/models instead of shipping the "default" placeholder.
+                served = await client.get_served_model_name()
+                if served:
+                    logger.info("Discovered vLLM served model name: %s", served)
+                    client._set_model_identity(served)
+                else:
+                    logger.warning(
+                        "Could not discover a served model name from %s/models; "
+                        "sending placeholder 'default' (vLLM will 404 if it "
+                        "validates the model field)",
+                        base,
+                    )
+            if self._budget_tokens is not None:
+                budget = self._budget_tokens
+            else:
+                ctx_len = await client.get_context_length()
+                if ctx_len is None:
+                    raise RuntimeError(
+                        f"backend at {self._backend_url} did not report a context "
+                        "length; pass budget_tokens explicitly"
+                    )
+                budget = ctx_len
 
         context_manager = ContextManager(
             strategy=TieredCompact(),
             budget_tokens=budget,
         )
-        return client, context_manager
+        return client, context_manager, lazy_discovery
 
-    async def _setup_managed(self) -> tuple[LLMClient, ContextManager]:
+    async def _setup_managed(
+        self,
+    ) -> tuple[LLMClient, ContextManager, LazyDiscovery | None]:
         """Managed mode: forge starts the backend via setup_backend."""
         assert self._backend is not None
         client = self._build_managed_client()
@@ -402,7 +447,9 @@ class ProxyServer:
             extra_flags=self._extra_flags,
         )
         self._server_manager = server
-        return client, context_manager
+        # Managed mode probes its own ungated local backend at startup — never
+        # deferred.
+        return client, context_manager, None
 
     def _build_managed_client(self) -> LLMClient:
         """Construct the right client for the managed backend."""

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -197,7 +197,12 @@ class ProxyServer:
         self._backend_protocol = backend_protocol
         self._backend_timeout = backend_timeout
         self._reasoning_replay = validate_reasoning_replay(reasoning_replay)
-        self._backend_api_key = backend_api_key
+        # A blank/whitespace --backend-api-key is not a credential: normalize it
+        # to None so it neither rides the wire as garbage nor disables lazy
+        # discovery (which keys off "is a static key present").
+        self._backend_api_key = (
+            backend_api_key if (backend_api_key and backend_api_key.strip()) else None
+        )
 
         # Auto-detect serialization: managed (no external url) = single local
         # GPU = serialize. External callers manage their own concurrency.

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -16,7 +16,7 @@ from typing import Any
 from forge.clients.base import AUTH_HEADER_NAMES, LLMClient
 from forge.context.manager import ContextManager
 from forge.core.reasoning import DEFAULT_REASONING_REPLAY, ReasoningReplay, validate_reasoning_replay
-from forge.errors import MultipleCredentialsError
+from forge.errors import MissingCredentialError, MultipleCredentialsError
 from forge.proxy.auth import DUPLICATE_AUTH_MARKER
 from forge.proxy.handler import handle_chat_completions
 
@@ -295,11 +295,16 @@ class HTTPServer:
         if isinstance(result, Exception):
             error_msg = str(result)
             logger.info("<< ERROR: %s", error_msg[:120])
-            # A credential conflict is a client error (the caller sent two
-            # credentials, or one that collides with --backend-api-key), not a
-            # backend failure. The error message carries only slot names, never
-            # a secret value.
-            status = 400 if isinstance(result, MultipleCredentialsError) else 502
+            # Credential problems are client errors (the caller sent two
+            # credentials / one colliding with --backend-api-key → 400, or none
+            # at all to an auth-required backend → 401), not backend failures.
+            # These messages carry only slot names, never a secret value.
+            if isinstance(result, MultipleCredentialsError):
+                status = 400
+            elif isinstance(result, MissingCredentialError):
+                status = 401
+            else:
+                status = 502
             if is_stream:
                 await self._send_sse_body(writer, [{"error": error_msg}], protocol=protocol)
             else:
@@ -454,6 +459,7 @@ def _status_text(code: int) -> str:
         200: "OK",
         204: "No Content",
         400: "Bad Request",
+        401: "Unauthorized",
         404: "Not Found",
         413: "Payload Too Large",
         500: "Internal Server Error",

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -23,8 +23,12 @@ from forge.errors import (
     MissingCredentialError,
     MultipleCredentialsError,
 )
-from forge.proxy.auth import DUPLICATE_AUTH_MARKER
-from forge.proxy.handler import LazyDiscovery, handle_chat_completions
+from forge.proxy.auth import DUPLICATE_AUTH_MARKER, resolve_inbound_credential
+from forge.proxy.handler import (
+    LazyDiscovery,
+    handle_chat_completions,
+    run_lazy_discovery,
+)
 
 logger = logging.getLogger("forge.proxy")
 
@@ -274,6 +278,23 @@ class HTTPServer:
             protocol, is_stream, msg_count, tool_count, body.get("model", "?"),
         )
 
+        # Streaming responses flush a 200 + SSE header before the handler runs
+        # (so a queued client knows the connection is alive). Run the checks that
+        # must be able to fail with a real HTTP status — credential resolution
+        # and the first-request discovery probe — BEFORE that flush, so a bad/
+        # missing/duplicate credential returns 400/401 rather than 200 + an SSE
+        # error event. On success they latch, so the handler skips re-running
+        # discovery; its credential resolution is pure and repeats harmlessly.
+        # Non-streaming needs no pre-check — it never flushes early, so its
+        # errors already carry a real status.
+        if is_stream:
+            predispatch_error = await self._predispatch(protocol, headers)
+            if predispatch_error is not None:
+                await self._send_exception(
+                    writer, predispatch_error, protocol, as_stream=False,
+                )
+                return
+
         if self._serialize:
             # Queue the request and wait for the worker to process it
             item = _QueueItem(body=body, protocol=protocol, headers=headers)
@@ -301,36 +322,7 @@ class HTTPServer:
             return
 
         if isinstance(result, Exception):
-            # Scrub before logging OR returning: a backend error body (or a
-            # traceback containing one) may have echoed an inbound auth header.
-            # forge never authors a secret into a message, but it does not
-            # control what a backend reflects back.
-            error_msg = redact_secrets(str(result))
-            logger.info("<< ERROR: %s", error_msg[:120])
-            # Credential problems are client errors (the caller sent two
-            # credentials / one colliding with --backend-api-key → 400, or none
-            # at all to an auth-required backend → 401), not backend failures.
-            # These messages carry only slot names, never a secret value.
-            if isinstance(result, MultipleCredentialsError):
-                status = 400
-            elif isinstance(result, MissingCredentialError):
-                status = 401
-            elif isinstance(result, BackendDiscoveryError):
-                # Deferred first-request discovery failed: a backend auth
-                # rejection is the caller's 401; any other cause (backend down,
-                # bad shape) is a 502.
-                status = 401 if result.status_code in (401, 403) else 502
-            elif isinstance(result, BackendError) and result.status_code in (401, 403):
-                # A backend auth rejection during normal dispatch (e.g. a later
-                # zero-credential request to a gated backend, or a bad inbound
-                # key) is the caller's 401, not a forge/backend fault.
-                status = 401
-            else:
-                status = 502
-            if is_stream:
-                await self._send_sse_body(writer, [{"error": error_msg}], protocol=protocol)
-            else:
-                await self._send_error(writer, status, error_msg)
+            await self._send_exception(writer, result, protocol, as_stream=is_stream)
             return
 
         if is_stream:
@@ -339,6 +331,72 @@ class HTTPServer:
         else:
             logger.info("<< JSON 200")
             await self._send_json(writer, 200, json.dumps(result))
+
+    async def _predispatch(
+        self, protocol: str, headers: dict[str, str],
+    ) -> Exception | None:
+        """Pre-flush validation for a streaming request.
+
+        Resolves the inbound credential and runs first-request backend discovery
+        — the checks that must be able to fail with a real HTTP status — and
+        returns the Exception to surface, or None to proceed. Idempotent: the
+        handler re-resolves the (pure) credential and sees discovery latched, so
+        running this first changes nothing on the success path.
+        """
+        try:
+            extra_headers = resolve_inbound_credential(
+                headers,
+                source_protocol=protocol,
+                target_protocol=self._backend_protocol,
+                backend_api_key_present=self._backend_api_key_present,
+            )
+            await run_lazy_discovery(
+                self._client, self._context_manager, self._lazy_discovery, extra_headers,
+            )
+            return None
+        except Exception as exc:
+            return exc
+
+    async def _send_exception(
+        self,
+        writer: asyncio.StreamWriter,
+        exc: Exception,
+        protocol: str,
+        as_stream: bool,
+    ) -> None:
+        """Send an exception as the response.
+
+        ``as_stream`` True → an SSE error event (the 200 + SSE header was already
+        flushed, e.g. a backend fault mid-generation); False → a real HTTP error
+        status. The message is scrubbed of credential-looking substrings before
+        it is logged or sent: a backend error body (or a traceback containing
+        one) may have echoed an inbound auth header — forge never authors a
+        secret into a message, but it doesn't control what a backend reflects.
+        """
+        error_msg = redact_secrets(str(exc))
+        logger.info("<< ERROR: %s", error_msg[:120])
+        # Credential problems are client errors (two credentials / one colliding
+        # with --backend-api-key → 400, or none to an auth-required backend →
+        # 401), not backend failures. These messages carry only slot names.
+        if isinstance(exc, MultipleCredentialsError):
+            status = 400
+        elif isinstance(exc, MissingCredentialError):
+            status = 401
+        elif isinstance(exc, BackendDiscoveryError):
+            # Deferred discovery failed: a backend auth rejection is the caller's
+            # 401; any other cause (backend down, bad shape) is a 502.
+            status = 401 if exc.status_code in (401, 403) else 502
+        elif isinstance(exc, BackendError) and exc.status_code in (401, 403):
+            # A backend auth rejection during normal dispatch (a later zero-cred
+            # request to a gated backend, or a bad inbound key) is the caller's
+            # 401, not a forge/backend fault.
+            status = 401
+        else:
+            status = 502
+        if as_stream:
+            await self._send_sse_body(writer, [{"error": error_msg}], protocol=protocol)
+        else:
+            await self._send_error(writer, status, error_msg)
 
     async def _await_with_disconnect(
         self,

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -16,9 +16,13 @@ from typing import Any
 from forge.clients.base import AUTH_HEADER_NAMES, LLMClient
 from forge.context.manager import ContextManager
 from forge.core.reasoning import DEFAULT_REASONING_REPLAY, ReasoningReplay, validate_reasoning_replay
-from forge.errors import MissingCredentialError, MultipleCredentialsError
+from forge.errors import (
+    BackendDiscoveryError,
+    MissingCredentialError,
+    MultipleCredentialsError,
+)
 from forge.proxy.auth import DUPLICATE_AUTH_MARKER
-from forge.proxy.handler import handle_chat_completions
+from forge.proxy.handler import LazyDiscovery, handle_chat_completions
 
 logger = logging.getLogger("forge.proxy")
 
@@ -61,9 +65,11 @@ class HTTPServer:
         reasoning_replay: ReasoningReplay = DEFAULT_REASONING_REPLAY,
         backend_protocol: str = "openai",
         backend_api_key_present: bool = False,
+        lazy_discovery: LazyDiscovery | None = None,
     ) -> None:
         self._client = client
         self._context_manager = context_manager
+        self._lazy_discovery = lazy_discovery
         self._host = host
         self._port = port
         self._max_retries = max_retries
@@ -303,6 +309,11 @@ class HTTPServer:
                 status = 400
             elif isinstance(result, MissingCredentialError):
                 status = 401
+            elif isinstance(result, BackendDiscoveryError):
+                # Deferred first-request discovery failed: a backend auth
+                # rejection is the caller's 401; any other cause (backend down,
+                # bad shape) is a 502.
+                status = 401 if result.status_code in (401, 403) else 502
             else:
                 status = 502
             if is_stream:
@@ -362,6 +373,7 @@ class HTTPServer:
                 headers=headers,
                 backend_protocol=self._backend_protocol,
                 backend_api_key_present=self._backend_api_key_present,
+                lazy_discovery=self._lazy_discovery,
             )
         except Exception as exc:
             logger.exception("Handler error")

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -10,11 +10,10 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import traceback
 from dataclasses import dataclass, field
 from typing import Any
 
-from forge.clients.base import AUTH_HEADER_NAMES, LLMClient, redact_secrets
+from forge.clients.base import AUTH_HEADER_NAMES, LLMClient
 from forge.context.manager import ContextManager
 from forge.core.reasoning import DEFAULT_REASONING_REPLAY, ReasoningReplay, validate_reasoning_replay
 from forge.errors import (
@@ -368,12 +367,11 @@ class HTTPServer:
 
         ``as_stream`` True → an SSE error event (the 200 + SSE header was already
         flushed, e.g. a backend fault mid-generation); False → a real HTTP error
-        status. The message is scrubbed of credential-looking substrings before
-        it is logged or sent: a backend error body (or a traceback containing
-        one) may have echoed an inbound auth header — forge never authors a
-        secret into a message, but it doesn't control what a backend reflects.
+        status. Exception messages are safe to log/return by construction —
+        forge never authors a secret into one, and ``BackendError`` keeps the raw
+        backend body off its message (on ``exc.body`` instead).
         """
-        error_msg = redact_secrets(str(exc))
+        error_msg = str(exc)
         logger.info("<< ERROR: %s", error_msg[:120])
         # Credential problems are client errors (two credentials / one colliding
         # with --backend-api-key → 400, or none to an auth-required backend →
@@ -445,10 +443,7 @@ class HTTPServer:
                 lazy_discovery=self._lazy_discovery,
             )
         except Exception as exc:
-            # Redact the traceback before logging: a chained BackendError can
-            # carry a backend body that echoed an inbound auth header. Keep the
-            # full stack (debuggability) but scrub credential-looking substrings.
-            logger.error("Handler error:\n%s", redact_secrets(traceback.format_exc()))
+            logger.exception("Handler error")
             return exc
 
     async def _send_json(

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -13,9 +13,11 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-from forge.clients.base import LLMClient
+from forge.clients.base import AUTH_HEADER_NAMES, LLMClient
 from forge.context.manager import ContextManager
 from forge.core.reasoning import DEFAULT_REASONING_REPLAY, ReasoningReplay, validate_reasoning_replay
+from forge.errors import MultipleCredentialsError
+from forge.proxy.auth import DUPLICATE_AUTH_MARKER
 from forge.proxy.handler import handle_chat_completions
 
 logger = logging.getLogger("forge.proxy")
@@ -30,6 +32,9 @@ class _QueueItem:
 
     body: dict[str, Any]
     protocol: str = "openai"
+    # Per-request inbound headers (lowercased). Carries the inbound credential
+    # the handler relocates to the backend. Per-item, never shared.
+    headers: dict[str, str] = field(default_factory=dict)
     future: asyncio.Future = field(default=None)  # type: ignore[assignment]
     cancelled: bool = False
 
@@ -54,6 +59,8 @@ class HTTPServer:
         native_passthrough: bool = True,
         inject_respond_tool: bool = False,
         reasoning_replay: ReasoningReplay = DEFAULT_REASONING_REPLAY,
+        backend_protocol: str = "openai",
+        backend_api_key_present: bool = False,
     ) -> None:
         self._client = client
         self._context_manager = context_manager
@@ -65,6 +72,13 @@ class HTTPServer:
         self._native_passthrough = native_passthrough
         self._inject_respond_tool = inject_respond_tool
         self._reasoning_replay = validate_reasoning_replay(reasoning_replay)
+        # Target wire protocol of the backend (relocation target) and whether a
+        # static --backend-api-key is configured (for the two-source check).
+        # The raw key itself never reaches the handler — it is baked into the
+        # backend client at construction; the handler only needs to know it
+        # exists to refuse an inbound credential alongside it.
+        self._backend_protocol = backend_protocol
+        self._backend_api_key_present = backend_api_key_present
         self._server: asyncio.Server | None = None
         self._serialize = serialize_requests
         self._queue: asyncio.Queue[_QueueItem] = asyncio.Queue()
@@ -104,7 +118,7 @@ class HTTPServer:
                 if item.cancelled or item.future.cancelled():
                     logger.info("   Skipping cancelled request")
                     continue
-                result = await self._run_handler(item.body, item.protocol)
+                result = await self._run_handler(item.body, item.protocol, item.headers)
                 if not item.future.done():
                     item.future.set_result(result)
             except asyncio.CancelledError:
@@ -166,9 +180,13 @@ class HTTPServer:
             elif method == "GET" and path == "/v1/models":
                 await self._handle_models(writer)
             elif method == "POST" and path == "/v1/chat/completions":
-                await self._handle_completions(writer, body_bytes, protocol="openai")
+                await self._handle_completions(
+                    writer, body_bytes, protocol="openai", headers=headers,
+                )
             elif method == "POST" and path == "/v1/messages":
-                await self._handle_completions(writer, body_bytes, protocol="anthropic")
+                await self._handle_completions(
+                    writer, body_bytes, protocol="anthropic", headers=headers,
+                )
             elif method == "OPTIONS":
                 await self._send_cors_preflight(writer)
             else:
@@ -199,7 +217,13 @@ class HTTPServer:
                 break
             if ":" in decoded:
                 key, value = decoded.split(":", 1)
-                headers[key.strip().lower()] = value.strip()
+                key = key.strip().lower()
+                # A repeated auth header name would collapse to last-wins in a
+                # plain dict — forge must never silently pick a credential
+                # winner, so flag it for the credential resolver to refuse.
+                if key in AUTH_HEADER_NAMES and key in headers:
+                    headers[DUPLICATE_AUTH_MARKER] = "1"
+                headers[key] = value.strip()
         return headers
 
     async def _handle_health(self, writer: asyncio.StreamWriter) -> None:
@@ -220,8 +244,10 @@ class HTTPServer:
         writer: asyncio.StreamWriter,
         body_bytes: bytes,
         protocol: str = "openai",
+        headers: dict[str, str] | None = None,
     ) -> None:
         """POST /v1/chat/completions (or /v1/messages) — the main proxy endpoint."""
+        headers = headers or {}
         try:
             body = json.loads(body_bytes)
         except json.JSONDecodeError:
@@ -242,7 +268,7 @@ class HTTPServer:
 
         if self._serialize:
             # Queue the request and wait for the worker to process it
-            item = _QueueItem(body=body, protocol=protocol)
+            item = _QueueItem(body=body, protocol=protocol, headers=headers)
             queue_depth = self._queue.qsize()
             if queue_depth > 0:
                 logger.info("   Queued (depth=%d)", queue_depth + 1)
@@ -259,7 +285,7 @@ class HTTPServer:
         else:
             if is_stream:
                 await self._send_sse_header(writer)
-            result = await self._run_handler(body, protocol)
+            result = await self._run_handler(body, protocol, headers)
 
         if result is None:
             # Client disconnected
@@ -269,10 +295,15 @@ class HTTPServer:
         if isinstance(result, Exception):
             error_msg = str(result)
             logger.info("<< ERROR: %s", error_msg[:120])
+            # A credential conflict is a client error (the caller sent two
+            # credentials, or one that collides with --backend-api-key), not a
+            # backend failure. The error message carries only slot names, never
+            # a secret value.
+            status = 400 if isinstance(result, MultipleCredentialsError) else 502
             if is_stream:
                 await self._send_sse_body(writer, [{"error": error_msg}], protocol=protocol)
             else:
-                await self._send_error(writer, 502, error_msg)
+                await self._send_error(writer, status, error_msg)
             return
 
         if is_stream:
@@ -305,7 +336,10 @@ class HTTPServer:
         return item.future.result()
 
     async def _run_handler(
-        self, body: dict[str, Any], protocol: str = "openai",
+        self,
+        body: dict[str, Any],
+        protocol: str = "openai",
+        headers: dict[str, str] | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]] | Exception:
         """Run the handler, catching errors."""
         try:
@@ -320,6 +354,9 @@ class HTTPServer:
                 inject_respond_tool=self._inject_respond_tool,
                 protocol=protocol,
                 reasoning_replay=self._reasoning_replay,
+                headers=headers,
+                backend_protocol=self._backend_protocol,
+                backend_api_key_present=self._backend_api_key_present,
             )
         except Exception as exc:
             logger.exception("Handler error")

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -10,14 +10,16 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import traceback
 from dataclasses import dataclass, field
 from typing import Any
 
-from forge.clients.base import AUTH_HEADER_NAMES, LLMClient
+from forge.clients.base import AUTH_HEADER_NAMES, LLMClient, redact_secrets
 from forge.context.manager import ContextManager
 from forge.core.reasoning import DEFAULT_REASONING_REPLAY, ReasoningReplay, validate_reasoning_replay
 from forge.errors import (
     BackendDiscoveryError,
+    BackendError,
     MissingCredentialError,
     MultipleCredentialsError,
 )
@@ -299,7 +301,11 @@ class HTTPServer:
             return
 
         if isinstance(result, Exception):
-            error_msg = str(result)
+            # Scrub before logging OR returning: a backend error body (or a
+            # traceback containing one) may have echoed an inbound auth header.
+            # forge never authors a secret into a message, but it does not
+            # control what a backend reflects back.
+            error_msg = redact_secrets(str(result))
             logger.info("<< ERROR: %s", error_msg[:120])
             # Credential problems are client errors (the caller sent two
             # credentials / one colliding with --backend-api-key → 400, or none
@@ -314,6 +320,11 @@ class HTTPServer:
                 # rejection is the caller's 401; any other cause (backend down,
                 # bad shape) is a 502.
                 status = 401 if result.status_code in (401, 403) else 502
+            elif isinstance(result, BackendError) and result.status_code in (401, 403):
+                # A backend auth rejection during normal dispatch (e.g. a later
+                # zero-credential request to a gated backend, or a bad inbound
+                # key) is the caller's 401, not a forge/backend fault.
+                status = 401
             else:
                 status = 502
             if is_stream:
@@ -376,7 +387,10 @@ class HTTPServer:
                 lazy_discovery=self._lazy_discovery,
             )
         except Exception as exc:
-            logger.exception("Handler error")
+            # Redact the traceback before logging: a chained BackendError can
+            # carry a backend body that echoed an inbound auth header. Keep the
+            # full stack (debuggability) but scrub credential-looking substrings.
+            logger.error("Handler error:\n%s", redact_secrets(traceback.format_exc()))
             return exc
 
     async def _send_json(
@@ -457,7 +471,11 @@ class HTTPServer:
             "HTTP/1.1 204 No Content\r\n"
             "Access-Control-Allow-Origin: *\r\n"
             "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
-            "Access-Control-Allow-Headers: Content-Type, Authorization\r\n"
+            # x-api-key is a first-class inbound credential slot (Anthropic-wire);
+            # browser clients must be allowed to preflight it. anthropic-version /
+            # anthropic-beta are standard Anthropic client headers.
+            "Access-Control-Allow-Headers: Content-Type, Authorization, X-Api-Key, "
+            "anthropic-version, anthropic-beta\r\n"
             "Connection: close\r\n"
             "\r\n"
         )

--- a/src/forge/server.py
+++ b/src/forge/server.py
@@ -295,7 +295,7 @@ class ServerManager:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(url)
             if resp.status_code != 200:
-                raise BackendError(resp.status_code, resp.text)
+                raise BackendError(resp.status_code, raw_body=resp.text)
             return resp.json()
 
     async def get_server_context(self) -> int:
@@ -317,7 +317,7 @@ class ServerManager:
                 async with httpx.AsyncClient(timeout=10.0) as client:
                     resp = await client.get(url)
                     if resp.status_code != 200:
-                        raise BackendError(resp.status_code, resp.text)
+                        raise BackendError(resp.status_code, raw_body=resp.text)
                     data = resp.json()
             except (httpx.HTTPError, BackendError) as exc:
                 raise BudgetResolutionError(cause=exc) from exc

--- a/tests/unit/test_client_auth.py
+++ b/tests/unit/test_client_auth.py
@@ -31,7 +31,7 @@ from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
 from forge.clients.openai_compat import OpenAICompatClient
 from forge.clients.vllm import VLLMClient
-from forge.errors import MultipleCredentialsError
+from forge.errors import MissingCredentialError, MultipleCredentialsError
 
 _USER_MSG = [{"role": "user", "content": "hi"}]
 
@@ -502,3 +502,38 @@ async def test_anthropic_stream_installs_recased_credential() -> None:
         )
     ]
     assert captured["kwargs"]["extra_headers"] == {"X-Api-Key": "REALKEY"}
+
+
+# ── zero-credential fail-loud (no credential at all) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_anthropic_zero_credential_send_raises_missing(monkeypatch) -> None:
+    # Pure passthrough (api_key="" -> None), no ambient env, no per-call auth:
+    # forge must fail loud BEFORE the SDK's opaque "could not resolve
+    # authentication" error (which surfaces as HTTP 502). Raised pre-dispatch,
+    # so no network call is attempted.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    client = AnthropicClient(model="claude", api_key="")
+    assert client._client.api_key is None and client._client.auth_token is None
+    with pytest.raises(MissingCredentialError):
+        await client.send(_USER_MSG)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_zero_credential_stream_raises_missing(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    client = AnthropicClient(model="claude", api_key="")
+    with pytest.raises(MissingCredentialError):
+        _ = [c async for c in client.send_stream(_USER_MSG)]
+
+
+def test_anthropic_ambient_env_satisfies_credential_requirement(monkeypatch) -> None:
+    # WR direct use: api_key=None reads ANTHROPIC_API_KEY at construction, so the
+    # zero-credential guard must NOT trip even with no per-call header.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key")
+    client = AnthropicClient(model="claude")  # api_key=None default
+    assert client._client.api_key == "env-key"
+    client._ensure_credential(None)  # no raise

--- a/tests/unit/test_client_auth.py
+++ b/tests/unit/test_client_auth.py
@@ -14,6 +14,7 @@ preflight; and the anthropic-version/beta filter.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock
 
 import httpx
@@ -345,12 +346,45 @@ def _anthropic_capturing(
     )
 
 
-def test_anthropic_empty_key_neutralizes_static_auth() -> None:
-    # The proxy constructs with api_key="" for pure inbound passthrough — no
-    # static credential, env not consulted.
+def test_anthropic_empty_key_is_pure_passthrough_no_static_auth() -> None:
+    # The proxy constructs with api_key="" for pure inbound passthrough: no
+    # static credential, and api_key is mapped to None so the SDK emits no auth
+    # header at all (no spurious empty X-Api-Key).
     client = AnthropicClient(model="claude", api_key="")
     assert client._static_auth is False
-    assert client._client.api_key == ""
+    assert client._client.api_key is None
+    assert client._client.auth_token is None
+
+
+def test_anthropic_passthrough_suppresses_ambient_env(monkeypatch) -> None:
+    # B1/B2: with ambient ANTHROPIC_* set, a pure-passthrough client must carry
+    # NO ambient credential, and the env must be restored after construction.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-api-key")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "env-auth-token")
+    client = AnthropicClient(model="claude", api_key="")
+    assert client._client.api_key is None
+    assert client._client.auth_token is None
+    # restored for forge's own (eval) clients / other processes
+    assert os.environ["ANTHROPIC_API_KEY"] == "env-api-key"
+    assert os.environ["ANTHROPIC_AUTH_TOKEN"] == "env-auth-token"
+
+
+def test_anthropic_static_key_suppresses_ambient_auth_token(monkeypatch) -> None:
+    # A static --backend-api-key must be the ONLY credential — ambient
+    # ANTHROPIC_AUTH_TOKEN must not add a second (Authorization: Bearer).
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "env-auth-token")
+    client = AnthropicClient(model="claude", api_key="STATIC")
+    assert client._client.api_key == "STATIC"
+    assert client._client.auth_token is None
+    assert os.environ["ANTHROPIC_AUTH_TOKEN"] == "env-auth-token"
+
+
+def test_anthropic_none_key_defers_to_env(monkeypatch) -> None:
+    # WR direct use: api_key=None reads ANTHROPIC_API_KEY (the dev's deliberate
+    # single credential); forge does not suppress it.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-api-key")
+    client = AnthropicClient(model="claude")  # api_key=None default
+    assert client._client.api_key == "env-api-key"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_client_auth.py
+++ b/tests/unit/test_client_auth.py
@@ -110,32 +110,31 @@ def _capturing_http(construction_headers: httpx.Headers, captured: dict) -> http
     )
 
 
-def _openai(**kw) -> tuple[OpenAICompatClient, dict]:
-    c = OpenAICompatClient(base_url="https://b/v1", model="m", **kw)
-    cap: dict = {}
-    c._http = _capturing_http(c._http.headers, cap)
-    return c, cap
+def _swap_transport(client, handler) -> None:
+    """Swap a built client's httpx transport for a capturing one, keeping its
+    real construction headers."""
+    client._http = httpx.AsyncClient(
+        headers=client._http.headers, transport=httpx.MockTransport(handler)
+    )
 
 
-def _ollama(**kw) -> tuple[OllamaClient, dict]:
-    c = OllamaClient(model="m", base_url="https://b", **kw)
-    cap: dict = {}
-    c._http = _capturing_http(c._http.headers, cap)
-    return c, cap
+def _wire(build):
+    """Turn a client constructor into a ``(**kw) -> (client, cap)`` factory whose
+    client captures the merged request headers."""
+
+    def factory(**kw) -> tuple[object, dict]:
+        c = build(**kw)
+        cap: dict = {}
+        c._http = _capturing_http(c._http.headers, cap)
+        return c, cap
+
+    return factory
 
 
-def _llamafile(**kw) -> tuple[LlamafileClient, dict]:
-    c = LlamafileClient(gguf_path="m.gguf", base_url="https://b/v1", **kw)
-    cap: dict = {}
-    c._http = _capturing_http(c._http.headers, cap)
-    return c, cap
-
-
-def _vllm(**kw) -> tuple[VLLMClient, dict]:
-    c = VLLMClient(model_path="m", base_url="https://b/v1", **kw)
-    cap: dict = {}
-    c._http = _capturing_http(c._http.headers, cap)
-    return c, cap
+_openai = _wire(lambda **kw: OpenAICompatClient(base_url="https://b/v1", model="m", **kw))
+_ollama = _wire(lambda **kw: OllamaClient(model="m", base_url="https://b", **kw))
+_llamafile = _wire(lambda **kw: LlamafileClient(gguf_path="m.gguf", base_url="https://b/v1", **kw))
+_vllm = _wire(lambda **kw: VLLMClient(model_path="m", base_url="https://b/v1", **kw))
 
 
 _FACTORIES = [
@@ -207,9 +206,7 @@ async def test_ollama_think_retry_keeps_credential() -> None:
         return httpx.Response(200, json={"message": {"content": "ok"}})
 
     client = OllamaClient(model="reasoner", base_url="https://b", think=None)
-    client._http = httpx.AsyncClient(
-        headers=client._http.headers, transport=httpx.MockTransport(handler)
-    )
+    _swap_transport(client, handler)
     await client.send(_USER_MSG, extra_headers={"Authorization": "Bearer INBOUND"})
     assert len(requests) == 2  # initial + retry
     assert requests[1].headers["authorization"] == "Bearer INBOUND"
@@ -234,9 +231,7 @@ async def test_sse_stream_forwards_credential(factory) -> None:
         cap["request"] = request
         return httpx.Response(200, content=sse)
 
-    client._http = httpx.AsyncClient(
-        headers=client._http.headers, transport=httpx.MockTransport(handler)
-    )
+    _swap_transport(client, handler)
     chunks = [
         c async for c in client.send_stream(
             _USER_MSG, extra_headers={"Authorization": "Bearer INBOUND"}
@@ -256,9 +251,7 @@ async def test_ollama_stream_forwards_credential() -> None:
         return httpx.Response(200, content=ndjson)
 
     client = OllamaClient(model="m", base_url="https://b", think=False)
-    client._http = httpx.AsyncClient(
-        headers=client._http.headers, transport=httpx.MockTransport(handler)
-    )
+    _swap_transport(client, handler)
     _ = [
         c async for c in client.send_stream(
             _USER_MSG, extra_headers={"Authorization": "Bearer INBOUND"}

--- a/tests/unit/test_client_auth.py
+++ b/tests/unit/test_client_auth.py
@@ -1,0 +1,477 @@
+"""Auth-credential tests for the client layer (forge v0.8.0).
+
+forge carries exactly ONE credential to the backend, in the backend's native
+auth header. These tests assert the real wire behavior via httpx.MockTransport
+(for the four httpx clients) and the Anthropic SDK's own request pipeline (for
+AnthropicClient), so the credential's final on-the-wire placement — not just
+what forge passes to httpx — is what's verified.
+
+Covers design §12: construction key → canonical header; per-call extra_headers
+reaches the wire; two credentials on one call → raises; the shared-instance
+no-leak property; cross-protocol re-casing for the case-sensitive Anthropic SDK
+preflight; and the anthropic-version/beta filter.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from forge.clients.anthropic import AnthropicClient, _prepare_anthropic_headers
+from forge.clients.base import (
+    AUTH_HEADER_NAMES,
+    has_auth_header,
+    redact_auth_headers,
+    resolve_request_headers,
+)
+from forge.clients.llamafile import LlamafileClient
+from forge.clients.ollama import OllamaClient
+from forge.clients.openai_compat import OpenAICompatClient
+from forge.clients.vllm import VLLMClient
+from forge.errors import MultipleCredentialsError
+
+_USER_MSG = [{"role": "user", "content": "hi"}]
+
+_OPENAI_OK = {"choices": [{"message": {"content": "ok"}}]}
+
+
+# ── base.py shared helpers ───────────────────────────────────────────
+
+
+class TestResolveRequestHeaders:
+    def test_none_extra_returns_none(self) -> None:
+        assert resolve_request_headers(True, None) is None
+        assert resolve_request_headers(False, None) is None
+        assert resolve_request_headers(True, {}) is None
+
+    def test_no_static_passes_through_as_copy(self) -> None:
+        src = {"Authorization": "Bearer x"}
+        out = resolve_request_headers(False, src)
+        assert out == src
+        assert out is not src  # must not alias the caller's dict
+
+    def test_static_plus_per_call_auth_raises(self) -> None:
+        with pytest.raises(MultipleCredentialsError):
+            resolve_request_headers(True, {"x-api-key": "k"})
+        with pytest.raises(MultipleCredentialsError):
+            resolve_request_headers(True, {"Authorization": "Bearer k"})
+
+    def test_static_plus_per_call_nonauth_is_fine(self) -> None:
+        out = resolve_request_headers(True, {"X-Trace-Id": "1"})
+        assert out == {"X-Trace-Id": "1"}
+
+
+class TestHasAuthHeader:
+    def test_case_insensitive(self) -> None:
+        assert has_auth_header({"AUTHORIZATION": "x"})
+        assert has_auth_header({"X-Api-Key": "x"})
+        assert has_auth_header({"x-api-key": "x"})
+
+    def test_negatives(self) -> None:
+        assert not has_auth_header(None)
+        assert not has_auth_header({})
+        assert not has_auth_header({"X-Trace-Id": "1"})
+
+    def test_constant(self) -> None:
+        assert AUTH_HEADER_NAMES == {"authorization", "x-api-key"}
+
+
+class TestRedactAuthHeaders:
+    def test_masks_auth_values_keeps_names(self) -> None:
+        out = redact_auth_headers({"Authorization": "Bearer secret", "X-Trace": "1"})
+        assert out == {"Authorization": "***", "X-Trace": "1"}
+
+    def test_masks_x_api_key(self) -> None:
+        assert redact_auth_headers({"x-api-key": "sk-secret"}) == {"x-api-key": "***"}
+
+    def test_none(self) -> None:
+        assert redact_auth_headers(None) == {}
+
+
+# ── httpx clients: real wire headers via MockTransport ───────────────
+#
+# Each factory builds the client normally (so its construction headers come
+# from the real api_key/extra_headers path), then swaps only the transport —
+# preserving the exact construction headers — so the captured request shows the
+# genuine httpx merge of construction + per-call headers.
+
+
+def _capturing_http(construction_headers: httpx.Headers, captured: dict) -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["request"] = request
+        return httpx.Response(200, json=_OPENAI_OK)
+
+    return httpx.AsyncClient(
+        headers=construction_headers,
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def _openai(**kw) -> tuple[OpenAICompatClient, dict]:
+    c = OpenAICompatClient(base_url="https://b/v1", model="m", **kw)
+    cap: dict = {}
+    c._http = _capturing_http(c._http.headers, cap)
+    return c, cap
+
+
+def _ollama(**kw) -> tuple[OllamaClient, dict]:
+    c = OllamaClient(model="m", base_url="https://b", **kw)
+    cap: dict = {}
+    c._http = _capturing_http(c._http.headers, cap)
+    return c, cap
+
+
+def _llamafile(**kw) -> tuple[LlamafileClient, dict]:
+    c = LlamafileClient(gguf_path="m.gguf", base_url="https://b/v1", **kw)
+    cap: dict = {}
+    c._http = _capturing_http(c._http.headers, cap)
+    return c, cap
+
+
+def _vllm(**kw) -> tuple[VLLMClient, dict]:
+    c = VLLMClient(model_path="m", base_url="https://b/v1", **kw)
+    cap: dict = {}
+    c._http = _capturing_http(c._http.headers, cap)
+    return c, cap
+
+
+_FACTORIES = [
+    pytest.param(_openai, id="openai_compat"),
+    pytest.param(_ollama, id="ollama"),
+    pytest.param(_llamafile, id="llamafile"),
+    pytest.param(_vllm, id="vllm"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", _FACTORIES)
+async def test_construction_api_key_sets_bearer_on_wire(factory) -> None:
+    client, cap = factory(api_key="STATICKEY")
+    await client.send(_USER_MSG)
+    assert cap["request"].headers["authorization"] == "Bearer STATICKEY"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", _FACTORIES)
+async def test_per_call_extra_headers_reach_the_wire(factory) -> None:
+    client, cap = factory(api_key="")  # no static credential
+    await client.send(_USER_MSG, extra_headers={"Authorization": "Bearer INBOUND"})
+    assert cap["request"].headers["authorization"] == "Bearer INBOUND"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", _FACTORIES)
+async def test_static_plus_per_call_auth_raises(factory) -> None:
+    client, _ = factory(api_key="STATICKEY")
+    with pytest.raises(MultipleCredentialsError):
+        await client.send(_USER_MSG, extra_headers={"x-api-key": "INBOUND"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", _FACTORIES)
+async def test_construction_extra_headers_auth_also_blocks_per_call(factory) -> None:
+    # §10.3 must trip even when the static credential came via extra_headers
+    # (not api_key=), so static_present can't be derived from api_key alone.
+    client, _ = factory(extra_headers={"Authorization": "Bearer STATIC"})
+    with pytest.raises(MultipleCredentialsError):
+        await client.send(_USER_MSG, extra_headers={"Authorization": "Bearer INBOUND"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", _FACTORIES)
+async def test_no_credential_leak_across_serialized_requests(factory) -> None:
+    # The proxy reuses one client instance across requests. A per-call inbound
+    # credential must NOT persist into a later request that carries none.
+    client, cap = factory(api_key="")
+    await client.send(_USER_MSG, extra_headers={"Authorization": "Bearer A"})
+    assert cap["request"].headers["authorization"] == "Bearer A"
+    await client.send(_USER_MSG)  # no per-call credential this time
+    assert "authorization" not in cap["request"].headers
+
+
+@pytest.mark.asyncio
+async def test_ollama_think_retry_keeps_credential() -> None:
+    # The think-unsupported fallback re-POSTs; that second request must still
+    # carry the per-call credential (M6).
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                400, json={"error": "registry.ollama.ai does not support thinking"}
+            )
+        return httpx.Response(200, json={"message": {"content": "ok"}})
+
+    client = OllamaClient(model="reasoner", base_url="https://b", think=None)
+    client._http = httpx.AsyncClient(
+        headers=client._http.headers, transport=httpx.MockTransport(handler)
+    )
+    await client.send(_USER_MSG, extra_headers={"Authorization": "Bearer INBOUND"})
+    assert len(requests) == 2  # initial + retry
+    assert requests[1].headers["authorization"] == "Bearer INBOUND"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(_openai, id="openai_compat"),
+        pytest.param(_vllm, id="vllm"),
+        pytest.param(_llamafile, id="llamafile"),
+    ],
+)
+async def test_sse_stream_forwards_credential(factory) -> None:
+    # The three OpenAI-SSE clients must forward the per-call credential on the
+    # streaming path too (M6), not just send().
+    client, cap = factory(api_key="")
+    sse = b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        cap["request"] = request
+        return httpx.Response(200, content=sse)
+
+    client._http = httpx.AsyncClient(
+        headers=client._http.headers, transport=httpx.MockTransport(handler)
+    )
+    chunks = [
+        c async for c in client.send_stream(
+            _USER_MSG, extra_headers={"Authorization": "Bearer INBOUND"}
+        )
+    ]
+    assert chunks  # stream produced output
+    assert cap["request"].headers["authorization"] == "Bearer INBOUND"
+
+
+@pytest.mark.asyncio
+async def test_ollama_stream_forwards_credential() -> None:
+    cap: dict = {}
+    ndjson = b'{"message":{"content":"hi"},"done":false}\n{"done":true}\n'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        cap["request"] = request
+        return httpx.Response(200, content=ndjson)
+
+    client = OllamaClient(model="m", base_url="https://b", think=False)
+    client._http = httpx.AsyncClient(
+        headers=client._http.headers, transport=httpx.MockTransport(handler)
+    )
+    _ = [
+        c async for c in client.send_stream(
+            _USER_MSG, extra_headers={"Authorization": "Bearer INBOUND"}
+        )
+    ]
+    assert cap["request"].headers["authorization"] == "Bearer INBOUND"
+
+
+@pytest.mark.asyncio
+async def test_llamafile_prompt_mode_forwards_credential() -> None:
+    # Prompt capability routes through _send_prompt, a distinct outbound body
+    # from _send_native — verify it carries the credential too.
+    client, cap = _llamafile(api_key="STATICKEY", mode="prompt")
+    await client.send(_USER_MSG)
+    assert cap["request"].headers["authorization"] == "Bearer STATICKEY"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", _FACTORIES)
+async def test_construction_api_key_plus_auth_header_raises(factory) -> None:
+    # Two static credentials at construction (api_key AND an auth header) is
+    # itself two credentials → refused at construction (fail loud).
+    with pytest.raises(MultipleCredentialsError):
+        factory(api_key="STATICKEY", extra_headers={"x-api-key": "OTHER"})
+
+
+# ── Anthropic SDK seam ───────────────────────────────────────────────
+
+
+class TestPrepareAnthropicHeaders:
+    def test_recases_x_api_key_for_case_sensitive_preflight(self) -> None:
+        assert _prepare_anthropic_headers({"x-api-key": "k"}) == {"X-Api-Key": "k"}
+
+    def test_recases_authorization(self) -> None:
+        assert _prepare_anthropic_headers({"authorization": "Bearer k"}) == {
+            "Authorization": "Bearer k"
+        }
+
+    def test_drops_pinned_version_headers(self) -> None:
+        out = _prepare_anthropic_headers(
+            {"x-api-key": "k", "anthropic-version": "2023-06-01", "anthropic-beta": "x"}
+        )
+        assert out == {"X-Api-Key": "k"}
+
+    def test_passes_through_unknown_headers(self) -> None:
+        assert _prepare_anthropic_headers({"X-Trace": "1"}) == {"X-Trace": "1"}
+
+    def test_empty_returns_none(self) -> None:
+        assert _prepare_anthropic_headers(None) is None
+        assert _prepare_anthropic_headers({}) is None
+        # all-dropped collapses to None
+        assert _prepare_anthropic_headers({"anthropic-version": "x"}) is None
+
+
+def _anthropic_capturing(
+    client: AnthropicClient, captured: dict, api_key: str = "",
+) -> None:
+    """Swap the client's SDK for one whose transport captures the request.
+
+    ``api_key`` mirrors the construction credential so the SDK's own auth
+    (e.g. a static ``x-api-key``) is exercised on the captured request.
+    """
+    import anthropic
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["request"] = request
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    client._client = anthropic.AsyncAnthropic(
+        api_key=api_key,
+        base_url="https://b",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+
+def test_anthropic_empty_key_neutralizes_static_auth() -> None:
+    # The proxy constructs with api_key="" for pure inbound passthrough — no
+    # static credential, env not consulted.
+    client = AnthropicClient(model="claude", api_key="")
+    assert client._static_auth is False
+    assert client._client.api_key == ""
+
+
+@pytest.mark.asyncio
+async def test_anthropic_inbound_lowercase_xapikey_reaches_wire() -> None:
+    # The proxy lowercases inbound keys; forge must re-case to X-Api-Key so the
+    # SDK's case-sensitive preflight passes AND the wire carries the credential
+    # exactly once. (Regression guard for blocker B1.)
+    client = AnthropicClient(model="claude", api_key="")
+    cap: dict = {}
+    _anthropic_capturing(client, cap)
+    # lowercase, as it would arrive from the proxy's header dict
+    await client.send(_USER_MSG, extra_headers={"x-api-key": "REALKEY"})
+    wire = cap["request"].headers
+    assert wire["x-api-key"] == "REALKEY"  # httpx.Headers lookup is case-insensitive
+    # exactly one auth credential on the wire
+    assert wire.get_list("x-api-key") == ["REALKEY"]
+    assert "authorization" not in wire
+
+
+@pytest.mark.asyncio
+async def test_anthropic_static_plus_per_call_auth_raises() -> None:
+    client = AnthropicClient(model="claude", api_key="STATIC")
+    assert client._static_auth is True
+    with pytest.raises(MultipleCredentialsError):
+        await client.send(_USER_MSG, extra_headers={"x-api-key": "INBOUND"})
+
+
+def test_anthropic_construction_api_key_plus_default_header_raises() -> None:
+    with pytest.raises(MultipleCredentialsError):
+        AnthropicClient(
+            model="claude", api_key="STATIC",
+            default_headers={"x-api-key": "OTHER"},
+        )
+
+
+def test_anthropic_construction_default_headers_recased_for_sdk() -> None:
+    # Construction default_headers must reach the SDK re-cased to X-Api-Key
+    # (the SDK's case-sensitive preflight slot).
+    client = AnthropicClient(
+        model="claude", api_key="", default_headers={"x-api-key": "STATICKEY"},
+    )
+    assert client._static_auth is True
+    stored = {k.lower(): v for k, v in dict(client._client.default_headers).items()}
+    assert stored.get("x-api-key") == "STATICKEY"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_verbatim_body_cannot_smuggle_extra_headers() -> None:
+    # The real hole (review finding #4): a verbatim inbound body carrying a
+    # top-level ``extra_headers`` with NO forge per-call credential. Unfixed
+    # code left it in kwargs → it reached the wire. Use a static key so the
+    # request is authenticated (and proceeds); assert the smuggled header is
+    # gone and only the static credential rides.
+    client = AnthropicClient(model="claude", api_key="STATIC")
+    cap: dict = {}
+    _anthropic_capturing(client, cap, api_key="STATIC")
+    malicious_body = {
+        "model": "claude",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 16,
+        "extra_headers": {"x-api-key": "SMUGGLED"},
+    }
+    await client.send(_USER_MSG, inbound_anthropic_body=malicious_body)
+    values = cap["request"].headers.get_list("x-api-key")
+    assert "SMUGGLED" not in values
+    assert values == ["STATIC"]  # exactly the static credential, nothing smuggled
+
+
+@pytest.mark.asyncio
+async def test_anthropic_passthrough_cannot_smuggle_extra_headers() -> None:
+    # Same guard on the non-verbatim path: a passthrough dict carrying
+    # ``extra_headers`` must not inject auth either.
+    client = AnthropicClient(model="claude", api_key="STATIC")
+    cap: dict = {}
+    _anthropic_capturing(client, cap, api_key="STATIC")
+    await client.send(
+        _USER_MSG,
+        passthrough={"extra_headers": {"x-api-key": "SMUGGLED"}, "max_tokens": 16},
+    )
+    values = cap["request"].headers.get_list("x-api-key")
+    assert "SMUGGLED" not in values
+    assert values == ["STATIC"]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_installs_recased_credential() -> None:
+    # send_stream shares the credential install + re-casing with send; verify
+    # the re-cased header lands in the SDK stream call.
+    client = AnthropicClient(model="claude", api_key="")
+    captured: dict = {}
+
+    class _FakeStream:
+        async def __aenter__(self_):
+            return self_
+
+        async def __aexit__(self_, *args):
+            return False
+
+        def __aiter__(self_):
+            async def _gen():
+                if False:
+                    yield  # pragma: no cover - empty event stream
+            return _gen()
+
+        async def get_final_message(self_):
+            msg = MagicMock()
+            msg.usage.input_tokens = 1
+            msg.usage.output_tokens = 1
+            msg.usage.cache_creation_input_tokens = 0
+            msg.usage.cache_read_input_tokens = 0
+            return msg
+
+    def fake_stream(**kwargs):
+        captured["kwargs"] = kwargs
+        return _FakeStream()
+
+    client._client = MagicMock()
+    client._client.messages.stream = fake_stream
+    _ = [
+        c async for c in client.send_stream(
+            _USER_MSG, extra_headers={"x-api-key": "REALKEY"}
+        )
+    ]
+    assert captured["kwargs"]["extra_headers"] == {"X-Api-Key": "REALKEY"}

--- a/tests/unit/test_client_auth.py
+++ b/tests/unit/test_client_auth.py
@@ -25,8 +25,8 @@ from forge.clients.base import (
     AUTH_HEADER_NAMES,
     has_auth_header,
     redact_auth_headers,
-    redact_secrets,
     resolve_request_headers,
+    static_auth_present,
 )
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
@@ -64,6 +64,50 @@ class TestResolveRequestHeaders:
         out = resolve_request_headers(True, {"X-Trace-Id": "1"})
         assert out == {"X-Trace-Id": "1"}
 
+    def test_two_per_call_auth_headers_raises(self) -> None:
+        # One credential per request — two auth headers in one call is refused
+        # (the proxy never hands two, but a direct library caller could).
+        with pytest.raises(MultipleCredentialsError):
+            resolve_request_headers(False, {"Authorization": "Bearer A", "x-api-key": "B"})
+
+    def test_blank_per_call_auth_does_not_collide_with_static(self) -> None:
+        # A blank / scheme-only per-call auth header carries no credential, so it
+        # must not trip the static-plus-per-call conflict.
+        assert resolve_request_headers(True, {"Authorization": ""}) == {"Authorization": ""}
+        assert resolve_request_headers(True, {"Authorization": "Bearer "}) == {
+            "Authorization": "Bearer ",
+        }
+
+
+class TestStaticAuthPresent:
+    def test_none_is_false(self) -> None:
+        assert static_auth_present(None, None) is False
+        assert static_auth_present("", {}) is False
+
+    def test_single_source_is_true(self) -> None:
+        assert static_auth_present("sk-x", None) is True
+        assert static_auth_present(None, {"x-api-key": "k"}) is True
+
+    def test_key_plus_header_raises(self) -> None:
+        with pytest.raises(MultipleCredentialsError):
+            static_auth_present("sk-x", {"x-api-key": "k"})
+
+    def test_two_construction_headers_raises(self) -> None:
+        with pytest.raises(MultipleCredentialsError):
+            static_auth_present(None, {"Authorization": "Bearer A", "x-api-key": "B"})
+
+    def test_blank_key_is_absent(self) -> None:
+        # "   " is not a credential: not present, and (in the proxy) must not
+        # disable lazy discovery as if a real static key existed.
+        assert static_auth_present("   ", None) is False
+
+    def test_blank_key_yields_to_real_header(self) -> None:
+        # Blank key ignored → the real header is the single credential.
+        assert static_auth_present("   ", {"x-api-key": "k"}) is True
+
+    def test_blank_construction_header_is_absent(self) -> None:
+        assert static_auth_present(None, {"Authorization": ""}) is False
+
 
 class TestHasAuthHeader:
     def test_case_insensitive(self) -> None:
@@ -90,25 +134,6 @@ class TestRedactAuthHeaders:
 
     def test_none(self) -> None:
         assert redact_auth_headers(None) == {}
-
-
-class TestRedactSecrets:
-    def test_scrubs_bearer_token(self) -> None:
-        out = redact_secrets("Backend returned 401: Authorization: Bearer sk-live-abc123 rejected")
-        assert "sk-live-abc123" not in out
-        assert "[REDACTED]" in out
-
-    def test_scrubs_x_api_key_json_and_header(self) -> None:
-        assert "secretkey" not in redact_secrets('echoed {"x-api-key": "secretkey"}')
-        assert "secretkey" not in redact_secrets("x-api-key: secretkey")
-
-    def test_scrubs_sk_prefix_anywhere(self) -> None:
-        out = redact_secrets("token sk-ant-api03-deadbeef leaked")
-        assert "deadbeef" not in out and "sk-ant-api03-deadbeef" not in out
-
-    def test_leaves_innocuous_text_intact(self) -> None:
-        msg = "Backend returned 500: model 'foo' not found"
-        assert redact_secrets(msg) == msg
 
 
 # ── httpx clients: real wire headers via MockTransport ───────────────

--- a/tests/unit/test_client_auth.py
+++ b/tests/unit/test_client_auth.py
@@ -25,6 +25,7 @@ from forge.clients.base import (
     AUTH_HEADER_NAMES,
     has_auth_header,
     redact_auth_headers,
+    redact_secrets,
     resolve_request_headers,
 )
 from forge.clients.llamafile import LlamafileClient
@@ -89,6 +90,25 @@ class TestRedactAuthHeaders:
 
     def test_none(self) -> None:
         assert redact_auth_headers(None) == {}
+
+
+class TestRedactSecrets:
+    def test_scrubs_bearer_token(self) -> None:
+        out = redact_secrets("Backend returned 401: Authorization: Bearer sk-live-abc123 rejected")
+        assert "sk-live-abc123" not in out
+        assert "[REDACTED]" in out
+
+    def test_scrubs_x_api_key_json_and_header(self) -> None:
+        assert "secretkey" not in redact_secrets('echoed {"x-api-key": "secretkey"}')
+        assert "secretkey" not in redact_secrets("x-api-key: secretkey")
+
+    def test_scrubs_sk_prefix_anywhere(self) -> None:
+        out = redact_secrets("token sk-ant-api03-deadbeef leaked")
+        assert "deadbeef" not in out and "sk-ant-api03-deadbeef" not in out
+
+    def test_leaves_innocuous_text_intact(self) -> None:
+        msg = "Backend returned 500: model 'foo' not found"
+        assert redact_secrets(msg) == msg
 
 
 # ── httpx clients: real wire headers via MockTransport ───────────────

--- a/tests/unit/test_inference_auth.py
+++ b/tests/unit/test_inference_auth.py
@@ -1,0 +1,109 @@
+"""Tests for run_inference threading the per-call credential to the client.
+
+The proxy hands run_inference a relocated inbound auth header via
+``extra_headers``; it must reach the client's send/send_stream. When unset, the
+kwarg must be omitted entirely (splat-only-when-set) so clients and test
+doubles that don't declare it keep their original signature.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from forge.clients.base import ChunkType, StreamChunk
+from forge.context.manager import ContextManager
+from forge.context.strategies import NoCompact
+from forge.core.inference import run_inference
+from forge.core.messages import Message, MessageMeta, MessageRole, MessageType
+from forge.core.workflow import ToolCall, ToolSpec
+from forge.guardrails import ErrorTracker, ResponseValidator
+
+
+def _ctx():
+    return ContextManager(strategy=NoCompact(), budget_tokens=8192)
+
+
+def _search_spec():
+    return ToolSpec.from_json_schema(
+        name="search", description="", schema={"type": "object", "properties": {}},
+    )
+
+
+def _messages():
+    return [Message(MessageRole.USER, "hi", MessageMeta(MessageType.USER_INPUT))]
+
+
+def _send_client(*responses):
+    client = AsyncMock()
+    client.api_format = "ollama"
+    client.send = AsyncMock(side_effect=list(responses))
+    client.last_usage = {}
+    client._slot_id = 0
+    return client
+
+
+async def _run(client, **kw):
+    return await run_inference(
+        messages=_messages(),
+        client=client,
+        context_manager=_ctx(),
+        validator=ResponseValidator(["search"], rescue_enabled=True),
+        error_tracker=ErrorTracker(max_retries=1),
+        tool_specs=[_search_spec()],
+        **kw,
+    )
+
+
+@pytest.mark.asyncio
+async def test_extra_headers_forwarded_to_send():
+    client = _send_client([ToolCall(tool="search", args={})])
+    await _run(client, extra_headers={"Authorization": "Bearer X"})
+    assert client.send.call_args.kwargs["extra_headers"] == {"Authorization": "Bearer X"}
+
+
+@pytest.mark.asyncio
+async def test_extra_headers_omitted_when_none():
+    # splat-only-when-set: no kwarg at all, so a client lacking the param works.
+    client = _send_client([ToolCall(tool="search", args={})])
+    await _run(client)
+    assert "extra_headers" not in client.send.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_extra_headers_forwarded_to_send_stream():
+    captured: dict = {}
+
+    async def fake_stream(*args, **kwargs):
+        captured.update(kwargs)
+        yield StreamChunk(
+            type=ChunkType.FINAL, response=[ToolCall(tool="search", args={})]
+        )
+
+    client = AsyncMock()
+    client.api_format = "ollama"
+    client.send_stream = fake_stream
+    client.last_usage = {}
+    client._slot_id = 0
+
+    await _run(client, stream=True, extra_headers={"x-api-key": "K"})
+    assert captured["extra_headers"] == {"x-api-key": "K"}
+
+
+@pytest.mark.asyncio
+async def test_extra_headers_omitted_from_send_stream_when_none():
+    captured: dict = {}
+
+    async def fake_stream(*args, **kwargs):
+        captured.update(kwargs)
+        yield StreamChunk(
+            type=ChunkType.FINAL, response=[ToolCall(tool="search", args={})]
+        )
+
+    client = AsyncMock()
+    client.api_format = "ollama"
+    client.send_stream = fake_stream
+    client.last_usage = {}
+    client._slot_id = 0
+
+    await _run(client, stream=True)
+    assert "extra_headers" not in captured

--- a/tests/unit/test_llamafile_client.py
+++ b/tests/unit/test_llamafile_client.py
@@ -425,6 +425,85 @@ class TestLlamafileGetContextLength:
             await client.get_context_length()
 
 
+# ── discover_backend_metadata (deferred discovery) ───────────────
+
+
+class TestLlamafileDiscoverBackendMetadata:
+    @pytest.mark.asyncio
+    async def test_returns_budget_no_identity(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "default_generation_settings": {"n_ctx": 32768}
+        })
+        model_before = client.model
+        budget = await client.discover_backend_metadata()
+        assert budget == 32768
+        # llama.cpp ignores the wire model field → no identity adopted/changed
+        assert client.model == model_before
+
+    @pytest.mark.asyncio
+    async def test_probes_props_not_v1(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "default_generation_settings": {"n_ctx": 4096}
+        })
+        await client.discover_backend_metadata()
+        url = client._http.get.await_args.args[0]
+        assert "/v1" not in url and url.endswith("/props")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_n_ctx(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({})
+        assert await client.discover_backend_metadata() is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_settings_returns_none(self) -> None:
+        # default_generation_settings present but not a dict → treat as no n_ctx
+        # (fail loud upstream), never an uncaught AttributeError.
+        client = _make_client()
+        client._http.get.return_value = _mock_response(
+            {"default_generation_settings": "not-a-dict"},
+        )
+        assert await client.discover_backend_metadata() is None
+
+    @pytest.mark.asyncio
+    async def test_non_int_n_ctx_raises_502(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response(
+            {"default_generation_settings": {"n_ctx": "huge"}},
+        )
+        with pytest.raises(BackendError) as exc_info:
+            await client.discover_backend_metadata()
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_non_200_raises_with_status_code(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({"error": "nope"}, status_code=401)
+        with pytest.raises(BackendError) as exc_info:
+            await client.discover_backend_metadata()
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_connection_error_raises_502(self) -> None:
+        client = _make_client()
+        client._http.get.side_effect = httpx.ConnectError("refused")
+        with pytest.raises(BackendError) as exc_info:
+            await client.discover_backend_metadata()
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_extra_headers_threaded_into_probe(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "default_generation_settings": {"n_ctx": 4096}
+        })
+        extra = {"Authorization": "Bearer inbound-token"}
+        await client.discover_backend_metadata(extra_headers=extra)
+        assert client._http.get.await_args.kwargs["headers"] == client._request_headers(extra)
+
+
 # ── send_stream ──────────────────────────────────────────────────
 
 

--- a/tests/unit/test_openai_compat_client.py
+++ b/tests/unit/test_openai_compat_client.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 from forge.clients.openai_compat import OpenAICompatClient
 from forge.clients.base import ChunkType
 from forge.core.workflow import TextResponse, ToolCall, ToolSpec
-from forge.errors import BackendError
+from forge.errors import BackendError, MultipleCredentialsError
 
 
 class PartParams(BaseModel):
@@ -446,11 +446,24 @@ class TestConstructor:
         assert client._http.headers["http-referer"] == "https://example.com"
         assert client._http.headers["x-title"] == "MyApp"
 
-    def test_extra_headers_can_override_authorization(self) -> None:
+    def test_api_key_plus_auth_header_raises(self) -> None:
+        # v0.8.0 one-credential rule: an ``api_key`` AND an auth header in
+        # ``extra_headers`` is two configured credentials → refused at
+        # construction (no silent precedence). For a non-Bearer scheme, pass
+        # ``extra_headers`` alone and omit ``api_key``.
+        with pytest.raises(MultipleCredentialsError):
+            OpenAICompatClient(
+                model="test-model",
+                base_url="https://x/v1",
+                api_key="ignored",
+                extra_headers={"Authorization": "ApiKey custom-scheme"},
+            )
+
+    def test_extra_headers_alone_set_custom_scheme(self) -> None:
+        # The supported path for a custom auth scheme: extra_headers, no api_key.
         client = OpenAICompatClient(
             model="test-model",
             base_url="https://x/v1",
-            api_key="ignored",
             extra_headers={"Authorization": "ApiKey custom-scheme"},
         )
         assert client._http.headers["authorization"] == "ApiKey custom-scheme"

--- a/tests/unit/test_proxy_auth.py
+++ b/tests/unit/test_proxy_auth.py
@@ -216,6 +216,26 @@ async def test_handler_no_inbound_credential_forwards_none():
 
 
 @pytest.mark.asyncio
+async def test_handler_logs_redacted_credential(caplog):
+    import logging
+
+    client = _mock_client(TextResponse(content="ok"))
+    with caplog.at_level(logging.DEBUG, logger="forge.proxy"):
+        await handle_chat_completions(
+            body=_body(),
+            client=client,
+            context_manager=_ctx(),
+            protocol="openai",
+            backend_protocol="anthropic",
+            headers={"authorization": "Bearer SUPERSECRET"},
+        )
+    text = "\n".join(r.getMessage() for r in caplog.records)
+    assert "SUPERSECRET" not in text  # never log a raw secret
+    assert "***" in text
+    assert "x-api-key" in text  # the relocated slot name is shown
+
+
+@pytest.mark.asyncio
 async def test_handler_inbound_plus_static_key_raises():
     client = _mock_client(TextResponse(content="ok"))
     with pytest.raises(MultipleCredentialsError):

--- a/tests/unit/test_proxy_auth.py
+++ b/tests/unit/test_proxy_auth.py
@@ -60,6 +60,26 @@ class TestExtractInboundCredential:
         assert extract_inbound_credential({"authorization": ""}) == (None, None)
         assert extract_inbound_credential({"x-api-key": "   "}) == (None, None)
 
+    def test_scheme_only_bearer_is_not_a_credential(self):
+        # "Bearer " (scheme, no token) is non-empty as a raw string but carries
+        # no credential — must be treated as absent, not forwarded as empty.
+        assert extract_inbound_credential({"authorization": "Bearer "}) == (None, None)
+        assert extract_inbound_credential({"authorization": "Bearer    "}) == (None, None)
+        assert extract_inbound_credential({"Authorization": "bearer "}) == (None, None)
+
+    def test_scheme_only_bearer_fails_loud_through_resolve(self):
+        # End-to-end: a token-less Bearer must not relocate to an empty
+        # x-api-key / "Bearer " — resolve returns None (→ fail loud downstream).
+        assert resolve_inbound_credential(
+            {"authorization": "Bearer "}, "openai", "anthropic", False,
+        ) is None
+
+    def test_real_bearer_token_still_extracted(self):
+        # Guard against over-stripping: a real token survives.
+        assert extract_inbound_credential({"authorization": "Bearer sk-abc123"}) == (
+            "authorization", "Bearer sk-abc123",
+        )
+
 
 # ── relocate_credential ──────────────────────────────────────────────
 

--- a/tests/unit/test_proxy_auth.py
+++ b/tests/unit/test_proxy_auth.py
@@ -1,0 +1,231 @@
+"""Proxy credential handling (forge v0.8.0 Phase C).
+
+Covers forge.proxy.auth (inbound extraction, cross-protocol relocation, the
+two-source rule) and the handler threading the resolved credential to the
+backend client.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from forge.context.manager import ContextManager
+from forge.context.strategies import NoCompact
+from forge.core.workflow import TextResponse, ToolCall
+from forge.errors import MultipleCredentialsError
+from forge.proxy.auth import (
+    DUPLICATE_AUTH_MARKER,
+    extract_inbound_credential,
+    relocate_credential,
+    resolve_inbound_credential,
+)
+from forge.proxy.handler import handle_chat_completions
+
+
+# ── extract_inbound_credential ───────────────────────────────────────
+
+
+class TestExtractInboundCredential:
+    def test_none_present(self):
+        assert extract_inbound_credential({"content-type": "application/json"}) == (None, None)
+        assert extract_inbound_credential(None) == (None, None)
+        assert extract_inbound_credential({}) == (None, None)
+
+    def test_authorization(self):
+        assert extract_inbound_credential({"authorization": "Bearer x"}) == (
+            "authorization", "Bearer x",
+        )
+
+    def test_x_api_key(self):
+        assert extract_inbound_credential({"x-api-key": "k"}) == ("x-api-key", "k")
+
+    def test_case_insensitive_name(self):
+        # The proxy lowercases keys, but be robust to mixed case anyway.
+        assert extract_inbound_credential({"Authorization": "Bearer x"}) == (
+            "authorization", "Bearer x",
+        )
+
+    def test_two_distinct_auth_headers_raises(self):
+        with pytest.raises(MultipleCredentialsError):
+            extract_inbound_credential({"authorization": "Bearer x", "x-api-key": "k"})
+
+    def test_duplicate_same_name_marker_raises(self):
+        # The proxy reader injects the marker when one auth name repeats.
+        with pytest.raises(MultipleCredentialsError):
+            extract_inbound_credential(
+                {"authorization": "Bearer x", DUPLICATE_AUTH_MARKER: "1"},
+            )
+
+    def test_empty_or_whitespace_value_is_not_a_credential(self):
+        assert extract_inbound_credential({"authorization": ""}) == (None, None)
+        assert extract_inbound_credential({"x-api-key": "   "}) == (None, None)
+
+
+# ── relocate_credential ──────────────────────────────────────────────
+
+
+class TestRelocateCredential:
+    def test_same_protocol_openai_verbatim(self):
+        assert relocate_credential("authorization", "Bearer x", "openai", "openai") == {
+            "authorization": "Bearer x",
+        }
+
+    def test_same_protocol_anthropic_verbatim(self):
+        assert relocate_credential("x-api-key", "k", "anthropic", "anthropic") == {
+            "x-api-key": "k",
+        }
+
+    def test_cross_anthropic_to_openai_wraps_bearer(self):
+        # CC (x-api-key) → OpenAI backend → Authorization: Bearer
+        assert relocate_credential("x-api-key", "k", "anthropic", "openai") == {
+            "Authorization": "Bearer k",
+        }
+
+    def test_cross_openai_to_anthropic_strips_bearer(self):
+        # OpenAI client (Authorization Bearer) → Anthropic backend → x-api-key
+        assert relocate_credential("authorization", "Bearer k", "openai", "anthropic") == {
+            "x-api-key": "k",
+        }
+
+    def test_cross_bearer_strip_is_case_insensitive(self):
+        assert relocate_credential("authorization", "BEARER k", "openai", "anthropic") == {
+            "x-api-key": "k",
+        }
+
+    def test_cross_non_bearer_authorization_passes_whole(self):
+        # A non-Bearer scheme cross-relocated is passed as-is (documented:
+        # cross-protocol assumes Bearer/x-api-key token semantics).
+        assert relocate_credential("authorization", "Basic abc", "openai", "anthropic") == {
+            "x-api-key": "Basic abc",
+        }
+
+    def test_no_double_scheme_on_round_trip(self):
+        # x-api-key → openai (Bearer k) is the only scheme-adding path; verify
+        # it never doubles even when value coincidentally starts with "Bearer".
+        assert relocate_credential("x-api-key", "Bearer-like", "anthropic", "openai") == {
+            "Authorization": "Bearer Bearer-like",
+        }
+
+
+# ── resolve_inbound_credential ───────────────────────────────────────
+
+
+class TestResolveInboundCredential:
+    def test_no_inbound_returns_none(self):
+        assert resolve_inbound_credential({}, "openai", "openai", False) is None
+
+    def test_inbound_plus_static_key_raises(self):
+        with pytest.raises(MultipleCredentialsError):
+            resolve_inbound_credential(
+                {"authorization": "Bearer x"}, "openai", "openai",
+                backend_api_key_present=True,
+            )
+
+    def test_inbound_relocated_when_no_static(self):
+        out = resolve_inbound_credential(
+            {"x-api-key": "k"}, "anthropic", "openai", backend_api_key_present=False,
+        )
+        assert out == {"Authorization": "Bearer k"}
+
+    def test_two_inbound_auth_headers_raises(self):
+        with pytest.raises(MultipleCredentialsError):
+            resolve_inbound_credential(
+                {"authorization": "Bearer x", "x-api-key": "k"},
+                "openai", "openai", False,
+            )
+
+    def test_empty_inbound_value_returns_none(self):
+        # An empty/whitespace auth value is not a credential, so it must not
+        # spuriously trip the two-source block against a static backend key.
+        assert resolve_inbound_credential(
+            {"authorization": ""}, "openai", "openai", backend_api_key_present=True,
+        ) is None
+
+
+# ── handler threading ────────────────────────────────────────────────
+
+
+def _mock_client(response):
+    client = AsyncMock()
+    client.api_format = "ollama"
+    client.send = AsyncMock(return_value=response)
+    client.last_usage = {}
+    client._slot_id = 0
+    return client
+
+
+def _ctx():
+    return ContextManager(strategy=NoCompact(), budget_tokens=8192)
+
+
+def _body(tools=None):
+    body = {"model": "test", "messages": [{"role": "user", "content": "hi"}], "stream": False}
+    if tools:
+        body["tools"] = tools
+    return body
+
+
+_SEARCH_TOOL = [{
+    "type": "function",
+    "function": {"name": "search", "description": "", "parameters": {"type": "object", "properties": {}}},
+}]
+
+
+@pytest.mark.asyncio
+async def test_handler_no_tools_relocates_inbound_credential():
+    client = _mock_client(TextResponse(content="ok"))
+    await handle_chat_completions(
+        body=_body(),
+        client=client,
+        context_manager=_ctx(),
+        protocol="openai",
+        backend_protocol="anthropic",
+        headers={"authorization": "Bearer INBOUND"},
+    )
+    # cross openai→anthropic: Bearer stripped, relocated to x-api-key
+    assert client.send.call_args.kwargs["extra_headers"] == {"x-api-key": "INBOUND"}
+
+
+@pytest.mark.asyncio
+async def test_handler_with_tools_threads_credential_via_run_inference():
+    client = _mock_client([ToolCall(tool="search", args={})])
+    await handle_chat_completions(
+        body=_body(tools=_SEARCH_TOOL),
+        client=client,
+        context_manager=_ctx(),
+        protocol="anthropic",
+        backend_protocol="openai",
+        headers={"x-api-key": "INBOUND"},
+    )
+    # cross anthropic→openai: wrapped as Authorization: Bearer
+    assert client.send.call_args.kwargs["extra_headers"] == {"Authorization": "Bearer INBOUND"}
+
+
+@pytest.mark.asyncio
+async def test_handler_no_inbound_credential_forwards_none():
+    client = _mock_client(TextResponse(content="ok"))
+    await handle_chat_completions(
+        body=_body(),
+        client=client,
+        context_manager=_ctx(),
+        protocol="openai",
+        backend_protocol="openai",
+        headers={},
+    )
+    assert client.send.call_args.kwargs["extra_headers"] is None
+
+
+@pytest.mark.asyncio
+async def test_handler_inbound_plus_static_key_raises():
+    client = _mock_client(TextResponse(content="ok"))
+    with pytest.raises(MultipleCredentialsError):
+        await handle_chat_completions(
+            body=_body(),
+            client=client,
+            context_manager=_ctx(),
+            protocol="openai",
+            backend_protocol="openai",
+            headers={"authorization": "Bearer INBOUND"},
+            backend_api_key_present=True,
+        )
+    client.send.assert_not_awaited()  # refused before dispatch

--- a/tests/unit/test_proxy_handler.py
+++ b/tests/unit/test_proxy_handler.py
@@ -10,7 +10,12 @@ from forge.context.manager import ContextManager
 from forge.context.strategies import NoCompact
 from forge.core.workflow import TextResponse, ToolCall
 from forge.clients.base import TokenUsage
-from forge.proxy.handler import handle_chat_completions, _extract_tool_specs
+from forge.errors import BackendDiscoveryError, BackendError
+from forge.proxy.handler import (
+    LazyDiscovery,
+    handle_chat_completions,
+    _extract_tool_specs,
+)
 
 
 # ── Helpers ──────────────────────────────────────────────────
@@ -114,6 +119,128 @@ class TestNoToolsPassthrough:
             _body(model="my-model"), client, _context_manager(),
         )
         assert result["model"] == "my-model"
+
+
+# ── Deferred external-mode discovery (finding #2) ────────────
+
+
+def _discovery_client(*, budget=50000):
+    """A no-tools passthrough client whose deferred probe returns ``budget``."""
+    client = _mock_client(TextResponse(content="ok"))
+    client.discover_backend_metadata = AsyncMock(return_value=budget)
+    return client
+
+
+class TestLazyDiscovery:
+    @pytest.mark.asyncio
+    async def test_first_request_runs_discovery_and_latches(self):
+        client = _discovery_client(budget=50000)
+        ctx = _context_manager()
+        lazy = LazyDiscovery(deferred=True, apply_budget=True)
+        await handle_chat_completions(_body(), client, ctx, lazy_discovery=lazy)
+        client.discover_backend_metadata.assert_awaited_once()
+        assert ctx.budget_tokens == 50000  # discovered budget applied
+        assert lazy.done is True
+
+    @pytest.mark.asyncio
+    async def test_runs_on_no_tools_path(self):
+        # The probe must run even for a no-tools request: vLLM needs its served
+        # identity on every call, not just the compacting tool path.
+        client = _discovery_client()
+        lazy = LazyDiscovery(deferred=True, apply_budget=True)
+        await handle_chat_completions(_body(), client, _context_manager(), lazy_discovery=lazy)
+        client.discover_backend_metadata.assert_awaited_once()
+        assert lazy.done is True
+
+    @pytest.mark.asyncio
+    async def test_second_request_skips_after_latch(self):
+        client = _discovery_client()
+        lazy = LazyDiscovery(deferred=True, apply_budget=True, done=True)
+        await handle_chat_completions(_body(), client, _context_manager(), lazy_discovery=lazy)
+        client.discover_backend_metadata.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_none_discovery_skips_block(self):
+        client = _discovery_client()
+        await handle_chat_completions(_body(), client, _context_manager(), lazy_discovery=None)
+        client.discover_backend_metadata.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_apply_budget_false_keeps_explicit_budget(self):
+        # Explicit --budget-tokens: discovery still runs (to adopt identity) but
+        # the returned budget must NOT overwrite the explicit one.
+        client = _discovery_client(budget=99999)
+        ctx = _context_manager()  # budget 8192
+        lazy = LazyDiscovery(deferred=True, apply_budget=False)
+        await handle_chat_completions(_body(), client, ctx, lazy_discovery=lazy)
+        client.discover_backend_metadata.assert_awaited_once()
+        assert ctx.budget_tokens == 8192
+        assert lazy.done is True
+
+    @pytest.mark.asyncio
+    async def test_discovery_failure_raises_and_does_not_latch(self):
+        client = _discovery_client()
+        client.discover_backend_metadata = AsyncMock(
+            side_effect=BackendError(401, "unauthorized"),
+        )
+        lazy = LazyDiscovery(deferred=True, apply_budget=True)
+        with pytest.raises(BackendDiscoveryError) as exc_info:
+            await handle_chat_completions(_body(), client, _context_manager(), lazy_discovery=lazy)
+        assert exc_info.value.status_code == 401  # carried for the 401 mapping
+        assert lazy.done is False  # not latched → a later good request retries
+
+    @pytest.mark.asyncio
+    async def test_none_budget_when_apply_raises(self):
+        # A probe that succeeds but yields no budget (apply_budget) is a loud
+        # failure, not a silent default.
+        client = _discovery_client(budget=None)
+        lazy = LazyDiscovery(deferred=True, apply_budget=True)
+        with pytest.raises(BackendDiscoveryError) as exc_info:
+            await handle_chat_completions(_body(), client, _context_manager(), lazy_discovery=lazy)
+        assert exc_info.value.status_code is None
+        assert lazy.done is False
+
+    @pytest.mark.asyncio
+    async def test_inbound_credential_threaded_to_probe(self):
+        client = _discovery_client()
+        lazy = LazyDiscovery(deferred=True, apply_budget=True)
+        await handle_chat_completions(
+            _body(), client, _context_manager(),
+            headers={"authorization": "Bearer inbound-tok"},
+            lazy_discovery=lazy,
+        )
+        extra = client.discover_backend_metadata.await_args.kwargs["extra_headers"]
+        assert "Bearer inbound-tok" in str(extra)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_first_requests_converge(self):
+        # External is unserialized: two first requests may both probe. Force the
+        # actual race — a gate holds BOTH probes open until both have passed the
+        # `not done` check, so we exercise the concurrent-probe interleave (not a
+        # serialized one). The probe is idempotent, so the latch stays consistent.
+        import asyncio
+
+        client = _mock_client(TextResponse(content="ok"))
+        both_arrived = asyncio.Event()
+        arrivals = {"n": 0}
+
+        async def gated_probe(extra_headers=None):
+            arrivals["n"] += 1
+            if arrivals["n"] >= 2:
+                both_arrived.set()
+            await both_arrived.wait()  # neither returns until both are past the gate
+            return 70000
+
+        client.discover_backend_metadata = AsyncMock(side_effect=gated_probe)
+        ctx = _context_manager()
+        lazy = LazyDiscovery(deferred=True, apply_budget=True)
+        await asyncio.gather(*(
+            handle_chat_completions(_body(), client, ctx, lazy_discovery=lazy)
+            for _ in range(2)
+        ))
+        assert client.discover_backend_metadata.await_count == 2  # both probed
+        assert ctx.budget_tokens == 70000  # consistent, no torn state
+        assert lazy.done is True
 
 
 # ── With tools → guardrails ─────────────────────────────────

--- a/tests/unit/test_proxy_path1.py
+++ b/tests/unit/test_proxy_path1.py
@@ -59,10 +59,11 @@ class TestProxyServerValidation:
             mock_client.get_context_length = AsyncMock(return_value=200000)
             mock_client_cls.return_value = mock_client
 
-            client, ctx = await proxy._setup_external()
+            client, ctx, lazy = await proxy._setup_external()
 
         assert client is mock_client
         assert ctx.budget_tokens == 200000
+        assert lazy is None  # Anthropic path is never deferred
         mock_client_cls.assert_called_once_with(
             model="claude",
             base_url="http://localhost:8080",

--- a/tests/unit/test_proxy_path1.py
+++ b/tests/unit/test_proxy_path1.py
@@ -67,6 +67,9 @@ class TestProxyServerValidation:
             model="claude",
             base_url="http://localhost:8080",
             timeout=1800.0,
+            # explicit "" → no static credential and ambient ANTHROPIC_* env is
+            # suppressed at construction (one credential per request).
+            api_key="",
         )
 
 

--- a/tests/unit/test_proxy_proxy.py
+++ b/tests/unit/test_proxy_proxy.py
@@ -289,6 +289,19 @@ class TestExternalDeferredDiscovery:
         assert lazy is None
         assert ctx.budget_tokens == 32768
 
+    @pytest.mark.asyncio
+    async def test_blank_static_key_treated_as_passthrough(self) -> None:
+        # A whitespace --backend-api-key is not a credential: it must normalize
+        # to None and still defer (bool("   ") would have made it eager).
+        proxy = ProxyServer(backend_url="http://localhost:8080", backend_api_key="   ")
+        assert proxy._backend_api_key is None
+        with patch.object(
+            LlamafileClient, "get_context_length", new_callable=AsyncMock,
+        ) as probe:
+            _, _, lazy = await proxy._setup_external()
+        probe.assert_not_awaited()
+        assert lazy is not None and lazy.deferred is True
+
 
 class TestSetupManaged:
     """Managed mode delegates to setup_backend with the right identity field."""

--- a/tests/unit/test_proxy_proxy.py
+++ b/tests/unit/test_proxy_proxy.py
@@ -101,32 +101,36 @@ class TestSetupExternal:
             budget_tokens=8192,
             backend_timeout=1800.0,
         )
-        client, ctx = await proxy._setup_external()
+        client, ctx, lazy = await proxy._setup_external()
         assert isinstance(client, LlamafileClient)
         assert client.base_url == "http://localhost:8080/v1"
         assert client._http.timeout.read == 1800.0
         assert ctx.budget_tokens == 8192
+        # llama.cpp + explicit budget + no key → nothing to probe → not deferred.
+        assert lazy is None
 
     @pytest.mark.asyncio
     async def test_explicit_llamafile_backend_uses_llamafile_client(self) -> None:
         proxy = ProxyServer(
             backend_url="http://localhost:8080", backend="llamafile", budget_tokens=8192,
         )
-        client, _ = await proxy._setup_external()
+        client, _, _ = await proxy._setup_external()
         assert isinstance(client, LlamafileClient)
 
     @pytest.mark.asyncio
     async def test_vllm_uses_vllm_client(self) -> None:
+        # Static key → eager startup discovery path.
         proxy = ProxyServer(
             backend_url="http://localhost:8000",
             backend="vllm",
             budget_tokens=8192,
+            backend_api_key="K",
             backend_timeout=1800.0,
         )
         with patch.object(
             VLLMClient, "get_served_model_name", new_callable=AsyncMock, return_value=None,
         ):
-            client, ctx = await proxy._setup_external()
+            client, ctx, _ = await proxy._setup_external()
         assert isinstance(client, VLLMClient)
         assert client.base_url == "http://localhost:8000/v1"
         assert client._http.timeout.read == 1800.0
@@ -134,14 +138,16 @@ class TestSetupExternal:
 
     @pytest.mark.asyncio
     async def test_vllm_adopts_served_model_name(self) -> None:
+        # Static key authenticates the startup probe → eager served-name adoption.
         proxy = ProxyServer(
-            backend_url="http://localhost:8000", backend="vllm", budget_tokens=8192,
+            backend_url="http://localhost:8000", backend="vllm",
+            budget_tokens=8192, backend_api_key="K",
         )
         with patch.object(
             VLLMClient, "get_served_model_name",
             new_callable=AsyncMock, return_value="my-awq-model",
         ):
-            client, _ = await proxy._setup_external()
+            client, _, _ = await proxy._setup_external()
         assert client.model == "my-awq-model"
         assert client.sampling_key == "my-awq-model"
 
@@ -151,57 +157,137 @@ class TestSetupExternal:
         # it), while the registry key is the derived stem — the (model,
         # sampling_key) invariant, applied to served-name adoption.
         proxy = ProxyServer(
-            backend_url="http://localhost:8000", backend="vllm", budget_tokens=8192,
+            backend_url="http://localhost:8000", backend="vllm",
+            budget_tokens=8192, backend_api_key="K",
         )
         with patch.object(
             VLLMClient, "get_served_model_name",
             new_callable=AsyncMock, return_value="google/gemma-4-26B-A4B-it",
         ):
-            client, _ = await proxy._setup_external()
+            client, _, _ = await proxy._setup_external()
         assert client.model == "google/gemma-4-26B-A4B-it"
         assert client.sampling_key == "gemma-4-26B-A4B-it"
 
     @pytest.mark.asyncio
     async def test_vllm_keeps_placeholder_when_discovery_fails(self) -> None:
         proxy = ProxyServer(
-            backend_url="http://localhost:8000", backend="vllm", budget_tokens=8192,
+            backend_url="http://localhost:8000", backend="vllm",
+            budget_tokens=8192, backend_api_key="K",
         )
         with patch.object(
             VLLMClient, "get_served_model_name", new_callable=AsyncMock, return_value=None,
         ):
-            client, _ = await proxy._setup_external()
+            client, _, _ = await proxy._setup_external()
         assert client.model == "default"
 
     @pytest.mark.asyncio
     async def test_url_v1_suffix_preserved(self) -> None:
         proxy = ProxyServer(backend_url="http://localhost:8080/v1", budget_tokens=8192)
-        client, _ = await proxy._setup_external()
+        client, _, _ = await proxy._setup_external()
         assert client.base_url == "http://localhost:8080/v1"
 
     @pytest.mark.asyncio
     async def test_url_trailing_slash_stripped(self) -> None:
         proxy = ProxyServer(backend_url="http://localhost:8080/", budget_tokens=8192)
-        client, _ = await proxy._setup_external()
+        client, _, _ = await proxy._setup_external()
         assert client.base_url == "http://localhost:8080/v1"
 
     @pytest.mark.asyncio
     async def test_budget_from_backend_when_unspecified(self) -> None:
-        proxy = ProxyServer(backend_url="http://localhost:8080")
+        # Static key → eager budget discovery from the backend at startup.
+        proxy = ProxyServer(backend_url="http://localhost:8080", backend_api_key="K")
         with patch.object(
             LlamafileClient, "get_context_length",
             new_callable=AsyncMock, return_value=32768,
         ):
-            _, ctx = await proxy._setup_external()
+            _, ctx, _ = await proxy._setup_external()
         assert ctx.budget_tokens == 32768
 
     @pytest.mark.asyncio
     async def test_budget_unresolvable_raises(self) -> None:
-        proxy = ProxyServer(backend_url="http://localhost:8080")
+        # Eager path (static key): an unresolvable context length fails at startup.
+        proxy = ProxyServer(backend_url="http://localhost:8080", backend_api_key="K")
         with patch.object(
             LlamafileClient, "get_context_length",
             new_callable=AsyncMock, return_value=None,
         ), pytest.raises(RuntimeError, match="did not report a context length"):
             await proxy._setup_external()
+
+
+class TestExternalDeferredDiscovery:
+    """External passthrough defers startup backend probes to the first request.
+
+    Without a static --backend-api-key the startup probe would be unauthenticated
+    against a gated backend (finding #2), so _setup_external skips it and returns
+    a LazyDiscovery latch; the handler runs the probe on the first request with
+    that request's inbound credential.
+    """
+
+    @pytest.mark.asyncio
+    async def test_llamacpp_passthrough_no_budget_defers(self) -> None:
+        proxy = ProxyServer(backend_url="http://localhost:8080")
+        with patch.object(
+            LlamafileClient, "get_context_length", new_callable=AsyncMock,
+        ) as probe:
+            _, _, lazy = await proxy._setup_external()
+        probe.assert_not_awaited()  # no unauthenticated startup probe
+        assert lazy is not None
+        assert lazy.deferred is True
+        assert lazy.apply_budget is True  # no explicit budget → discovery sets it
+        assert lazy.done is False
+
+    @pytest.mark.asyncio
+    async def test_vllm_passthrough_no_budget_defers_both_probes(self) -> None:
+        proxy = ProxyServer(backend_url="http://localhost:8000", backend="vllm")
+        with patch.object(
+            VLLMClient, "get_served_model_name", new_callable=AsyncMock,
+        ) as served, patch.object(
+            VLLMClient, "get_context_length", new_callable=AsyncMock,
+        ) as ctxlen:
+            client, _, lazy = await proxy._setup_external()
+        served.assert_not_awaited()
+        ctxlen.assert_not_awaited()
+        assert client.model == "default"  # identity deferred → still placeholder
+        assert lazy.deferred is True
+        assert lazy.apply_budget is True
+
+    @pytest.mark.asyncio
+    async def test_vllm_passthrough_with_budget_still_defers_for_identity(self) -> None:
+        # Explicit budget but no key: the served-name probe is still
+        # unauthenticated, so vLLM defers — but the discovered budget must NOT
+        # override the explicit one (apply_budget False).
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm", budget_tokens=4096,
+        )
+        with patch.object(
+            VLLMClient, "get_served_model_name", new_callable=AsyncMock,
+        ) as served:
+            _, ctx, lazy = await proxy._setup_external()
+        served.assert_not_awaited()
+        assert ctx.budget_tokens == 4096
+        assert lazy.deferred is True
+        assert lazy.apply_budget is False
+
+    @pytest.mark.asyncio
+    async def test_llamacpp_passthrough_with_budget_not_deferred(self) -> None:
+        # llama.cpp has no served-name probe, so an explicit budget leaves
+        # nothing to defer even without a key.
+        proxy = ProxyServer(backend_url="http://localhost:8080", budget_tokens=4096)
+        _, ctx, lazy = await proxy._setup_external()
+        assert lazy is None
+        assert ctx.budget_tokens == 4096
+
+    @pytest.mark.asyncio
+    async def test_static_key_is_eager_not_deferred(self) -> None:
+        proxy = ProxyServer(backend_url="http://localhost:8080", backend_api_key="K")
+        with patch.object(
+            LlamafileClient, "get_context_length",
+            new_callable=AsyncMock, return_value=32768,
+        ) as probe:
+            _, ctx, lazy = await proxy._setup_external()
+        probe.assert_awaited_once()  # static key authenticates the eager probe
+        assert lazy is None
+        assert ctx.budget_tokens == 32768
 
 
 class TestSetupManaged:
@@ -225,7 +311,7 @@ class TestSetupManaged:
             "forge.proxy.proxy.setup_backend",
             new_callable=AsyncMock, return_value=(mock_server, mock_ctx),
         ) as mock_setup:
-            client, ctx = await proxy._setup_managed()
+            client, ctx, _ = await proxy._setup_managed()
 
         assert isinstance(client, LlamafileClient)
         assert client.base_url == "http://localhost:8080/v1"
@@ -256,7 +342,7 @@ class TestSetupManaged:
             "forge.proxy.proxy.setup_backend",
             new_callable=AsyncMock, return_value=(MagicMock(), mock_ctx),
         ) as mock_setup:
-            client, _ = await proxy._setup_managed()
+            client, _, _ = await proxy._setup_managed()
 
         assert isinstance(client, VLLMClient)
         assert client.base_url == "http://localhost:8000/v1"
@@ -282,7 +368,7 @@ class TestSetupManaged:
             "forge.proxy.proxy.setup_backend",
             new_callable=AsyncMock, return_value=(MagicMock(), mock_ctx),
         ) as mock_setup:
-            client, _ = await proxy._setup_managed()
+            client, _, _ = await proxy._setup_managed()
         assert isinstance(client, OllamaClient)
         assert client._http.timeout.read == 1800.0
         kwargs = mock_setup.await_args.kwargs
@@ -304,7 +390,7 @@ class TestSetupManaged:
             "forge.proxy.proxy.setup_backend",
             new_callable=AsyncMock, return_value=(MagicMock(), mock_ctx),
         ) as mock_setup:
-            client, _ = await proxy._setup_managed()
+            client, _, _ = await proxy._setup_managed()
         assert isinstance(client, LlamafileClient)
         assert client.mode == "native"
         assert mock_setup.await_args.kwargs["mode"] == "native"
@@ -347,7 +433,7 @@ class TestBackendCapability:
     @pytest.mark.asyncio
     async def test_external_default_builds_native_client(self) -> None:
         proxy = ProxyServer(backend_url="http://localhost:8080", budget_tokens=8192)
-        client, _ = await proxy._setup_external()
+        client, _, _ = await proxy._setup_external()
         assert isinstance(client, LlamafileClient)
         assert client.mode == "native"
 
@@ -358,7 +444,7 @@ class TestBackendCapability:
             backend_capability="prompt",
             budget_tokens=8192,
         )
-        client, _ = await proxy._setup_external()
+        client, _, _ = await proxy._setup_external()
         assert isinstance(client, LlamafileClient)
         assert client.mode == "prompt"
 
@@ -375,7 +461,7 @@ class TestBackendCapability:
             "forge.proxy.proxy.setup_backend",
             new_callable=AsyncMock, return_value=(MagicMock(), mock_ctx),
         ) as mock_setup:
-            client, _ = await proxy._setup_managed()
+            client, _, _ = await proxy._setup_managed()
         assert isinstance(client, LlamafileClient)
         assert client.mode == "prompt"
         assert mock_setup.await_args.kwargs["mode"] == "native"

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -313,3 +313,127 @@ class TestSerialization:
         assert status == 200
         data = json.loads(response_body)
         assert data["choices"][0]["message"]["content"] == "ok"
+
+
+# ── Inbound credential threading (v0.8.0) ────────────────────
+
+
+async def _http_request_with_auth(port, body, auth_header):
+    """POST /v1/chat/completions with an extra Authorization header."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        body_bytes = json.dumps(body).encode()
+        request = (
+            f"POST /v1/chat/completions HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{port}\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Authorization: {auth_header}\r\n"
+            f"Content-Length: {len(body_bytes)}\r\n"
+            f"\r\n"
+        ).encode() + body_bytes
+        writer.write(request)
+        await writer.drain()
+        await asyncio.wait_for(reader.read(65536), timeout=10.0)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+async def _auth_server(serialize, backend_api_key_present=False):
+    """An HTTPServer fronting an Anthropic-wire backend, with a mock client."""
+    client = _mock_client(TextResponse(content="ok"))
+    ctx = ContextManager(strategy=NoCompact(), budget_tokens=8192)
+    srv = HTTPServer(
+        client=client,
+        context_manager=ctx,
+        host="127.0.0.1",
+        port=0,
+        serialize_requests=serialize,
+        backend_protocol="anthropic",
+        backend_api_key_present=backend_api_key_present,
+    )
+    await srv.start()
+    port = srv._server.sockets[0].getsockname()[1]
+    return srv, port, client
+
+
+async def _raw_request(port, header_lines, body):
+    """POST with arbitrary extra header lines; return (status, body_str)."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        body_bytes = json.dumps(body).encode()
+        extra = "".join(f"{line}\r\n" for line in header_lines)
+        request = (
+            f"POST /v1/chat/completions HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{port}\r\n"
+            f"Content-Type: application/json\r\n"
+            f"{extra}"
+            f"Content-Length: {len(body_bytes)}\r\n"
+            f"\r\n"
+        ).encode() + body_bytes
+        writer.write(request)
+        await writer.drain()
+        data = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+        text = data.decode("utf-8", errors="replace")
+        status = int(text.split("\r\n", 1)[0].split(" ", 2)[1])
+        start = text.find("\r\n\r\n")
+        return status, (text[start + 4:] if start >= 0 else "")
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+class TestInboundCredentialThreading:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("serialize", [False, True])
+    async def test_inbound_auth_relocated_to_backend_client(self, serialize):
+        # Both dispatch paths (direct and the serialized queue worker) must
+        # carry the inbound header to the handler. Source openai endpoint →
+        # anthropic backend: Bearer stripped, relocated to x-api-key.
+        srv, port, client = await _auth_server(serialize)
+        try:
+            await _http_request_with_auth(
+                port,
+                {"messages": [{"role": "user", "content": "hi"}]},
+                "Bearer INBOUND",
+            )
+            assert client.send.await_count == 1
+            assert client.send.call_args.kwargs["extra_headers"] == {"x-api-key": "INBOUND"}
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_auth_header_refused_400_no_secret(self):
+        # Two same-name Authorization headers must be refused (never pick a
+        # winner), as a 400 client error, with no secret in the response body.
+        srv, port, client = await _auth_server(serialize=False)
+        try:
+            status, resp_body = await _raw_request(
+                port,
+                ["Authorization: Bearer SECRET-ONE", "Authorization: Bearer SECRET-TWO"],
+                {"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert status == 400
+            assert "SECRET-ONE" not in resp_body
+            assert "SECRET-TWO" not in resp_body
+            client.send.assert_not_awaited()
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_inbound_plus_static_key_refused_400(self):
+        # Inbound credential + configured --backend-api-key → 400 client error.
+        srv, port, client = await _auth_server(
+            serialize=False, backend_api_key_present=True,
+        )
+        try:
+            status, resp_body = await _raw_request(
+                port,
+                ["Authorization: Bearer SECRET-INBOUND"],
+                {"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert status == 400
+            assert "SECRET-INBOUND" not in resp_body
+            client.send.assert_not_awaited()
+        finally:
+            await srv.stop()

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -577,17 +577,18 @@ class TestBackendErrorStatusMapping:
 class TestSecretHygiene:
     @pytest.mark.asyncio
     async def test_backend_error_body_secret_not_leaked_to_client(self):
-        # A backend that echoes the inbound auth header in its error body must
-        # not leak it back through the proxy's error response.
+        # A backend that echoes the inbound auth header in its raw error body
+        # must not leak it: the raw body rides exc.body (off the message), so the
+        # proxy returns only the safe "Backend returned <status>" summary.
         srv, port = await _error_server(
-            BackendError(500, "rejected Authorization: Bearer sk-leak-7777"),
+            BackendError(500, raw_body="rejected Authorization: Bearer sk-leak-7777"),
         )
         try:
             _, body = await _raw_request(
                 port, [], {"messages": [{"role": "user", "content": "hi"}]},
             )
             assert "sk-leak-7777" not in body
-            assert "[REDACTED]" in body
+            assert "Backend returned 500" in body  # safe status summary only
         finally:
             await srv.stop()
 

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -506,3 +506,104 @@ class TestDeferredDiscoveryStatusMapping:
             client.discover_backend_metadata.assert_awaited_once()
         finally:
             await srv.stop()
+
+
+# ── Codex review hardening (backend-error status + secret hygiene + CORS) ──
+
+
+async def _error_server(exc):
+    """An openai-wire server whose backend client.send raises ``exc``."""
+    client = _mock_client(TextResponse(content="x"))
+    client.send = AsyncMock(side_effect=exc)
+    ctx = ContextManager(strategy=NoCompact(), budget_tokens=8192)
+    srv = HTTPServer(
+        client=client, context_manager=ctx, host="127.0.0.1", port=0,
+        serialize_requests=False, backend_protocol="openai",
+    )
+    await srv.start()
+    return srv, srv._server.sockets[0].getsockname()[1]
+
+
+async def _raw_response(port, method, path):
+    """Return the full raw HTTP response string for a bodyless request."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        writer.write(
+            f"{method} {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\r\n".encode()
+        )
+        await writer.drain()
+        data = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+        return data.decode("utf-8", errors="replace")
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+class TestBackendErrorStatusMapping:
+    @pytest.mark.asyncio
+    async def test_backend_401_during_dispatch_maps_401(self):
+        srv, port = await _error_server(BackendError(401, "unauthorized"))
+        try:
+            status, _ = await _raw_request(
+                port, [], {"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert status == 401  # backend auth rejection is the caller's 401
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_backend_403_maps_401(self):
+        srv, port = await _error_server(BackendError(403, "forbidden"))
+        try:
+            status, _ = await _raw_request(
+                port, [], {"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert status == 401
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_backend_500_still_maps_502(self):
+        srv, port = await _error_server(BackendError(500, "boom"))
+        try:
+            status, _ = await _raw_request(
+                port, [], {"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert status == 502  # non-auth backend fault stays 502
+        finally:
+            await srv.stop()
+
+
+class TestSecretHygiene:
+    @pytest.mark.asyncio
+    async def test_backend_error_body_secret_not_leaked_to_client(self):
+        # A backend that echoes the inbound auth header in its error body must
+        # not leak it back through the proxy's error response.
+        srv, port = await _error_server(
+            BackendError(500, "rejected Authorization: Bearer sk-leak-7777"),
+        )
+        try:
+            _, body = await _raw_request(
+                port, [], {"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert "sk-leak-7777" not in body
+            assert "[REDACTED]" in body
+        finally:
+            await srv.stop()
+
+
+class TestCorsAllowsApiKey:
+    @pytest.mark.asyncio
+    async def test_preflight_allows_x_api_key(self):
+        srv, _, _ = await _auth_server(serialize=False)
+        port = srv._server.sockets[0].getsockname()[1]
+        try:
+            raw = await _raw_response(port, "OPTIONS", "/v1/chat/completions")
+            assert raw.startswith("HTTP/1.1 204")
+            allow = next(
+                l for l in raw.splitlines()
+                if l.lower().startswith("access-control-allow-headers")
+            )
+            assert "x-api-key" in allow.lower()
+        finally:
+            await srv.stop()

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock
 from forge.context.manager import ContextManager
 from forge.context.strategies import NoCompact
 from forge.core.workflow import TextResponse, ToolCall
+from forge.errors import BackendError
+from forge.proxy.handler import LazyDiscovery
 from forge.proxy.server import HTTPServer
 
 
@@ -435,5 +437,72 @@ class TestInboundCredentialThreading:
             assert status == 400
             assert "SECRET-INBOUND" not in resp_body
             client.send.assert_not_awaited()
+        finally:
+            await srv.stop()
+
+
+# ── Deferred discovery → status mapping (finding #2) ─────────
+
+
+async def _discovery_server(*, side_effect=None, budget=50000, apply_budget=True):
+    """An OpenAI-wire server whose first request triggers deferred discovery."""
+    client = _mock_client(TextResponse(content="ok"))
+    if side_effect is not None:
+        client.discover_backend_metadata = AsyncMock(side_effect=side_effect)
+    else:
+        client.discover_backend_metadata = AsyncMock(return_value=budget)
+    ctx = ContextManager(strategy=NoCompact(), budget_tokens=8192)
+    srv = HTTPServer(
+        client=client,
+        context_manager=ctx,
+        host="127.0.0.1",
+        port=0,
+        serialize_requests=False,
+        backend_protocol="openai",
+        lazy_discovery=LazyDiscovery(deferred=True, apply_budget=apply_budget),
+    )
+    await srv.start()
+    port = srv._server.sockets[0].getsockname()[1]
+    return srv, port, client, ctx
+
+
+class TestDeferredDiscoveryStatusMapping:
+    @pytest.mark.asyncio
+    async def test_auth_rejection_maps_401(self):
+        srv, port, client, _ = await _discovery_server(
+            side_effect=BackendError(401, "unauthorized"),
+        )
+        try:
+            status, _ = await _raw_request(
+                port, [], {"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert status == 401  # backend rejected the probe credential
+            client.send.assert_not_awaited()
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_backend_fault_maps_502(self):
+        srv, port, client, _ = await _discovery_server(
+            side_effect=BackendError(502, "backend unreachable"),
+        )
+        try:
+            status, _ = await _raw_request(
+                port, [], {"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert status == 502
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_success_applies_budget_and_serves_200(self):
+        srv, port, client, ctx = await _discovery_server(budget=50000)
+        try:
+            status, _ = await _raw_request(
+                port, [], {"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert status == 200
+            assert ctx.budget_tokens == 50000  # discovered budget latched
+            client.discover_backend_metadata.assert_awaited_once()
         finally:
             await srv.stop()

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -592,6 +592,57 @@ class TestSecretHygiene:
             await srv.stop()
 
 
+class TestStreamingErrorStatus:
+    """Pre-dispatch errors on a streaming request return a real HTTP status,
+    not a 200 + SSE error event (the SSE header is flushed only after the
+    credential + first-request discovery checks pass)."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_duplicate_auth_returns_400_not_200(self):
+        srv, port, client = await _auth_server(serialize=False)
+        try:
+            status, body = await _raw_request(
+                port,
+                ["Authorization: Bearer SECRET-ONE", "Authorization: Bearer SECRET-TWO"],
+                {"messages": [{"role": "user", "content": "hi"}], "stream": True},
+            )
+            assert status == 400  # real status, not 200 + an SSE error event
+            assert "SECRET-ONE" not in body and "SECRET-TWO" not in body
+            client.send.assert_not_awaited()
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_streaming_discovery_failure_returns_401_not_200(self):
+        srv, port, client, _ = await _discovery_server(
+            side_effect=BackendError(401, "unauthorized"),
+        )
+        try:
+            status, _ = await _raw_request(
+                port, [],
+                {"messages": [{"role": "user", "content": "hi"}], "stream": True},
+            )
+            assert status == 401  # deferred-discovery 401 surfaces before the stream
+            client.send.assert_not_awaited()
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_streaming_success_still_sse_200(self):
+        # The success path is unchanged: header flushes and SSE events stream.
+        srv, port, client = await _auth_server(serialize=False)
+        try:
+            status, body = await _raw_request(
+                port,
+                ["Authorization: Bearer GOODKEY"],
+                {"messages": [{"role": "user", "content": "hi"}], "stream": True},
+            )
+            assert status == 200
+            assert "data:" in body
+        finally:
+            await srv.stop()
+
+
 class TestCorsAllowsApiKey:
     @pytest.mark.asyncio
     async def test_preflight_allows_x_api_key(self):

--- a/tests/unit/test_vllm_client.py
+++ b/tests/unit/test_vllm_client.py
@@ -540,6 +540,76 @@ class TestGetServedModelName:
         assert await client.get_served_model_name() is None
 
 
+# ── discover_backend_metadata (deferred discovery) ─────────────
+
+
+class TestDiscoverBackendMetadata:
+    @pytest.mark.asyncio
+    async def test_discovers_budget_and_adopts_identity(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "google/gemma-4-26B-A4B-it", "max_model_len": 113000}],
+        })
+        budget = await client.discover_backend_metadata()
+        assert budget == 113000
+        # served id reaches the wire verbatim; registry key is the derived stem
+        assert client.model == "google/gemma-4-26B-A4B-it"
+        assert client.sampling_key == "gemma-4-26B-A4B-it"
+
+    @pytest.mark.asyncio
+    async def test_missing_id_raises(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"max_model_len": 113000}],  # no id
+        })
+        with pytest.raises(BackendError, match="missing id"):
+            await client.discover_backend_metadata()
+
+    @pytest.mark.asyncio
+    async def test_missing_max_model_len_raises(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "local-primary"}],  # no max_model_len
+        })
+        with pytest.raises(BackendError, match="missing max_model_len"):
+            await client.discover_backend_metadata()
+
+    @pytest.mark.asyncio
+    async def test_empty_data_raises(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({"data": []})
+        with pytest.raises(BackendError, match="no entries"):
+            await client.discover_backend_metadata()
+
+    @pytest.mark.asyncio
+    async def test_non_200_raises_with_status_code(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({"error": "unauthorized"}, status_code=401)
+        with pytest.raises(BackendError) as exc_info:
+            await client.discover_backend_metadata()
+        # status_code is carried so the proxy maps a 401 rejection → 401, not 502
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_connection_error_raises_502(self) -> None:
+        client = _make_client()
+        client._http.get.side_effect = httpx.ConnectError("refused")
+        with pytest.raises(BackendError) as exc_info:
+            await client.discover_backend_metadata()
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_extra_headers_threaded_into_probe(self) -> None:
+        client = _make_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "m", "max_model_len": 4096}],
+        })
+        extra = {"Authorization": "Bearer inbound-token"}
+        await client.discover_backend_metadata(extra_headers=extra)
+        # the per-request credential reaches the probe GET
+        assert client._http.get.await_args.kwargs["headers"] == client._request_headers(extra)
+
+
 # ── edge cases ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## v0.8.0 — first-class authentication

Makes auth a first-class citizen across all proxy modes and backends. forge now forwards **exactly one credential** to the backend — a static `--backend-api-key` or a single inbound auth header — relocating it across protocols (`x-api-key` ↔ `Authorization: Bearer`) when the frontend and backend differ. Gated OpenAI-compatible backends (LM Studio, hosted vLLM, service accounts) work without monkey-patching. Closes #119.

### What's in here
- **`--backend-api-key` / `FORGE_BACKEND_API_KEY`** — static credential sent to the backend in its native auth slot (the case where the caller sends nothing).
- **Cross-protocol relocation** — inbound `x-api-key` ↔ `Authorization: Bearer` rewritten to the backend's protocol (the SSO/forwarded-token case). Frontend protocol by path, backend by `--backend-protocol`.
- **Deferred backend discovery for gated external backends** — the context-length / served-model-name probe now runs on the **first request**, authenticated by that request's credential, instead of unauthenticated at startup (which 401'd and crashed boot against a gated backend). Managed mode and the Anthropic external path are unaffected.
- Secret hygiene: raw backend bodies are cut from error messages/logs (carried on `exc.body`, never echoed into a message or traceback).

### The one-credential rule
Exactly one credential reaches the backend, in its native slot. Two anywhere (static + inbound, or two inbound headers) → **400**. Zero against an auth-required backend → fail loud **401** (never an empty/garbage credential). **Ungated local backends are unchanged** — leave `--backend-api-key` unset, send no auth header; zero credentials is the normal local path and still works.

### BREAKING (scoped, see CHANGELOG)
- Credential handling for **auth-required** backends only: zero → loud 401, two → 400. Ungated/local backends: no change, no migration.
- Removed the silent `extra_headers`-overrides-`api_key` merge (now a two-credential 400). Undocumented prior behavior.

### Validation
- 1323 unit tests pass (deferral path + auth-hardening cases).
- Live-validated against a real `llama-server` (external + managed) and a self-contained gated smoke test in `scripts/smoke_test_proxy.py` (deferred startup no-crash, first-request credentialed discovery → 200, missing-cred → clean 401 with no latch, retry succeeds).
- Independently reviewed by Codex over two passes; all findings resolved.

### Related work
- **Closes #119** (LM Studio auth tokens) — the motivating request.
- **Supersedes the auth mechanism of #104** (@tcsenpai) and **#106** (@raymondzml), which first surfaced the hosted-backend auth gap. v0.8.0 generalizes their `--api-key` into `--backend-api-key` + cross-protocol relocation + the one-credential rule, and authenticates the discovery probe rather than silently falling back.
- Carry-over (not addressed here, tracked separately): #104's bare model-name `.stem` dot-truncation fix, and #106's `--model`-overrides-discovery behavior (overlaps #75). Worth preserving in a follow-up before those PRs close.

### Review history
9 implementation/review commits + 1 release commit. The auth design diverged from the original "forward all headers" sketch toward the stricter one-credential + relocation model documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
