### PR TITLE
fix(llamafile): rescue tool calls from malformed tool-call 500s instead of leaking error JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to forge are documented here.
 
+## [0.8.1] — 2026-07-10
+
+A bug-fix release for the llamafile backend. When llama.cpp's tool-call parser rejects malformed model output with a 500, the raw error JSON no longer leaks into the conversation as assistant text — complete tool calls are rescued out of the error body and executed, and unrecoverable ones trigger a clean re-sample nudge.
+
+### Added
+- **Tool-call rescue from malformed-500 bodies.** llama.cpp's `Failed to parse input` message embeds the rejected generation; forge now leniently re-parses `<tool_call>` blocks out of it (Qwen-coder XML format) and returns each block that names a tool from the request's `tools` array as a real `ToolCall` — deduped, with parameters coerced to their declared schema types. Skeleton/preview blocks are passed through too: dispatch rejects them with a `[ToolError]` on the tool channel, the canonical corrective signal, while complete calls simply execute. Unknown tool names are never fabricated. Rescues are counted on `LlamafileClient.rescued_tool_calls` and logged, so rescued runs stay auditable.
+
+### Fixed
+- **Malformed tool-call 500s no longer leak error JSON into the conversation.** When llama.cpp rejects a malformed or incomplete tool call and nothing can be rescued from the body, forge returns a targeted retry nudge (naming the stutter pattern when a `<tool_call>` block was visible, generic otherwise) so the retry loop re-samples a clean call. Previously the raw 500 body was echoed back as if the model had said it.
+
+### Changed
+- **Arbitrary llamafile 500s now fail loud.** A 500 that is *not* a tool-call parse rejection raises `BackendError` instead of being returned as a `TextResponse` carrying the error body — genuine backend failures now cascade, matching the other clients, rather than entering the conversation as model text.
+
 ## [0.8.0] — 2026-06-27
 
 First-class authentication across all proxy modes and backends. forge now forwards exactly one credential to the backend — a static `--backend-api-key` or a single inbound auth header — relocating it across protocols (`x-api-key` ↔ `Authorization: Bearer`) when the frontend and backend differ. Gated OpenAI-compatible backends (LM Studio, hosted vLLM, service accounts) work without monkey-patching. Closes #119.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forge-guardrails"
-version = "0.8.0"
+version = "0.8.1"
 description = "A reliability layer for self-hosted LLM tool-calling. Guardrails, context management, and backend adapters for multi-step agentic workflows."
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -60,10 +60,12 @@ _MALFORMED_TOOL_CALL_RETRY_TEXT = (
     "single, complete, well-formed tool call.)"
 )
 
