### PR TITLE
fix(clients): capture reasoning on tool calls in OpenAICompatClient (#114)

### DIFF
--- a/src/forge/clients/openai_compat.py
+++ b/src/forge/clients/openai_compat.py
@@ -28,8 +28,10 @@ from forge.clients.base import (
     static_auth_present,
 )
 from forge.clients.sampling_defaults import apply_sampling_defaults
+from forge.core.reasoning import REASONING_MESSAGE_FIELDS
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
 from forge.errors import BackendError
+from forge.prompts.think_tags import extract_think_tags
 
 
 class OpenAICompatClient:
@@ -176,7 +178,44 @@ class OpenAICompatClient:
         )
 
     @staticmethod
-    def _parse_tool_calls(tool_calls: list[dict[str, Any]]) -> LLMResponse:
+    def _structured_reasoning(source: dict[str, Any]) -> str:
+        """First non-empty canonical reasoning field, or ''.
+
+        Ordered by ``REASONING_MESSAGE_FIELDS`` (``reasoning_content`` →
+        ``reasoning`` → ``reasoning_text``) so providers using different field
+        names all work.
+        """
+        for field in REASONING_MESSAGE_FIELDS:
+            val = source.get(field)
+            if val:
+                return str(val)
+        return ""
+
+    @staticmethod
+    def _resolve_reasoning(structured: str, content: str) -> str | None:
+        """Reasoning from a structured field or inline ``<think>`` tags — never
+        bare content.
+
+        This client is provider-agnostic (Groq/Together/OpenRouter/hosted
+        instruct), where a ``content`` preamble alongside a tool call is
+        routinely legitimate user-facing text, not chain-of-thought; labeling it
+        reasoning would mis-route a real assistant turn (and silently drop it
+        under ``reasoning_replay=none``, the default). So — unlike
+        vLLM/Ollama/llamafile — there is deliberately no raw-content fallback
+        (issue #114). Both send paths pass the same ``(structured, content)``
+        pair so they resolve identically.
+        """
+        if structured:
+            return structured
+        think, _ = extract_think_tags(content)
+        return think or None
+
+    @staticmethod
+    def _parse_tool_calls(
+        tool_calls: list[dict[str, Any]],
+        *,
+        reasoning: str | None = None,
+    ) -> LLMResponse:
         """Parse OpenAI ``tool_calls`` into ``ToolCall`` objects.
 
         Tool-call ``arguments`` arrive as JSON strings. Forge is fail-loud:
@@ -187,13 +226,18 @@ class OpenAICompatClient:
         ``ToolCall``; ``ResponseValidator``'s args-shape check then routes it
         through the tool-error channel, so the model self-corrects on the
         canonical tool-result channel rather than a trailing retry nudge.
+
+        ``reasoning`` is keyword-only with a default so existing positional
+        callers keep working; it is attached to the FIRST ToolCall only
+        (parity with vLLM/Ollama).
         """
         return [
             ToolCall(
                 tool=tc.get("function", {}).get("name", ""),
                 args=decode_tool_args(tc.get("function", {}).get("arguments")),
+                reasoning=reasoning if i == 0 else None,
             )
-            for tc in tool_calls
+            for i, tc in enumerate(tool_calls)
         ]
 
     # ── send ─────────────────────────────────────────────────────────
@@ -238,8 +282,18 @@ class OpenAICompatClient:
         msg = choices[0].get("message", {})
         tool_calls = msg.get("tool_calls")
         if tool_calls:
-            return self._parse_tool_calls(tool_calls)
-        return TextResponse(content=msg.get("content") or "")
+            return self._parse_tool_calls(
+                tool_calls,
+                reasoning=self._resolve_reasoning(
+                    self._structured_reasoning(msg), msg.get("content") or "",
+                ),
+            )
+        # No tool calls: strip inline <think> so the TextResponse carries clean,
+        # user-facing content (reasoning is only useful attached to a ToolCall).
+        # extract_think_tags returns the text unchanged when no tags are present,
+        # so plain preambles/answers survive verbatim.
+        _, content = extract_think_tags(msg.get("content") or "")
+        return TextResponse(content=content)
 
     # ── streaming ────────────────────────────────────────────────────
 
