### PR TITLE
fix(proxy): explicit --model overrides served-name discovery (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Then configure your client to use `http://localhost:8081/v1` as the API base URL
 **Backend compatibility:**
 
 - **Managed mode** spins up the backend for you. Supported backends: `llamaserver`, `llamafile`, `ollama`, `vllm` (use `--backend <name>` with `--gguf` for the GGUF-based backends, `--model-path` for vllm, or `--model` for ollama).
-- **External mode** is backend-agnostic — forge talks `POST /v1/chat/completions` to whatever you point `--backend-url` at, as long as it speaks the OpenAI schema. Tool calls must come back in OpenAI `tool_calls` format or in one of forge's rescue-parsed formats (Mistral `[TOOL_CALLS]`, Qwen `<tool_call>` XML, fenced JSON). For a vLLM server, add `--backend vllm` so the proxy adopts vLLM's `--served-model-name` (vLLM 404s on a mismatched `model` field, unlike llama.cpp).
+- **External mode** is backend-agnostic — forge talks `POST /v1/chat/completions` to whatever you point `--backend-url` at, as long as it speaks the OpenAI schema. Tool calls must come back in OpenAI `tool_calls` format or in one of forge's rescue-parsed formats (Mistral `[TOOL_CALLS]`, Qwen `<tool_call>` XML, fenced JSON). For a vLLM server, add `--backend vllm` so the proxy adopts vLLM's `--served-model-name` (vLLM 404s on a mismatched `model` field, unlike llama.cpp). An explicit `--model` overrides that discovery — for hosted multi-model gateways (one `/v1/models` endpoint listing many models), pin your model and skip discovery entirely: `--backend vllm --model <name> --budget-tokens <n> --backend-api-key <key>`.
 
 ### What proxy mode fortifies
 

--- a/docs/BACKEND_SETUP.md
+++ b/docs/BACKEND_SETUP.md
@@ -272,7 +272,7 @@ from forge.clients import VLLMClient
 client = VLLMClient(model_path="/path/to/awq-dir")  # or a HuggingFace repo id
 ```
 
-`model_path` is the canonical identity — a directory of safetensors/config or a HuggingFace repo id; its trailing segment is used for sampling-defaults lookup and the wire `model` field. Unlike llama.cpp, vLLM validates that field against its `--served-model-name`, so in proxy external mode forge auto-discovers the served name from `/v1/models` (pass `--backend vllm`).
+`model_path` is the canonical identity — a directory of safetensors/config or a HuggingFace repo id; its trailing segment is used for sampling-defaults lookup and the wire `model` field. Unlike llama.cpp, vLLM validates that field against its `--served-model-name`, so in proxy external mode forge auto-discovers the served name from `/v1/models` (pass `--backend vllm`). An explicit `--model` pins the identity and overrides discovery — the recipe for hosted multi-model gateways, where `/v1/models` lists many models and `data[0]` is arbitrary: `--backend vllm --model <name> --budget-tokens <n> --backend-api-key <key>` (with `--budget-tokens` set, no metadata probe runs at all; without it, the budget is discovered from the pinned model's own `/v1/models` entry and fails loud if the backend doesn't list it).
 
 ---
 

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -35,9 +35,10 @@ _SHARD_SUFFIX_RE = re.compile(r"-\d{5}-of-\d{5}$")
 
 # Known file extensions for GGUF/llamafile model files. These are the only
 # suffixes we strip from the filename when deriving the model identity string.
-# ``Path.stem`` is NOT used here because it strips everything after the *first*
-# dot, which silently truncates dotted model names (e.g. ``mimo-v2.5.gguf``
-# → ``mimo-v2`` instead of ``mimo-v2.5``).
+# ``Path.stem`` is NOT used here because it strips whatever follows the LAST
+# dot whether or not it is a real extension — harmless for actual
+# ``*.gguf``/``*.llamafile`` files, but it silently truncates BARE dotted
+# model names as they arrive in proxy mode (e.g. ``mimo-v2.5`` → ``mimo-v2``).
 _KNOWN_GGUF_EXTENSIONS: tuple[str, ...] = (".gguf", ".llamafile")
 
 

--- a/src/forge/clients/vllm.py
+++ b/src/forge/clients/vllm.py
@@ -480,12 +480,13 @@ class VLLMClient:
         one credentialed GET yields both — collapsing the two separate startup
         round-trips. When ``adopt_served_identity`` (construction), the served
         id is adopted into this client immediately (``_set_model_identity``);
-        when the identity was pinned explicitly it is never overwritten — a
-        pinned name absent from the served list only logs a warning (the
-        backend will reject a truly wrong name itself, loudly). The budget is
-        returned for the caller to apply to the context manager, read from the
-        pinned model's own entry when the backend lists it (on multi-model
-        gateways ``data[0]`` is arbitrary).
+        when the identity was pinned explicitly it is never overwritten. The
+        budget is returned for the caller to apply to the context manager —
+        when pinned, it is read from the pinned model's OWN entry (on
+        multi-model gateways ``data[0]`` is arbitrary), and a pinned name the
+        backend doesn't list raises: any other entry's budget would have wrong
+        provenance, and this method is only called when a budget is actually
+        needed (an explicit budget skips the probe entirely).
 
         Both fields are required: vLLM 404s every request without a valid served
         id, and a missing ``max_model_len`` leaves the budget undiscoverable —
@@ -514,21 +515,30 @@ class VLLMClient:
             self._set_model_identity(served)
         else:
             # Identity pinned at construction (proxy --model): never overwrite.
-            # Prefer the pinned model's own entry for budget metadata; warn when
-            # the backend doesn't list it, but honor the pin — the backend
-            # rejects a truly wrong name itself with a self-explanatory error.
-            pinned = next((m for m in models if m.get("id") == self.model), None)
-            if pinned is None:
-                logger.warning(
-                    "Explicit model %r is not among the backend-served ids %s; "
-                    "honoring the explicit name (the backend may reject it)",
-                    self.model, [m.get("id") for m in models],
+            # The budget must come from the pinned model's own entry — on a
+            # multi-model gateway data[0] is arbitrary, so a fallback budget
+            # would silently mis-size the context window. No entry, no budget:
+            # fail loud and name the escape hatch.
+            entry_or_none = next(
+                (m for m in models if m.get("id") == self.model), None,
+            )
+            if entry_or_none is None:
+                raise BackendError(
+                    500,
+                    f"explicit model {self.model!r} is not among the "
+                    f"{len(models)} backend-served ids (first ids: "
+                    f"{[m.get('id') for m in models[:5]]}); cannot discover its "
+                    "context budget — pass an explicit budget (--budget-tokens) "
+                    "or fix the model name",
                 )
-            entry = pinned or models[0]
+            entry = entry_or_none
 
         max_model_len = entry.get("max_model_len")
         if max_model_len is None:
             raise BackendError(
-                500, f"vLLM /v1/models entry missing max_model_len: {entry}",
+                500,
+                f"vLLM /v1/models entry missing max_model_len: {entry} — pass "
+                "an explicit budget (--budget-tokens) if the backend doesn't "
+                "report one",
             )
         return int(max_model_len)

--- a/src/forge/clients/vllm.py
+++ b/src/forge/clients/vllm.py
@@ -72,6 +72,7 @@ class VLLMClient:
         recommended_sampling: bool = False,
         api_key: str = "",
         extra_headers: dict[str, str] | None = None,
+        adopt_served_identity: bool = True,
     ) -> None:
         self.base_url = base_url
         # Two identity roles, set together (see _set_model_identity):
@@ -82,6 +83,11 @@ class VLLMClient:
         #   self.sampling_key — the derived registry-lookup key for
         #                       apply_sampling_defaults below (must be set first).
         self._set_model_identity(model_path)
+        # Whether external-mode discovery may replace the identity above with
+        # the backend-reported served name. The proxy sets this False when the
+        # user pinned an explicit --model (issue #122): an explicit identity is
+        # never overwritten, only warned about on mismatch.
+        self._adopt_served_identity = adopt_served_identity
 
         # Apply per-model recommended sampling defaults. Caller's explicit
         # (non-None) kwargs win over the map field-by-field.
@@ -472,9 +478,14 @@ class VLLMClient:
         vLLM exposes ``max_model_len`` (context budget) and the served model
         ``id`` (the wire ``model`` field it validates) on the same endpoint, so
         one credentialed GET yields both — collapsing the two separate startup
-        round-trips. The served id is adopted into this client immediately
-        (``_set_model_identity``), and the budget is returned for the caller to
-        apply to the context manager.
+        round-trips. When ``adopt_served_identity`` (construction), the served
+        id is adopted into this client immediately (``_set_model_identity``);
+        when the identity was pinned explicitly it is never overwritten — a
+        pinned name absent from the served list only logs a warning (the
+        backend will reject a truly wrong name itself, loudly). The budget is
+        returned for the caller to apply to the context manager, read from the
+        pinned model's own entry when the backend lists it (on multi-model
+        gateways ``data[0]`` is arbitrary).
 
         Both fields are required: vLLM 404s every request without a valid served
         id, and a missing ``max_model_len`` leaves the budget undiscoverable —
@@ -493,13 +504,27 @@ class VLLMClient:
         models = resp.json().get("data") or []
         if not models:
             raise BackendError(500, "vLLM /v1/models returned no entries")
-        entry = models[0]
 
-        served = entry.get("id")
-        if not served:
-            raise BackendError(500, f"vLLM /v1/models entry missing id: {entry}")
-        logger.info("Discovered vLLM served model name: %s", served)
-        self._set_model_identity(served)
+        if self._adopt_served_identity:
+            entry = models[0]
+            served = entry.get("id")
+            if not served:
+                raise BackendError(500, f"vLLM /v1/models entry missing id: {entry}")
+            logger.info("Discovered vLLM served model name: %s", served)
+            self._set_model_identity(served)
+        else:
+            # Identity pinned at construction (proxy --model): never overwrite.
+            # Prefer the pinned model's own entry for budget metadata; warn when
+            # the backend doesn't list it, but honor the pin — the backend
+            # rejects a truly wrong name itself with a self-explanatory error.
+            pinned = next((m for m in models if m.get("id") == self.model), None)
+            if pinned is None:
+                logger.warning(
+                    "Explicit model %r is not among the backend-served ids %s; "
+                    "honoring the explicit name (the backend may reject it)",
+                    self.model, [m.get("id") for m in models],
+                )
+            entry = pinned or models[0]
 
         max_model_len = entry.get("max_model_len")
         if max_model_len is None:

--- a/src/forge/proxy/__main__.py
+++ b/src/forge/proxy/__main__.py
@@ -35,7 +35,13 @@ def main() -> None:
     )
 
     # Managed mode options
-    parser.add_argument("--model", help="Model name (required for ollama)")
+    parser.add_argument(
+        "--model",
+        help="Model name (required for ollama). In external mode this pins the "
+             "wire model identity and overrides served-model-name discovery; on "
+             "hosted multi-model backends pair it with --budget-tokens (the "
+             "discovered budget comes from the backend's model list).",
+    )
     parser.add_argument("--gguf", help="Path to GGUF file (llamaserver/llamafile)")
     parser.add_argument("--model-path", help="Model directory or HF repo id (vllm, managed mode)")
     parser.add_argument("--backend-port", type=int, default=8080, help="Backend port (default: 8080)")

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -349,11 +349,16 @@ class ProxyServer:
             base = base + "/v1"
 
         if self._backend == "vllm":
+            # An explicit --model pins the wire identity (issue #122): it seeds
+            # (model, sampling_key) at construction and suppresses served-name
+            # adoption in both discovery paths below. Without it, "default" is
+            # a placeholder that discovery replaces.
             client = VLLMClient(
-                model_path="default",
+                model_path=self._model or "default",
                 base_url=base,
                 timeout=self._backend_timeout,
                 api_key=self._backend_api_key or "",
+                adopt_served_identity=self._model is None,
             )
         else:
             # llamaserver / llamafile / unspecified — OpenAI-compatible adapter.
@@ -373,11 +378,16 @@ class ProxyServer:
         # fail-fast. Pure passthrough (no static key) can't probe at startup —
         # the probe would be unauthenticated against a gated backend (finding
         # #2) — so defer it to the first request, which carries the credential.
-        # vLLM always needs deferral when passthrough (its served-identity probe
-        # is unauthenticated too); llama.cpp only needs it to discover a budget.
+        # vLLM needs deferral when passthrough (its served-identity probe is
+        # unauthenticated too) — unless the identity was pinned via --model, in
+        # which case there is nothing to discover beyond the budget; llama.cpp
+        # only needs it to discover a budget. Pinned identity + explicit budget
+        # means zero probes: passthrough vLLM starts serving with no metadata
+        # round-trip at all.
         static_key = bool(self._backend_api_key)
         defer = (not static_key) and (
-            self._budget_tokens is None or self._backend == "vllm"
+            self._budget_tokens is None
+            or (self._backend == "vllm" and self._model is None)
         )
 
         if defer:
@@ -392,11 +402,13 @@ class ProxyServer:
             )
         else:
             lazy_discovery = None
-            if self._backend == "vllm":
+            if self._backend == "vllm" and self._model is None:
                 # Unlike llama.cpp, vLLM validates the wire `model` field against
                 # its --served-model-name aliases (404 on mismatch). External
                 # mode has no model path to send, so discover the served identity
                 # from /v1/models instead of shipping the "default" placeholder.
+                # (Skipped entirely when --model pinned the identity: an explicit
+                # name is never overwritten by discovery.)
                 served = await client.get_served_model_name()
                 if served:
                     logger.info("Discovered vLLM served model name: %s", served)

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -138,6 +138,12 @@ class ProxyServer:
                 request is refused (one credential per request). Leave None for
                 pure inbound-credential passthrough.
         """
+        # A blank/whitespace --model is not an identity: normalize it to None
+        # BEFORE validation (mirrors --backend-api-key below) so the managed
+        # "requires model" check catches it as missing, and so the
+        # "or 'default'" fallbacks and the is-None pin logic (external vLLM,
+        # issue #122) can't disagree about whether a model was given.
+        model = model if (model and model.strip()) else None
         if backend_url is None and backend is None:
             raise ValueError("Provide either backend_url (external) or backend (managed)")
         if backend_protocol == "anthropic" and backend_url is None:
@@ -180,11 +186,7 @@ class ProxyServer:
 
         self._backend_url = backend_url
         self._backend = backend
-        # A blank/whitespace --model is not an identity: normalize it to None
-        # (mirrors --backend-api-key below) so the "or 'default'" fallbacks and
-        # the is-None pin logic (external vLLM, issue #122) can't disagree — an
-        # empty string must neither pin the placeholder nor suppress discovery.
-        self._model = model if (model and model.strip()) else None
+        self._model = model
         self._gguf = gguf
         self._model_path = model_path
         self._backend_port = backend_port
@@ -406,25 +408,35 @@ class ProxyServer:
             )
         else:
             lazy_discovery = None
-            if self._backend == "vllm" and self._model is None:
-                # Unlike llama.cpp, vLLM validates the wire `model` field against
-                # its --served-model-name aliases (404 on mismatch). External
-                # mode has no model path to send, so discover the served identity
-                # from /v1/models instead of shipping the "default" placeholder.
-                # (Skipped entirely when --model pinned the identity: an explicit
-                # name is never overwritten by discovery.)
-                served = await client.get_served_model_name()
-                if served:
-                    logger.info("Discovered vLLM served model name: %s", served)
-                    client._set_model_identity(served)
-                else:
-                    logger.warning(
-                        "Could not discover a served model name from %s/models; "
-                        "sending placeholder 'default' (vLLM will 404 if it "
-                        "validates the model field)",
-                        base,
-                    )
-            if self._budget_tokens is not None:
+            if self._backend == "vllm" and self._budget_tokens is None:
+                # One credentialed probe yields both roles: the served identity
+                # (adopted only when --model didn't pin it) and the context
+                # budget — read from the pinned model's own /v1/models entry
+                # when pinned, so a multi-model gateway's arbitrary data[0]
+                # never sizes the window.
+                budget = await client.discover_backend_metadata()
+            elif self._backend == "vllm":
+                budget = self._budget_tokens
+                if self._model is None:
+                    # Unlike llama.cpp, vLLM validates the wire `model` field
+                    # against its --served-model-name aliases (404 on mismatch).
+                    # External mode has no model path to send, so discover the
+                    # served identity from /v1/models instead of shipping the
+                    # "default" placeholder. (Skipped when --model pinned the
+                    # identity: an explicit name is never overwritten by
+                    # discovery.)
+                    served = await client.get_served_model_name()
+                    if served:
+                        logger.info("Discovered vLLM served model name: %s", served)
+                        client._set_model_identity(served)
+                    else:
+                        logger.warning(
+                            "Could not discover a served model name from "
+                            "%s/models; sending placeholder 'default' (vLLM "
+                            "will 404 if it validates the model field)",
+                            base,
+                        )
+            elif self._budget_tokens is not None:
                 budget = self._budget_tokens
             else:
                 ctx_len = await client.get_context_length()

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -180,7 +180,11 @@ class ProxyServer:
 
         self._backend_url = backend_url
         self._backend = backend
-        self._model = model
+        # A blank/whitespace --model is not an identity: normalize it to None
+        # (mirrors --backend-api-key below) so the "or 'default'" fallbacks and
+        # the is-None pin logic (external vLLM, issue #122) can't disagree — an
+        # empty string must neither pin the placeholder nor suppress discovery.
+        self._model = model if (model and model.strip()) else None
         self._gguf = gguf
         self._model_path = model_path
         self._backend_port = backend_port

--- a/tests/unit/test_proxy_handler.py
+++ b/tests/unit/test_proxy_handler.py
@@ -201,6 +201,34 @@ class TestLazyDiscovery:
         assert lazy.done is False
 
     @pytest.mark.asyncio
+    async def test_pinned_unlisted_probe_fails_loud_and_does_not_latch(self):
+        # A REAL pinned VLLMClient against a backend that lists other models:
+        # the fail-loud budget raise flows through run_lazy_discovery as a
+        # BackendDiscoveryError, the latch stays open (a later request — or a
+        # fixed --model / explicit --budget-tokens — retries), and the pin
+        # itself survives the failed probe.
+        from forge.clients.vllm import VLLMClient
+
+        client = VLLMClient(
+            model_path="nv-mistral-large",
+            base_url="http://test:8000/v1",
+            adopt_served_identity=False,
+        )
+        client._http = AsyncMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"data": [{"id": "other-model", "max_model_len": 8192}]}
+        client._http.get.return_value = resp
+        lazy = LazyDiscovery(deferred=True, apply_budget=True)
+        with pytest.raises(BackendDiscoveryError) as exc_info:
+            await handle_chat_completions(
+                _body(), client, _context_manager(), lazy_discovery=lazy,
+            )
+        assert exc_info.value.status_code == 500
+        assert lazy.done is False
+        assert client.model == "nv-mistral-large"
+
+    @pytest.mark.asyncio
     async def test_inbound_credential_threaded_to_probe(self):
         client = _discovery_client()
         lazy = LazyDiscovery(deferred=True, apply_budget=True)

--- a/tests/unit/test_proxy_proxy.py
+++ b/tests/unit/test_proxy_proxy.py
@@ -201,6 +201,52 @@ class TestSetupExternal:
         assert client.model == "default"
 
     @pytest.mark.asyncio
+    async def test_vllm_eager_pinned_no_budget_single_discovery_probe(self) -> None:
+        # Static key + pinned model + no explicit budget: the eager path takes
+        # ONE credentialed discover_backend_metadata probe (which honors the
+        # pin and reads the pinned entry's budget) — never the separate
+        # served-name/context-length probes that read data[0].
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm",
+            backend_api_key="K", model="nv-mistral-large",
+        )
+        with patch.object(
+            VLLMClient, "discover_backend_metadata",
+            new_callable=AsyncMock, return_value=128000,
+        ) as discover, patch.object(
+            VLLMClient, "get_served_model_name", new_callable=AsyncMock,
+        ) as served, patch.object(
+            VLLMClient, "get_context_length", new_callable=AsyncMock,
+        ) as ctxlen:
+            client, ctx, lazy = await proxy._setup_external()
+        discover.assert_awaited_once()
+        served.assert_not_awaited()
+        ctxlen.assert_not_awaited()
+        assert lazy is None
+        assert ctx.budget_tokens == 128000
+        assert client.model == "nv-mistral-large"
+
+    @pytest.mark.asyncio
+    async def test_vllm_eager_unpinned_no_budget_single_discovery_probe(self) -> None:
+        # Same single-probe collapse without a pin: identity adoption happens
+        # inside discover_backend_metadata (client-level tested).
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm",
+            backend_api_key="K",
+        )
+        with patch.object(
+            VLLMClient, "discover_backend_metadata",
+            new_callable=AsyncMock, return_value=113000,
+        ) as discover, patch.object(
+            VLLMClient, "get_served_model_name", new_callable=AsyncMock,
+        ) as served:
+            _, ctx, lazy = await proxy._setup_external()
+        discover.assert_awaited_once()
+        served.assert_not_awaited()
+        assert lazy is None
+        assert ctx.budget_tokens == 113000
+
+    @pytest.mark.asyncio
     async def test_vllm_empty_model_is_not_a_pin(self) -> None:
         # A blank --model is normalized away: discovery behaves exactly as if
         # no model was given (placeholder + adoption), instead of pinning

--- a/tests/unit/test_proxy_proxy.py
+++ b/tests/unit/test_proxy_proxy.py
@@ -16,6 +16,7 @@ from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
 from forge.clients.vllm import VLLMClient
 from forge.context.manager import ContextManager
+from forge.errors import BackendError
 from forge.proxy.proxy import ProxyServer
 from forge.server import BudgetMode
 
@@ -245,6 +246,23 @@ class TestSetupExternal:
         served.assert_not_awaited()
         assert lazy is None
         assert ctx.budget_tokens == 113000
+
+    @pytest.mark.asyncio
+    async def test_vllm_eager_pinned_unlisted_raise_propagates(self) -> None:
+        # The fail-loud raise for a pinned-but-unlisted model must surface at
+        # startup — _setup_external must not swallow it into a soft fallback.
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm",
+            backend_api_key="K", model="nv-mistral-large",
+        )
+        with patch.object(
+            VLLMClient, "discover_backend_metadata",
+            new_callable=AsyncMock,
+            side_effect=BackendError(
+                500, "explicit model 'nv-mistral-large' is not among ...",
+            ),
+        ), pytest.raises(BackendError, match="not among"):
+            await proxy._setup_external()
 
     @pytest.mark.asyncio
     async def test_vllm_empty_model_is_not_a_pin(self) -> None:

--- a/tests/unit/test_proxy_proxy.py
+++ b/tests/unit/test_proxy_proxy.py
@@ -201,6 +201,42 @@ class TestSetupExternal:
         assert client.model == "default"
 
     @pytest.mark.asyncio
+    async def test_vllm_explicit_model_skips_eager_adoption(self) -> None:
+        # Issue #122: an explicit --model pins the identity — the eager
+        # served-name probe is skipped entirely, never adopted over the pin.
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm",
+            budget_tokens=8192, backend_api_key="K",
+            model="nv-mistral-large",
+        )
+        with patch.object(
+            VLLMClient, "get_served_model_name", new_callable=AsyncMock,
+        ) as served:
+            client, _, _ = await proxy._setup_external()
+        served.assert_not_awaited()
+        assert client.model == "nv-mistral-large"
+        assert client.sampling_key == "nv-mistral-large"
+        assert client._adopt_served_identity is False
+
+    @pytest.mark.asyncio
+    async def test_vllm_explicit_repo_id_model_derives_registry_key(self) -> None:
+        # A pinned HF-repo-id reaches the wire verbatim; the registry key is
+        # the derived stem — the (model, sampling_key) invariant, applied at
+        # construction instead of served-name adoption.
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm",
+            budget_tokens=8192, backend_api_key="K",
+            model="google/gemma-4-26B-A4B-it",
+        )
+        with patch.object(
+            VLLMClient, "get_served_model_name", new_callable=AsyncMock,
+        ) as served:
+            client, _, _ = await proxy._setup_external()
+        served.assert_not_awaited()
+        assert client.model == "google/gemma-4-26B-A4B-it"
+        assert client.sampling_key == "gemma-4-26B-A4B-it"
+
+    @pytest.mark.asyncio
     async def test_url_v1_suffix_preserved(self) -> None:
         proxy = ProxyServer(backend_url="http://localhost:8080/v1", budget_tokens=8192)
         client, _, _ = await proxy._setup_external()
@@ -296,6 +332,45 @@ class TestExternalDeferredDiscovery:
         _, ctx, lazy = await proxy._setup_external()
         assert lazy is None
         assert ctx.budget_tokens == 4096
+
+    @pytest.mark.asyncio
+    async def test_vllm_passthrough_pinned_model_and_budget_not_deferred(self) -> None:
+        # Issue #122: pinned identity + explicit budget = nothing left to
+        # discover — passthrough vLLM starts with zero metadata probes.
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm",
+            budget_tokens=4096, model="nv-mistral-large",
+        )
+        with patch.object(
+            VLLMClient, "get_served_model_name", new_callable=AsyncMock,
+        ) as served, patch.object(
+            VLLMClient, "get_context_length", new_callable=AsyncMock,
+        ) as ctxlen:
+            client, ctx, lazy = await proxy._setup_external()
+        served.assert_not_awaited()
+        ctxlen.assert_not_awaited()
+        assert lazy is None
+        assert ctx.budget_tokens == 4096
+        assert client.model == "nv-mistral-large"
+
+    @pytest.mark.asyncio
+    async def test_vllm_passthrough_pinned_model_no_budget_still_defers(self) -> None:
+        # Pinned identity but no budget and no key: deferral still happens for
+        # budget discovery; the pin survives it (adopt_served_identity False).
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm",
+            model="nv-mistral-large",
+        )
+        with patch.object(
+            VLLMClient, "get_served_model_name", new_callable=AsyncMock,
+        ) as served:
+            client, _, lazy = await proxy._setup_external()
+        served.assert_not_awaited()
+        assert lazy is not None
+        assert lazy.deferred is True
+        assert lazy.apply_budget is True
+        assert client.model == "nv-mistral-large"
+        assert client._adopt_served_identity is False
 
     @pytest.mark.asyncio
     async def test_static_key_is_eager_not_deferred(self) -> None:

--- a/tests/unit/test_proxy_proxy.py
+++ b/tests/unit/test_proxy_proxy.py
@@ -201,6 +201,24 @@ class TestSetupExternal:
         assert client.model == "default"
 
     @pytest.mark.asyncio
+    async def test_vllm_empty_model_is_not_a_pin(self) -> None:
+        # A blank --model is normalized away: discovery behaves exactly as if
+        # no model was given (placeholder + adoption), instead of pinning
+        # "default" with adoption suppressed.
+        proxy = ProxyServer(
+            backend_url="http://localhost:8000", backend="vllm",
+            budget_tokens=8192, backend_api_key="K",
+            model="  ",
+        )
+        with patch.object(
+            VLLMClient, "get_served_model_name",
+            new_callable=AsyncMock, return_value="my-awq-model",
+        ):
+            client, _, _ = await proxy._setup_external()
+        assert client.model == "my-awq-model"
+        assert client._adopt_served_identity is True
+
+    @pytest.mark.asyncio
     async def test_vllm_explicit_model_skips_eager_adoption(self) -> None:
         # Issue #122: an explicit --model pins the identity — the eager
         # served-name probe is skipped entirely, never adopted over the pin.

--- a/tests/unit/test_vllm_client.py
+++ b/tests/unit/test_vllm_client.py
@@ -598,6 +598,89 @@ class TestDiscoverBackendMetadata:
             await client.discover_backend_metadata()
         assert exc_info.value.status_code == 502
 
+
+# ── discover_backend_metadata with a pinned identity (issue #122) ─────────────
+
+
+def _make_pinned_client(model: str = "nv-mistral-large") -> VLLMClient:
+    client = VLLMClient(
+        model_path=model,
+        base_url="http://test:8000/v1",
+        adopt_served_identity=False,
+    )
+    client._http = AsyncMock()
+    client._http.stream = MagicMock()
+    return client
+
+
+class TestDiscoverBackendMetadataPinned:
+    @pytest.mark.asyncio
+    async def test_pinned_identity_survives_discovery(self) -> None:
+        # Explicit --model wins: the served id is NOT adopted.
+        client = _make_pinned_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "some-other-model", "max_model_len": 32768}],
+        })
+        budget = await client.discover_backend_metadata()
+        assert budget == 32768
+        assert client.model == "nv-mistral-large"
+        assert client.sampling_key == "nv-mistral-large"
+
+    @pytest.mark.asyncio
+    async def test_budget_read_from_pinned_models_entry(self) -> None:
+        # Multi-model gateway: data[0] is arbitrary; the budget must come from
+        # the pinned model's own entry when the backend lists it.
+        client = _make_pinned_client()
+        client._http.get.return_value = _mock_response({
+            "data": [
+                {"id": "some-other-model", "max_model_len": 8192},
+                {"id": "nv-mistral-large", "max_model_len": 128000},
+            ],
+        })
+        assert await client.discover_backend_metadata() == 128000
+        assert client.model == "nv-mistral-large"
+
+    @pytest.mark.asyncio
+    async def test_pinned_absent_from_list_warns_and_keeps_pin(self, caplog) -> None:
+        client = _make_pinned_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "some-other-model", "max_model_len": 32768}],
+        })
+        with caplog.at_level("WARNING", logger="forge.clients.vllm"):
+            budget = await client.discover_backend_metadata()
+        assert budget == 32768
+        assert client.model == "nv-mistral-large"
+        assert any(
+            "not among the backend-served ids" in rec.message for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_pinned_present_in_list_no_warning(self, caplog) -> None:
+        client = _make_pinned_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "nv-mistral-large", "max_model_len": 128000}],
+        })
+        with caplog.at_level("WARNING", logger="forge.clients.vllm"):
+            await client.discover_backend_metadata()
+        assert not caplog.records
+
+    @pytest.mark.asyncio
+    async def test_pinned_missing_max_model_len_still_raises(self) -> None:
+        # Budget discovery stays loud when pinned: the escape hatch is an
+        # explicit --budget-tokens, not a guessed budget.
+        client = _make_pinned_client()
+        client._http.get.return_value = _mock_response({
+            "data": [{"id": "nv-mistral-large"}],
+        })
+        with pytest.raises(BackendError, match="missing max_model_len"):
+            await client.discover_backend_metadata()
+
+    def test_adopt_defaults_true(self) -> None:
+        # Direct (non-proxy) construction keeps today's adopt-on-discovery
+        # contract unless explicitly opted out.
+        client = _make_client()
+        assert client._adopt_served_identity is True
+
     @pytest.mark.asyncio
     async def test_extra_headers_threaded_into_probe(self) -> None:
         client = _make_client()

--- a/tests/unit/test_vllm_client.py
+++ b/tests/unit/test_vllm_client.py
@@ -616,10 +616,13 @@ def _make_pinned_client(model: str = "nv-mistral-large") -> VLLMClient:
 class TestDiscoverBackendMetadataPinned:
     @pytest.mark.asyncio
     async def test_pinned_identity_survives_discovery(self) -> None:
-        # Explicit --model wins: the served id is NOT adopted.
+        # Explicit --model wins: data[0]'s id is NOT adopted over the pin.
         client = _make_pinned_client()
         client._http.get.return_value = _mock_response({
-            "data": [{"id": "some-other-model", "max_model_len": 32768}],
+            "data": [
+                {"id": "some-other-model", "max_model_len": 8192},
+                {"id": "nv-mistral-large", "max_model_len": 32768},
+            ],
         })
         budget = await client.discover_backend_metadata()
         assert budget == 32768
@@ -641,27 +644,27 @@ class TestDiscoverBackendMetadataPinned:
         assert client.model == "nv-mistral-large"
 
     @pytest.mark.asyncio
-    async def test_pinned_absent_from_list_warns_and_keeps_pin(self, caplog) -> None:
+    async def test_pinned_absent_from_list_raises(self) -> None:
+        # Fail loud: another entry's max_model_len has wrong provenance, so a
+        # pinned model the backend doesn't list cannot yield a budget. The
+        # error names the escape hatch (--budget-tokens skips this probe).
         client = _make_pinned_client()
         client._http.get.return_value = _mock_response({
             "data": [{"id": "some-other-model", "max_model_len": 32768}],
         })
-        with caplog.at_level("WARNING", logger="forge.clients.vllm"):
-            budget = await client.discover_backend_metadata()
-        assert budget == 32768
+        with pytest.raises(BackendError, match="cannot discover its context budget"):
+            await client.discover_backend_metadata()
+        # The pin itself is untouched by the failed probe.
         assert client.model == "nv-mistral-large"
-        assert any(
-            "not among the backend-served ids" in rec.message for rec in caplog.records
-        )
 
     @pytest.mark.asyncio
-    async def test_pinned_present_in_list_no_warning(self, caplog) -> None:
+    async def test_pinned_present_in_list_succeeds_quietly(self, caplog) -> None:
         client = _make_pinned_client()
         client._http.get.return_value = _mock_response({
             "data": [{"id": "nv-mistral-large", "max_model_len": 128000}],
         })
         with caplog.at_level("WARNING", logger="forge.clients.vllm"):
-            await client.discover_backend_metadata()
+            assert await client.discover_backend_metadata() == 128000
         assert not caplog.records
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #122. In external proxy mode, an explicit `--model` now pins the vLLM wire identity and overrides served-model-name discovery — the fix for hosted multi-model gateways (surfaced by @raymondzml in #106), where `/v1/models` lists many models and adopting `data[0]` silently ignores the user's intended model.

## What changed

- **`VLLMClient` gains `adopt_served_identity` (default `True`)** — the default preserves today's contract for every existing caller; the proxy passes `False` iff `--model` was given. A pinned identity is set at construction through `_set_model_identity` (wire name verbatim, sampling key derived — the #75 invariant) and is never overwritten by discovery.
- **Eager and lazy discovery both honor the pin.** When a budget is needed, the eager static-key path now takes the same single credentialed `discover_backend_metadata` probe as the lazy path — identity + budget in one round-trip, with the budget read from the pinned model's **own** `/v1/models` entry (on multi-model gateways `data[0]` is arbitrary).
- **Fail loud, no silent fallbacks:** a pinned model absent from the served list raises (any other entry's `max_model_len` has wrong provenance and would silently mis-size compaction), naming `--budget-tokens` as the escape hatch; the missing-`max_model_len` error gains the same hint.
- **Zero-probe path:** pinned identity + explicit `--budget-tokens` on passthrough vLLM starts serving with no metadata round-trip at all — which also sidesteps discovery failures on gateways that don't report `max_model_len`.
- **Blank `--model` normalizes to `None`** before validation (mirrors the `--backend-api-key` idiom), so an empty string neither pins the placeholder nor suppresses discovery.
- **Docs:** `--model` CLI help, README, and BACKEND_SETUP now document the override and the hosted-gateway recipe (`--backend vllm --model <name> --budget-tokens <n> --backend-api-key <key>`).
- **Ride-along:** corrects the factually wrong `_KNOWN_GGUF_EXTENSIONS` comment from #123 (`Path.stem` strips after the *last* dot; only bare proxy-mode names were truncated, real `*.gguf` files never were).

## ⚠️ Breaking change for stale `--model` values

Previously a `--model` passed alongside `--backend vllm` in external mode was silently ignored (the client was constructed with a hardcoded `"default"` and discovery always won). After this change an explicit `--model` wins.

**If an existing launch script passes an incorrect or stale `--model` today, it currently works — discovery silently corrects it — and will start failing after this change** (e.g. `--model gpt-oss-120b` against a server serving `openai/gpt-oss-120b`). How it fails depends on the path: without an explicit budget, startup fails loud with an error that lists the actual served ids; with `--budget-tokens` set, no probe runs and the backend itself rejects the first request with its model-not-found error. Fix: correct the `--model` value, or drop the flag entirely to restore discovery-driven identity.

## Tests

Full suite: **1351 passed**.

Credit @raymondzml for the report (#106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