-# Used only when the 500 body demonstrably contains <tool_call> block(s) that
-# could not be rescued — i.e. we KNOW the model emitted a skeleton/preview call
-# (the write-stutter). A malformed-500 without visible blocks keeps the generic
-# text above; we don't name a stutter we haven't seen.
+# Used only when the 500 body demonstrably contains <tool_call> block(s) but
+# none re-parse to a tool from the request (mangled syntax or unknown tool
+# names) — i.e. we KNOW the model emitted a defective call block. A
+# malformed-500 without visible blocks keeps the generic text above; we don't
+# name a stutter we haven't seen. Parseable blocks — skeletons included — are
+# returned as real ToolCalls instead (see _rescue_tool_calls).
 _STUTTER_RETRY_TEXT = (
     "(The previous response contained a malformed tool-call block — a "
     "preview/skeleton call missing its required parameters, or a duplicated "
@@ -133,14 +135,20 @@ def _rescue_tool_calls(
     error_body: str,
     tools_array: list[dict[str, Any]] | None,
 ) -> tuple[list[ToolCall], bool]:
-    """Salvage complete, valid tool calls from a malformed-tool-call 500 body.
+    """Leniently re-parse tool calls out of a malformed-tool-call 500 body.
 
-    Returns ``(calls, saw_blocks)``. A block is rescued only if it strictly
-    parses, names a tool present in the request's ``tools`` array, and carries
-    every required parameter (skeleton/preview blocks fail this by
-    construction). Exact-duplicate calls are deduped. ``saw_blocks`` reports
-    whether any ``<tool_call>`` block was visible at all — it selects the
-    stutter-specific retry text when rescue comes up empty.
+    Returns ``(calls, saw_blocks)``. Every block that parses and names a tool
+    present in the request's ``tools`` array is returned — including
+    skeleton/preview blocks missing required parameters. Validity is decided
+    downstream: the ResponseValidator and the runner's ``fn(**args)`` dispatch
+    reject a skeleton with a ``[ToolError] TypeError`` on the tool channel
+    (the canonical corrective signal), while complete calls simply execute.
+    Unknown tool names are never returned (nothing we can't check against the
+    request), exact duplicates are deduped, and param values are coerced to
+    their declared schema types where possible (kept as raw strings when
+    coercion fails — the tool decides). ``saw_blocks`` reports whether any
+    ``<tool_call>`` block was visible at all — it selects the
+    stutter-specific retry text when parsing comes up empty.
     """
     try:
         message = json.loads(error_body).get("error", {}).get("message", "")
@@ -157,17 +165,13 @@ def _rescue_tool_calls(
         spec = requirements.get(name)
         if spec is None:
             continue  # unknown tool — never fabricate a call we can't check
-        required, types = spec
+        _required, types = spec
         args: dict[str, Any] = {}
-        valid = True
         for key, raw_value in _TOOL_PARAM_RE.findall(params_text):
             try:
                 args[key] = _coerce_param(raw_value, types.get(key))
             except ValueError:
-                valid = False
-                break
-        if not valid or not required.issubset(args):
-            continue  # skeleton or mangled block — nothing to execute
+                args[key] = raw_value
         dedupe_key = (name, json.dumps(args, sort_keys=True, default=str))
         if dedupe_key in seen:
             continue
@@ -556,17 +560,19 @@ class LlamafileClient:
                 async for line in response.aiter_lines():
                     error_body += line
                 if _is_malformed_tool_call_500(error_body):
-                    # First: try to salvage the complete call(s) behind a
-                    # skeleton/preview block (the write-stutter).
+                    # Leniently re-parse the model's calls out of the 500 body
+                    # and hand them downstream: complete calls execute,
+                    # skeletons get rejected by dispatch as [ToolError] on the
+                    # tool channel.
                     calls, saw_blocks = _rescue_tool_calls(
                         error_body, body.get("tools")
                     )
                     if calls:
                         self.rescued_tool_calls += len(calls)
                         log.warning(
-                            "[rescue] salvaged %d complete tool call(s) from a "
+                            "[rescue] re-parsed %d tool call(s) from a "
                             "malformed-tool-call 500: %s",
-                            len(calls), [c.tool for c in calls],
+                            len(calls), [(c.tool, sorted(c.args)) for c in calls],
                         )
                         yield StreamChunk(type=ChunkType.FINAL, response=calls)
                         return
@@ -751,15 +757,16 @@ class LlamafileClient:
         if resp.status_code == 500:
             is_parse = _is_malformed_tool_call_500(resp.text)
             if is_parse:
-                # First: try to salvage the complete call(s) the model buried
-                # behind a skeleton/preview block (the write-stutter).
+                # Leniently re-parse the model's calls out of the 500 body and
+                # hand them downstream: complete calls execute, skeletons get
+                # rejected by dispatch as [ToolError] on the tool channel.
                 calls, saw_blocks = _rescue_tool_calls(resp.text, body.get("tools"))
                 if calls:
                     self.rescued_tool_calls += len(calls)
                     log.warning(
-                        "[rescue] salvaged %d complete tool call(s) from a "
+                        "[rescue] re-parsed %d tool call(s) from a "
                         "malformed-tool-call 500: %s",
-                        len(calls), [c.tool for c in calls],
+                        len(calls), [(c.tool, sorted(c.args)) for c in calls],
                     )
                     return calls
                 # Recoverable: re-sample. Return a clean nudge, not the raw 500

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -58,6 +59,121 @@ _MALFORMED_TOOL_CALL_RETRY_TEXT = (
     "missing required parameter or a duplicated/incomplete call. Re-emitting a "
     "single, complete, well-formed tool call.)"
 )
+
+# Used only when the 500 body demonstrably contains <tool_call> block(s) that
+# could not be rescued — i.e. we KNOW the model emitted a skeleton/preview call
+# (the write-stutter). A malformed-500 without visible blocks keeps the generic
+# text above; we don't name a stutter we haven't seen.
+_STUTTER_RETRY_TEXT = (
+    "(The previous response contained a malformed tool-call block — a "
+    "preview/skeleton call missing its required parameters, or a duplicated "
+    "call. Re-emitting exactly ONE complete tool-call block with EVERY "
+    "required parameter filled in, with no preview or skeleton block before "
+    "it.)"
+)
+
+log = logging.getLogger(__name__)
+
+# llama.cpp's "Failed to parse input at pos N: ..." message embeds the raw
+# rejected generation from the failure position onward — including, in the
+# stutter case, the complete well-formed call the model emitted right after
+# the skeleton block. These parse that embedded text (Qwen-coder XML tool
+# format). Caveat: a parameter value containing a literal "</parameter>"
+# line would be truncated at it; rescue validation below rejects the block
+# if that loses a required parameter.
+_TOOL_CALL_BLOCK_RE = re.compile(
+    r"<tool_call>\s*<function=([^>\s]+)>(.*?)</function>\s*</tool_call>",
+    re.DOTALL,
+)
+_TOOL_PARAM_RE = re.compile(
+    r"<parameter=([^>\s]+)>\n?(.*?)\n?</parameter>", re.DOTALL
+)
+
+
+def _tool_requirements(
+    tools_array: list[dict[str, Any]] | None,
+) -> dict[str, tuple[set[str], dict[str, str | None]]]:
+    """Map tool name -> (required param names, param JSON types) from an
+    OpenAI-shape ``tools`` array (what the request body actually carried)."""
+    reqs: dict[str, tuple[set[str], dict[str, str | None]]] = {}
+    for entry in tools_array or []:
+        fn = entry.get("function") or {}
+        name = fn.get("name")
+        if not name:
+            continue
+        params = fn.get("parameters") or {}
+        required = set(params.get("required") or [])
+        types = {
+            key: (prop or {}).get("type")
+            for key, prop in (params.get("properties") or {}).items()
+        }
+        reqs[name] = (required, types)
+    return reqs
+
+
+def _coerce_param(value: str, json_type: str | None) -> Any:
+    """Coerce an XML-format (stringly-typed) param to its schema type.
+
+    Mirrors llama.cpp's own coercion. Raises ValueError when the value
+    cannot satisfy the declared type — the caller drops the block.
+    """
+    if json_type == "integer":
+        return int(value.strip())
+    if json_type == "number":
+        return float(value.strip())
+    if json_type == "boolean":
+        lowered = value.strip().lower()
+        if lowered in ("true", "false"):
+            return lowered == "true"
+        raise ValueError(f"not a boolean: {value!r}")
+    return value
+
+
+def _rescue_tool_calls(
+    error_body: str,
+    tools_array: list[dict[str, Any]] | None,
+) -> tuple[list[ToolCall], bool]:
+    """Salvage complete, valid tool calls from a malformed-tool-call 500 body.
+
+    Returns ``(calls, saw_blocks)``. A block is rescued only if it strictly
+    parses, names a tool present in the request's ``tools`` array, and carries
+    every required parameter (skeleton/preview blocks fail this by
+    construction). Exact-duplicate calls are deduped. ``saw_blocks`` reports
+    whether any ``<tool_call>`` block was visible at all — it selects the
+    stutter-specific retry text when rescue comes up empty.
+    """
+    try:
+        message = json.loads(error_body).get("error", {}).get("message", "")
+    except (ValueError, AttributeError):
+        message = error_body
+    if not isinstance(message, str) or not message:
+        message = error_body
+
+    requirements = _tool_requirements(tools_array)
+    calls: list[ToolCall] = []
+    seen: set[tuple[str, str]] = set()
+    blocks = _TOOL_CALL_BLOCK_RE.findall(message)
+    for name, params_text in blocks:
+        spec = requirements.get(name)
+        if spec is None:
+            continue  # unknown tool — never fabricate a call we can't check
+        required, types = spec
+        args: dict[str, Any] = {}
+        valid = True
+        for key, raw_value in _TOOL_PARAM_RE.findall(params_text):
+            try:
+                args[key] = _coerce_param(raw_value, types.get(key))
+            except ValueError:
+                valid = False
+                break
+        if not valid or not required.issubset(args):
+            continue  # skeleton or mangled block — nothing to execute
+        dedupe_key = (name, json.dumps(args, sort_keys=True, default=str))
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        calls.append(ToolCall(tool=name, args=args, reasoning=None))
+    return calls, bool(blocks)
 
 
 def _merge_consecutive(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -205,6 +321,9 @@ class LlamafileClient:
                 "backends)."
             )
         self.base_url = base_url
+        # Count of tool calls salvaged from malformed-tool-call 500 bodies —
+        # eval drivers can surface this so rescued runs stay auditable.
+        self.rescued_tool_calls = 0
         # gguf_path is the source path. self.model is the derived identity
         # (filename minus .gguf/.llamafile suffix, minus shard index) used as
         # the wire "model" field (llama-server ignores it but it flows into
@@ -437,10 +556,28 @@ class LlamafileClient:
                 async for line in response.aiter_lines():
                     error_body += line
                 if _is_malformed_tool_call_500(error_body):
+                    # First: try to salvage the complete call(s) behind a
+                    # skeleton/preview block (the write-stutter).
+                    calls, saw_blocks = _rescue_tool_calls(
+                        error_body, body.get("tools")
+                    )
+                    if calls:
+                        self.rescued_tool_calls += len(calls)
+                        log.warning(
+                            "[rescue] salvaged %d complete tool call(s) from a "
+                            "malformed-tool-call 500: %s",
+                            len(calls), [c.tool for c in calls],
+                        )
+                        yield StreamChunk(type=ChunkType.FINAL, response=calls)
+                        return
                     # Recoverable: re-sample. Clean nudge, not the raw 500 JSON.
+                    # Name the stutter only when blocks were actually seen.
                     yield StreamChunk(
                         type=ChunkType.FINAL,
-                        response=TextResponse(content=_MALFORMED_TOOL_CALL_RETRY_TEXT),
+                        response=TextResponse(
+                            content=_STUTTER_RETRY_TEXT if saw_blocks
+                            else _MALFORMED_TOOL_CALL_RETRY_TEXT
+                        ),
                     )
                     return
                 # Arbitrary backend 500 — cascade.
@@ -614,8 +751,23 @@ class LlamafileClient:
         if resp.status_code == 500:
             is_parse = _is_malformed_tool_call_500(resp.text)
             if is_parse:
-                # Recoverable: re-sample. Return a clean nudge, not the raw 500 JSON.
-                return TextResponse(content=_MALFORMED_TOOL_CALL_RETRY_TEXT)
+                # First: try to salvage the complete call(s) the model buried
+                # behind a skeleton/preview block (the write-stutter).
+                calls, saw_blocks = _rescue_tool_calls(resp.text, body.get("tools"))
+                if calls:
+                    self.rescued_tool_calls += len(calls)
+                    log.warning(
+                        "[rescue] salvaged %d complete tool call(s) from a "
+                        "malformed-tool-call 500: %s",
+                        len(calls), [c.tool for c in calls],
+                    )
+                    return calls
+                # Recoverable: re-sample. Return a clean nudge, not the raw 500
+                # JSON. Name the stutter only when blocks were actually seen.
+                return TextResponse(
+                    content=_STUTTER_RETRY_TEXT if saw_blocks
+                    else _MALFORMED_TOOL_CALL_RETRY_TEXT
+                )
             # Arbitrary backend 500 — cascade.
             raise BackendError(500, resp.text)
         if resp.status_code != 200:

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -42,6 +42,24 @@ _SHARD_SUFFIX_RE = re.compile(r"-\d{5}-of-\d{5}$")
 _KNOWN_GGUF_EXTENSIONS: tuple[str, ...] = (".gguf", ".llamafile")
 
 
+# A 500 whose body is llama.cpp's tool-call parser rejecting MALFORMED/INCOMPLETE
+# model output (e.g. a `write` missing `content`, or a duplicated/incomplete call)
+# — NOT an arbitrary backend error. This one is a transient sampling artifact and
+# recoverable by re-sampling, so we surface it as a retryable text response (the
+# run_inference retry loop nudges the model to re-emit a clean call) instead of
+# echoing the raw error JSON into the conversation. Every OTHER 500 cascades as a
+# BackendError.
+def _is_malformed_tool_call_500(body: str) -> bool:
+    return "Failed to parse input" in body and ("tool_call" in body or "<function=" in body)
+
+
+_MALFORMED_TOOL_CALL_RETRY_TEXT = (
+    "(The previous tool call was malformed and rejected by the parser — likely a "
+    "missing required parameter or a duplicated/incomplete call. Re-emitting a "
+    "single, complete, well-formed tool call.)"
+)
+
+
 def _merge_consecutive(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Ensure strict user/assistant alternation for Jinja parity checker.
 
@@ -418,11 +436,15 @@ class LlamafileClient:
                 error_body = ""
                 async for line in response.aiter_lines():
                     error_body += line
-                yield StreamChunk(
-                    type=ChunkType.FINAL,
-                    response=TextResponse(content=error_body),
-                )
-                return
+                if _is_malformed_tool_call_500(error_body):
+                    # Recoverable: re-sample. Clean nudge, not the raw 500 JSON.
+                    yield StreamChunk(
+                        type=ChunkType.FINAL,
+                        response=TextResponse(content=_MALFORMED_TOOL_CALL_RETRY_TEXT),
+                    )
+                    return
+                # Arbitrary backend 500 — cascade.
+                raise BackendError(500, error_body)
             async for line in response.aiter_lines():
                 line = line.strip()
                 if not line or not line.startswith("data: "):
@@ -590,7 +612,12 @@ class LlamafileClient:
             headers=self._request_headers(extra_headers),
         )
         if resp.status_code == 500:
-            return TextResponse(content=resp.text)
+            is_parse = _is_malformed_tool_call_500(resp.text)
+            if is_parse:
+                # Recoverable: re-sample. Return a clean nudge, not the raw 500 JSON.
+                return TextResponse(content=_MALFORMED_TOOL_CALL_RETRY_TEXT)
+            # Arbitrary backend 500 — cascade.
+            raise BackendError(500, resp.text)
         if resp.status_code != 200:
             raise BackendError(resp.status_code, raw_body=resp.text)
         data = resp.json()

--- a/tests/unit/test_llamafile_client.py
+++ b/tests/unit/test_llamafile_client.py
@@ -119,6 +119,41 @@ class TestLlamafileNativeSend:
         assert result.content == "I need more info"
 
     @pytest.mark.asyncio
+    async def test_malformed_tool_call_500_retries_with_clean_nudge(self) -> None:
+        # llama.cpp rejects a malformed/incomplete tool call the model emitted ->
+        # 500 "Failed to parse input". This is recoverable: return a clean nudge so
+        # the inference retry loop re-samples; do NOT leak the raw error JSON.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = (
+            '{"error":{"code":500,"message":"Failed to parse input at pos 84: '
+            '<tool_call>\\n<function=write>\\n<parameter=file_path>\\nx.py\\n'
+            '</parameter>\\n</function>\\n</tool_call>","type":"server_error"}}'
+        )
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[_make_spec()]
+        )
+        assert isinstance(result, TextResponse)
+        assert "malformed" in result.content.lower()
+        assert "Failed to parse input" not in result.content  # raw JSON must not leak
+
+    @pytest.mark.asyncio
+    async def test_arbitrary_500_cascades_as_backend_error(self) -> None:
+        # A real backend 500 (not a tool-call parse rejection) must cascade, not
+        # be swallowed as a retryable text response.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = '{"error":{"message":"CUDA out of memory","type":"server_error"}}'
+        client._http.post.return_value = resp
+        with pytest.raises(BackendError):
+            await client.send(
+                [{"role": "user", "content": "test"}], tools=[_make_spec()]
+            )
+
+    @pytest.mark.asyncio
     async def test_missing_choices_raises_backend_error(self) -> None:
         # Broken provider envelope (200, no choices) → fail loud and consistent
         # rather than KeyError/IndexError on data["choices"][0].

--- a/tests/unit/test_llamafile_client.py
+++ b/tests/unit/test_llamafile_client.py
@@ -171,10 +171,11 @@ class TestLlamafileNativeSend:
         assert "Failed to parse input" not in result.content  # raw JSON must not leak
 
     @pytest.mark.asyncio
-    async def test_malformed_500_rescues_complete_call_behind_skeleton(self) -> None:
+    async def test_malformed_500_reparses_skeleton_and_complete_call(self) -> None:
         # The write-stutter: a skeleton (path-only) block followed by the same
-        # call complete WITH content. llama.cpp 500s the whole generation; the
-        # complete call rides in the error body — salvage and execute it.
+        # call complete WITH content. llama.cpp 500s the whole generation; both
+        # calls ride in the error body — return BOTH and let downstream decide
+        # (skeleton TypeErrors on the tool channel, complete call executes).
         client = _make_client("native")
         resp = MagicMock()
         resp.status_code = 500
@@ -184,34 +185,36 @@ class TestLlamafileNativeSend:
             [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
         )
         assert isinstance(result, list)
-        assert len(result) == 1  # skeleton dropped, complete call kept
+        assert len(result) == 2
         assert result[0].tool == "write"
-        assert result[0].args["file_path"] == "tests/test_x.py"
-        assert result[0].args["content"].startswith("import unittest")
-        assert result[0].args["content"].endswith("    pass")
-        assert client.rescued_tool_calls == 1
+        assert result[0].args == {"file_path": "tests/test_x.py"}  # skeleton, as emitted
+        assert result[1].tool == "write"
+        assert result[1].args["file_path"] == "tests/test_x.py"
+        assert result[1].args["content"].startswith("import unittest")
+        assert result[1].args["content"].endswith("    pass")
+        assert client.rescued_tool_calls == 2
 
     @pytest.mark.asyncio
-    async def test_malformed_500_rescue_dedupes_repeated_complete_blocks(self) -> None:
-        # Stutters can repeat the complete call too — identical (tool, args)
-        # blocks collapse to one executed call.
+    async def test_malformed_500_rescue_dedupes_repeated_blocks(self) -> None:
+        # Stutters can repeat blocks — identical (tool, args) collapse to one.
         client = _make_client("native")
         resp = MagicMock()
         resp.status_code = 500
         resp.text = _malformed_500_body(
-            f"{_SKELETON_BLOCK}\n{_COMPLETE_BLOCK}\n{_COMPLETE_BLOCK}"
+            f"{_SKELETON_BLOCK}\n{_SKELETON_BLOCK}\n{_COMPLETE_BLOCK}\n{_COMPLETE_BLOCK}"
         )
         client._http.post.return_value = resp
         result = await client.send(
             [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
         )
         assert isinstance(result, list)
-        assert len(result) == 1
+        assert len(result) == 2  # one skeleton + one complete
 
     @pytest.mark.asyncio
-    async def test_malformed_500_skeleton_only_gets_stutter_nudge(self) -> None:
-        # Skeleton block with no complete call behind it: nothing to rescue,
-        # but we SAW the block — the retry text names the stutter explicitly.
+    async def test_malformed_500_skeleton_only_returned_as_call(self) -> None:
+        # Skeleton block alone: returned as a real ToolCall so the runner's
+        # dispatch rejects it with [ToolError] TypeError on the tool channel —
+        # the canonical corrective signal — instead of canned self-talk text.
         client = _make_client("native")
         resp = MagicMock()
         resp.status_code = 500
@@ -220,10 +223,11 @@ class TestLlamafileNativeSend:
         result = await client.send(
             [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
         )
-        assert isinstance(result, TextResponse)
-        assert "ONE complete" in result.content
-        assert "Failed to parse input" not in result.content
-        assert client.rescued_tool_calls == 0
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].tool == "write"
+        assert result[0].args == {"file_path": "tests/test_x.py"}
+        assert client.rescued_tool_calls == 1
 
     @pytest.mark.asyncio
     async def test_malformed_500_without_blocks_keeps_generic_nudge(self) -> None:

--- a/tests/unit/test_llamafile_client.py
+++ b/tests/unit/test_llamafile_client.py
@@ -19,6 +19,37 @@ class PartParams(BaseModel):
     part: str = Field(description="Part number")
 
 
+class WriteParams(BaseModel):
+    file_path: str = Field(description="Target path")
+    content: str = Field(description="File body")
+
+
+def _make_write_spec() -> ToolSpec:
+    return ToolSpec(name="write", description="Write a file", parameters=WriteParams)
+
+
+def _malformed_500_body(raw_input: str) -> str:
+    """A llama.cpp tool-call parse rejection body embedding ``raw_input``."""
+    return json.dumps({
+        "error": {
+            "code": 500,
+            "message": f"Failed to parse input at pos 84: {raw_input}",
+            "type": "server_error",
+        }
+    })
+
+
+_SKELETON_BLOCK = (
+    "<tool_call>\n<function=write>\n<parameter=file_path>\ntests/test_x.py\n"
+    "</parameter>\n</function>\n</tool_call>"
+)
+_COMPLETE_BLOCK = (
+    "<tool_call>\n<function=write>\n<parameter=file_path>\ntests/test_x.py\n"
+    "</parameter>\n<parameter=content>\nimport unittest\n\n\nclass T(unittest.TestCase):\n"
+    "    pass\n</parameter>\n</function>\n</tool_call>"
+)
+
+
 def _make_spec(name: str = "get_pricing") -> ToolSpec:
     return ToolSpec(
         name=name,
@@ -138,6 +169,96 @@ class TestLlamafileNativeSend:
         assert isinstance(result, TextResponse)
         assert "malformed" in result.content.lower()
         assert "Failed to parse input" not in result.content  # raw JSON must not leak
+
+    @pytest.mark.asyncio
+    async def test_malformed_500_rescues_complete_call_behind_skeleton(self) -> None:
+        # The write-stutter: a skeleton (path-only) block followed by the same
+        # call complete WITH content. llama.cpp 500s the whole generation; the
+        # complete call rides in the error body — salvage and execute it.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = _malformed_500_body(f"{_SKELETON_BLOCK}\n{_COMPLETE_BLOCK}")
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+        )
+        assert isinstance(result, list)
+        assert len(result) == 1  # skeleton dropped, complete call kept
+        assert result[0].tool == "write"
+        assert result[0].args["file_path"] == "tests/test_x.py"
+        assert result[0].args["content"].startswith("import unittest")
+        assert result[0].args["content"].endswith("    pass")
+        assert client.rescued_tool_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_500_rescue_dedupes_repeated_complete_blocks(self) -> None:
+        # Stutters can repeat the complete call too — identical (tool, args)
+        # blocks collapse to one executed call.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = _malformed_500_body(
+            f"{_SKELETON_BLOCK}\n{_COMPLETE_BLOCK}\n{_COMPLETE_BLOCK}"
+        )
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+        )
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_500_skeleton_only_gets_stutter_nudge(self) -> None:
+        # Skeleton block with no complete call behind it: nothing to rescue,
+        # but we SAW the block — the retry text names the stutter explicitly.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = _malformed_500_body(_SKELETON_BLOCK)
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+        )
+        assert isinstance(result, TextResponse)
+        assert "ONE complete" in result.content
+        assert "Failed to parse input" not in result.content
+        assert client.rescued_tool_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_malformed_500_without_blocks_keeps_generic_nudge(self) -> None:
+        # Fingerprint matches (parse failure + <function= marker) but no
+        # <tool_call> block is visible: we do NOT know it's a stutter, so the
+        # generic retry text is kept verbatim.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = _malformed_500_body("<function=write> garbled fragment")
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+        )
+        assert isinstance(result, TextResponse)
+        assert "Re-emitting a single, complete, well-formed tool call" in result.content
+        assert "ONE complete" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_malformed_500_unknown_tool_not_fabricated(self) -> None:
+        # A complete-looking block naming a tool absent from the request's
+        # tools array must never be executed — fall through to the retry text.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = _malformed_500_body(
+            "<tool_call>\n<function=rm_rf>\n<parameter=path>\n/\n</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+        )
+        assert isinstance(result, TextResponse)
+        assert client.rescued_tool_calls == 0
 
     @pytest.mark.asyncio
     async def test_arbitrary_500_cascades_as_backend_error(self) -> None:


### PR DESCRIPTION
## Summary

llama.cpp returns a 500 when its tool-call parser rejects malformed model output (e.g. a skeleton `write` call missing `content`, or a duplicated/incomplete block). Previously the llamafile client echoed that raw error JSON back as assistant text, poisoning the conversation. This PR handles that 500 class explicitly, releases as **v0.8.1**:

- **Rescue**: llama.cpp's `Failed to parse input` message embeds the rejected generation. Complete `<tool_call>` blocks are leniently re-parsed out of it (Qwen-coder XML format) and returned as real `ToolCall`s — validated against the request's `tools` array, deduped, params coerced to declared schema types. Skeleton blocks pass through to dispatch, which rejects them with `[ToolError]` on the tool channel (the canonical corrective signal). Unknown tool names are never fabricated. Rescues are counted on `LlamafileClient.rescued_tool_calls` and logged.
- **Nudge**: when nothing can be rescued, return a targeted retry nudge (stutter-specific when a `<tool_call>` block was visible, generic otherwise) so the retry loop re-samples a clean call.
- **Fail loud**: any *other* 500 now raises `BackendError` instead of returning the body as `TextResponse`, matching the other clients.

Covers both `send()` and `send_stream()`.

## Testing

- 7 new unit tests: rescue of skeleton+complete pairs, dedupe of repeated blocks, skeleton-only pass-through, generic vs stutter nudge selection, unknown-tool non-fabrication, arbitrary-500 cascade.
- Full suite: **1378 passed**, coverage 93%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)