@@ -262,6 +316,7 @@ class OpenAICompatClient:
         body = self._build_body(messages, tools, sampling, stream=True, passthrough=passthrough)
 
         accumulated_content = ""
+        accumulated_reasoning = ""
         tool_calls: dict[int, dict[str, Any]] = {}
         usage: dict[str, Any] | None = None
 
@@ -297,6 +352,17 @@ class OpenAICompatClient:
                         accumulated_content += content
                         yield StreamChunk(type=ChunkType.TEXT_DELTA, content=content)
 
+                # Accumulate structured reasoning deltas across all canonical
+                # field names (a given provider streams reasoning under one name
+                # consistently). Do NOT yield a chunk for reasoning deltas —
+                # mirror vLLM, which only accumulates; content deltas keep being
+                # yielded as TEXT_DELTA even when they are <think> fragments, and
+                # are stripped only in the FINAL response.
+                for field in REASONING_MESSAGE_FIELDS:
+                    frag = delta.get(field)
+                    if frag:
+                        accumulated_reasoning += str(frag)
+
                 for tc in delta.get("tool_calls") or []:
                     idx = tc.get("index", 0)
                     slot = tool_calls.setdefault(
@@ -326,9 +392,19 @@ class OpenAICompatClient:
 
         if tool_calls:
             ordered = [tool_calls[i] for i in sorted(tool_calls)]
-            final: LLMResponse = self._parse_tool_calls(ordered)
+            # Resolve reasoning exactly like send(): a structured field wins,
+            # else inline <think> tags. Accumulating raw content across chunks
+            # and extracting once at the end handles <think> tags that straddle
+            # chunk boundaries, and multi-chunk structured reasoning deltas.
+            final: LLMResponse = self._parse_tool_calls(
+                ordered,
+                reasoning=self._resolve_reasoning(
+                    accumulated_reasoning, accumulated_content,
+                ),
+            )
         else:
-            final = TextResponse(content=accumulated_content)
+            _, text = extract_think_tags(accumulated_content)
+            final = TextResponse(content=text)
         yield StreamChunk(type=ChunkType.FINAL, response=final)
 
     async def get_context_length(self) -> int | None:

--- a/src/forge/clients/openai_compat.py
+++ b/src/forge/clients/openai_compat.py
@@ -184,11 +184,24 @@ class OpenAICompatClient:
         Ordered by ``REASONING_MESSAGE_FIELDS`` (``reasoning_content`` →
         ``reasoning`` → ``reasoning_text``) so providers using different field
         names all work.
+
+        Fail-loud on a non-string reasoning value (some providers ship
+        structured block lists): silently ``str()``-coercing it would turn a
+        Python repr into chain-of-thought and replay it to the model under
+        ``full``/``keep-last``.
         """
         for field in REASONING_MESSAGE_FIELDS:
             val = source.get(field)
-            if val:
-                return str(val)
+            if not val:
+                continue
+            if not isinstance(val, str):
+                raise BackendError(
+                    500,
+                    f"reasoning field {field!r} is {type(val).__name__}, not a "
+                    f"string: {val!r} — refusing to coerce it into replayable "
+                    "chain-of-thought",
+                )
+            return val
         return ""
 
     @staticmethod
@@ -360,8 +373,18 @@ class OpenAICompatClient:
                 # are stripped only in the FINAL response.
                 for field in REASONING_MESSAGE_FIELDS:
                     frag = delta.get(field)
-                    if frag:
-                        accumulated_reasoning += str(frag)
+                    if not frag:
+                        continue
+                    if not isinstance(frag, str):
+                        # Same fail-loud rule as _structured_reasoning: never
+                        # repr-coerce provider block structures into replayable
+                        # chain-of-thought.
+                        raise BackendError(
+                            500,
+                            f"streamed reasoning field {field!r} is "
+                            f"{type(frag).__name__}, not a string: {frag!r}",
+                        )
+                    accumulated_reasoning += frag
 
                 for tc in delta.get("tool_calls") or []:
                     idx = tc.get("index", 0)

--- a/tests/unit/test_openai_compat_client.py
+++ b/tests/unit/test_openai_compat_client.py
@@ -396,6 +396,46 @@ class TestSend:
         assert result[1].reasoning is None
 
     @pytest.mark.asyncio
+    async def test_empty_string_structured_field_falls_through_to_tags(self) -> None:
+        # An empty-string structured field is not a capture: resolution falls
+        # through to <think> extraction (the falsy-skip is load-bearing).
+        client = _make_client()
+        client._http.post.return_value = _mock_response({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "reasoning": "",
+                    "content": "<think>plan</think>",
+                    "tool_calls": [{
+                        "function": {"name": "get_pricing", "arguments": '{"part": "X"}'},
+                    }],
+                }
+            }]
+        })
+        result = await client.send([{"role": "user", "content": "test"}], tools=[_make_spec()])
+        assert isinstance(result, list)
+        assert result[0].reasoning == "plan"
+
+    @pytest.mark.asyncio
+    async def test_non_string_reasoning_field_raises(self) -> None:
+        # Fail loud on provider block-structured reasoning: never repr-coerce
+        # it into replayable chain-of-thought.
+        client = _make_client()
+        client._http.post.return_value = _mock_response({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "reasoning": [{"type": "text", "text": "block"}],
+                    "tool_calls": [{
+                        "function": {"name": "get_pricing", "arguments": '{"part": "X"}'},
+                    }],
+                }
+            }]
+        })
+        with pytest.raises(BackendError, match="not a string"):
+            await client.send([{"role": "user", "content": "test"}], tools=[_make_spec()])
+
+    @pytest.mark.asyncio
     async def test_records_usage(self) -> None:
         client = _make_client()
         client._http.post.return_value = _mock_response({
@@ -616,6 +656,87 @@ class TestSendStream:
         assert len(finals) == 1
         assert isinstance(finals[0].response, TextResponse)
         assert finals[0].response.content == "The answer is 42."
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", ["reasoning_content", "reasoning_text"])
+    async def test_stream_other_canonical_fields_accumulate(self, field) -> None:
+        # The stream loop's own field walk covers every canonical name, not
+        # just "reasoning" (pins the multi-field loop against refactor).
+        client = _make_client()
+        lines = [
+            'data: ' + json.dumps({"choices": [{"delta": {field: "step one "}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {field: "step two"}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "function": {"name": "get_pricing", "arguments": '{"part": "X"}'}}
+            ]}}]}),
+            'data: [DONE]',
+        ]
+        client._http.stream.return_value = _MockStreamResponse(lines)
+        chunks = [c async for c in client.send_stream(
+            [{"role": "user", "content": "test"}], tools=[_make_spec()]
+        )]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert isinstance(finals[0].response, list)
+        assert finals[0].response[0].reasoning == "step one step two"
+
+    @pytest.mark.asyncio
+    async def test_stream_structured_preferred_over_content_tags(self) -> None:
+        # Streaming precedence mirrors send(): structured deltas win over
+        # <think> tags accumulated in content.
+        client = _make_client()
+        lines = [
+            'data: ' + json.dumps({"choices": [{"delta": {"reasoning": "structured"}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"content": "<think>inline</think>"}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "function": {"name": "get_pricing", "arguments": '{"part": "X"}'}}
+            ]}}]}),
+            'data: [DONE]',
+        ]
+        client._http.stream.return_value = _MockStreamResponse(lines)
+        chunks = [c async for c in client.send_stream(
+            [{"role": "user", "content": "test"}], tools=[_make_spec()]
+        )]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert isinstance(finals[0].response, list)
+        assert finals[0].response[0].reasoning == "structured"
+
+    @pytest.mark.asyncio
+    async def test_stream_reasoning_first_tool_call_only(self) -> None:
+        # Streaming parity with send(): reasoning lands on the first ToolCall
+        # only; siblings get None.
+        client = _make_client()
+        lines = [
+            'data: ' + json.dumps({"choices": [{"delta": {"reasoning": "because"}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "function": {"name": "get_pricing", "arguments": '{"part": "A"}'}},
+                {"index": 1, "function": {"name": "get_pricing", "arguments": '{"part": "B"}'}},
+            ]}}]}),
+            'data: [DONE]',
+        ]
+        client._http.stream.return_value = _MockStreamResponse(lines)
+        chunks = [c async for c in client.send_stream(
+            [{"role": "user", "content": "test"}], tools=[_make_spec()]
+        )]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert isinstance(finals[0].response, list)
+        assert finals[0].response[0].reasoning == "because"
+        assert finals[0].response[1].reasoning is None
+
+    @pytest.mark.asyncio
+    async def test_stream_non_string_reasoning_raises(self) -> None:
+        # Fail loud in streaming too: a block-structured reasoning delta is
+        # never repr-coerced into chain-of-thought.
+        client = _make_client()
+        lines = [
+            'data: ' + json.dumps({"choices": [{"delta": {
+                "reasoning": [{"type": "text", "text": "block"}],
+            }}]}),
+            'data: [DONE]',
+        ]
+        client._http.stream.return_value = _MockStreamResponse(lines)
+        with pytest.raises(BackendError, match="not a string"):
+            async for _ in client.send_stream([{"role": "user", "content": "test"}]):
+                pass
 
     @pytest.mark.asyncio
     async def test_stream_http_error_raises(self) -> None:

--- a/tests/unit/test_openai_compat_client.py
+++ b/tests/unit/test_openai_compat_client.py
@@ -262,6 +262,140 @@ class TestSend:
         assert exc.value.status_code == 401
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", ["reasoning_content", "reasoning", "reasoning_text"])
+    async def test_structured_reasoning_field_captured(self, field) -> None:
+        # #114: reasoning from any canonical structured field is attached to
+        # the ToolCall (covers all of REASONING_MESSAGE_FIELDS).
+        client = _make_client()
+        client._http.post.return_value = _mock_response({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    field: "I should check the price first.",
+                    "tool_calls": [{
+                        "function": {"name": "get_pricing", "arguments": '{"part": "X"}'},
+                    }],
+                }
+            }]
+        })
+        result = await client.send([{"role": "user", "content": "test"}], tools=[_make_spec()])
+        assert isinstance(result, list)
+        assert result[0].reasoning == "I should check the price first."
+
+    @pytest.mark.asyncio
+    async def test_extracts_think_tags_from_content_with_tool_call(self) -> None:
+        # #114: no structured field, thinking inline in content <think> tags is
+        # captured as reasoning.
+        client = _make_client()
+        client._http.post.return_value = _mock_response({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "<think>plan</think>",
+                    "tool_calls": [{
+                        "function": {"name": "get_pricing", "arguments": '{"part": "X"}'},
+                    }],
+                }
+            }]
+        })
+        result = await client.send([{"role": "user", "content": "test"}], tools=[_make_spec()])
+        assert isinstance(result, list)
+        assert result[0].reasoning == "plan"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_field_preferred_over_content_tags(self) -> None:
+        # Structured field wins over <think> tags in content.
+        client = _make_client()
+        client._http.post.return_value = _mock_response({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "<think>inline</think>",
+                    "reasoning": "structured",
+                    "tool_calls": [{
+                        "function": {"name": "get_pricing", "arguments": '{"part": "X"}'},
+                    }],
+                }
+            }]
+        })
+        result = await client.send([{"role": "user", "content": "test"}], tools=[_make_spec()])
+        assert result[0].reasoning == "structured"
+
+    @pytest.mark.asyncio
+    async def test_content_preamble_not_treated_as_reasoning(self) -> None:
+        # #114 NEGATIVE (locked, no raw-content fallback): a plain content
+        # preamble alongside a tool call — no structured field, no <think>
+        # tags — must NOT be captured as reasoning. Labeling hosted-provider
+        # preambles as reasoning would mis-route a real assistant turn.
+        client = _make_client()
+        client._http.post.return_value = _mock_response({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Let me look that up.",
+                    "tool_calls": [{
+                        "function": {"name": "get_pricing", "arguments": '{"part": "X"}'},
+                    }],
+                }
+            }]
+        })
+        result = await client.send([{"role": "user", "content": "test"}], tools=[_make_spec()])
+        assert isinstance(result, list)
+        assert result[0].reasoning is None
+
+    @pytest.mark.asyncio
+    async def test_think_tags_stripped_from_text_response(self) -> None:
+        # Bare text (no tool call): <think> tags are stripped from the
+        # TextResponse content (parity with vLLM/Ollama).
+        client = _make_client()
+        client._http.post.return_value = _mock_response({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "<think>x</think>The answer is 42.",
+            }}]
+        })
+        result = await client.send([{"role": "user", "content": "test"}])
+        assert isinstance(result, TextResponse)
+        assert result.content == "The answer is 42."
+
+    @pytest.mark.asyncio
+    async def test_plain_preamble_text_response_survives(self) -> None:
+        # A plain text reply with no tags is returned verbatim (strip only
+        # removes tags — content survives).
+        client = _make_client()
+        client._http.post.return_value = _mock_response({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "Let me look that up.",
+            }}]
+        })
+        result = await client.send([{"role": "user", "content": "test"}])
+        assert isinstance(result, TextResponse)
+        assert result.content == "Let me look that up."
+
+    @pytest.mark.asyncio
+    async def test_reasoning_attached_to_first_tool_call_only(self) -> None:
+        # Reasoning is attached to the first ToolCall only; siblings get None.
+        client = _make_client()
+        client._http.post.return_value = _mock_response({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "reasoning": "because",
+                    "tool_calls": [
+                        {"function": {"name": "get_pricing", "arguments": '{"part": "A"}'}},
+                        {"function": {"name": "get_pricing", "arguments": '{"part": "B"}'}},
+                    ],
+                }
+            }]
+        })
+        result = await client.send([{"role": "user", "content": "test"}], tools=[_make_spec()])
+        assert isinstance(result, list)
+        assert result[0].reasoning == "because"
+        assert result[1].reasoning is None
+
+    @pytest.mark.asyncio
     async def test_records_usage(self) -> None:
         client = _make_client()
         client._http.post.return_value = _mock_response({
@@ -396,6 +530,92 @@ class TestSendStream:
         assert len(finals) == 1
         assert isinstance(finals[0].response, list)
         assert finals[0].response[0].args == {"part": "X9"}
+
+    @pytest.mark.asyncio
+    async def test_accumulates_reasoning_across_deltas(self) -> None:
+        # #114 (streaming): structured reasoning deltas accumulate across chunks
+        # and land on the FINAL tool call's reasoning.
+        client = _make_client()
+        lines = [
+            'data: ' + json.dumps({"choices": [{"delta": {"reasoning": "Let me "}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"reasoning": "think... "}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "function": {"name": "get_pricing", "arguments": '{"part": "X"}'}}
+            ]}}]}),
+            'data: [DONE]',
+        ]
+        client._http.stream.return_value = _MockStreamResponse(lines)
+        chunks = [c async for c in client.send_stream(
+            [{"role": "user", "content": "test"}], tools=[_make_spec()]
+        )]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(finals) == 1
+        result = finals[0].response
+        assert isinstance(result, list)
+        assert result[0].reasoning == "Let me think... "
+
+    @pytest.mark.asyncio
+    async def test_stream_extracts_think_tags_from_content_with_tool_call(self) -> None:
+        # #114 (streaming): <think> tags straddling chunk boundaries are
+        # accumulated then extracted once at the end.
+        client = _make_client()
+        lines = [
+            'data: ' + json.dumps({"choices": [{"delta": {"content": "<think>inline "}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"content": "plan</think>"}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "function": {"name": "get_pricing", "arguments": '{"part": "X"}'}}
+            ]}}]}),
+            'data: [DONE]',
+        ]
+        client._http.stream.return_value = _MockStreamResponse(lines)
+        chunks = [c async for c in client.send_stream(
+            [{"role": "user", "content": "test"}], tools=[_make_spec()]
+        )]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(finals) == 1
+        result = finals[0].response
+        assert isinstance(result, list)
+        assert result[0].reasoning == "inline plan"
+
+    @pytest.mark.asyncio
+    async def test_stream_content_preamble_not_treated_as_reasoning(self) -> None:
+        # #114 NEGATIVE (streaming): plain content deltas (no tags, no
+        # structured field) alongside a tool call → reasoning stays None.
+        client = _make_client()
+        lines = [
+            'data: ' + json.dumps({"choices": [{"delta": {"content": "Let me "}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"content": "look that up."}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"tool_calls": [
+                {"index": 0, "function": {"name": "get_pricing", "arguments": '{"part": "X"}'}}
+            ]}}]}),
+            'data: [DONE]',
+        ]
+        client._http.stream.return_value = _MockStreamResponse(lines)
+        chunks = [c async for c in client.send_stream(
+            [{"role": "user", "content": "test"}], tools=[_make_spec()]
+        )]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(finals) == 1
+        result = finals[0].response
+        assert isinstance(result, list)
+        assert result[0].reasoning is None
+
+    @pytest.mark.asyncio
+    async def test_stream_strips_think_tags_from_text_response(self) -> None:
+        # #114 (streaming): with no tool call, <think> tags are stripped from
+        # the FINAL TextResponse content.
+        client = _make_client()
+        lines = [
+            'data: ' + json.dumps({"choices": [{"delta": {"content": "<think>x</think>"}}]}),
+            'data: ' + json.dumps({"choices": [{"delta": {"content": "The answer is 42."}}]}),
+            'data: [DONE]',
+        ]
+        client._http.stream.return_value = _MockStreamResponse(lines)
+        chunks = [c async for c in client.send_stream([{"role": "user", "content": "test"}])]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(finals) == 1
+        assert isinstance(finals[0].response, TextResponse)
+        assert finals[0].response.content == "The answer is 42."
 
     @pytest.mark.asyncio
     async def test_stream_http_error_raises(self) -> None:


### PR DESCRIPTION
## Summary

Closes #114. `OpenAICompatClient` now captures reasoning/thinking content on tool calls, completing the #110 parity work (#113 covered vLLM + Ollama).

Previously, reasoning models behind OpenAI-compatible endpoints (Groq, Together, OpenRouter, …) silently lost their chain-of-thought on every tool call: `ToolCall.reasoning` was never populated, so no REASONING message reached the runner and reasoning replay (`full`/`keep-last`) had nothing to replay.

## Design

- **Reasoning is captured only from canonical structured fields or `<think>` tags — no raw-content fallback.** `_structured_reasoning` walks `REASONING_MESSAGE_FIELDS` (`reasoning_content` → `reasoning` → `reasoning_text`) since providers vary in field naming; `_resolve_reasoning` applies precedence: structured field, else `<think>` extraction, else `None`. Unlike the local-model clients, a bare content preamble alongside a tool call is *not* treated as reasoning — on hosted providers that text is routinely a legitimate user-facing message, and mislabeling it would mis-route (and under `reasoning_replay=none`, drop) a real assistant turn.
- **Streaming**: reasoning deltas accumulate across chunks and resolution happens once at stream end, so `<think>` tags straddling chunk boundaries are handled without incremental tag parsing.
- **Non-string reasoning values raise `BackendError`** (some providers ship structured block lists) rather than being coerced into replayable text.
- Reasoning attaches to the first `ToolCall` only; `<think>` tags are stripped from `TextResponse` content; `_parse_tool_calls` gains a keyword-only `reasoning` param, so existing callers are unchanged.

No downstream changes needed — `ToolCall.reasoning` flows through the runner identically regardless of the producing client. The proxy is unaffected (it never constructs this client).

## Behavior change

`TextResponse` content from this client previously carried `<think>` tags verbatim; it is now stripped, matching every other client.

## Tests

20 new tests covering structured capture across all three field names (send + stream), `<think>` capture including chunk-straddling, structured-over-tags precedence, the negative no-fallback cases in both modes, first-ToolCall-only attachment, tag-stripping vs verbatim text, empty-string field fall-through, and the non-string failure. Full suite: 1371 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
