### PR TITLE
fix(llamafile): harden the malformed-500 rescue gate and drop skeleton calls

### DIFF
--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -60,12 +60,12 @@ _MALFORMED_TOOL_CALL_RETRY_TEXT = (
     "single, complete, well-formed tool call.)"
 )
 
-# Used only when the 500 body demonstrably contains <tool_call> block(s) but
-# none re-parse to a tool from the request (mangled syntax or unknown tool
-# names) — i.e. we KNOW the model emitted a defective call block. A
+# Used when the 500 body demonstrably contains <tool_call> block(s) but none
+# survive rescue — either mangled syntax / unknown tool names, or (the common
+# case) skeleton/preview blocks dropped for missing a required parameter. A
 # malformed-500 without visible blocks keeps the generic text above; we don't
-# name a stutter we haven't seen. Parseable blocks — skeletons included — are
-# returned as real ToolCalls instead (see _rescue_tool_calls).
+# name a stutter we haven't seen. Complete blocks are returned as real
+# ToolCalls and never reach this text (see _rescue_tool_calls).
 _STUTTER_RETRY_TEXT = (
     "(The previous response contained a malformed tool-call block — a "
     "preview/skeleton call missing its required parameters, or a duplicated "
@@ -135,20 +135,25 @@ def _rescue_tool_calls(
     error_body: str,
     tools_array: list[dict[str, Any]] | None,
 ) -> tuple[list[ToolCall], bool]:
-    """Leniently re-parse tool calls out of a malformed-tool-call 500 body.
+    """Re-parse the COMPLETE tool calls out of a malformed-tool-call 500 body.
 
-    Returns ``(calls, saw_blocks)``. Every block that parses and names a tool
-    present in the request's ``tools`` array is returned — including
-    skeleton/preview blocks missing required parameters. Validity is decided
-    downstream: the ResponseValidator and the runner's ``fn(**args)`` dispatch
-    reject a skeleton with a ``[ToolError] TypeError`` on the tool channel
-    (the canonical corrective signal), while complete calls simply execute.
-    Unknown tool names are never returned (nothing we can't check against the
+    Returns ``(calls, saw_blocks)``. A block is returned only when it parses,
+    names a tool present in the request's ``tools`` array, AND carries every
+    parameter that tool marks required. Skeleton/preview blocks missing a
+    required param are DROPPED — dispatching them would raise a
+    ``[ToolError] TypeError`` on the tool channel and, in the write-stutter
+    case (skeleton immediately followed by the complete call), drive the model
+    into consecutive-tool-error exhaustion. The complete call from that same
+    stutter survives the filter and is returned alone; a skeleton-only body
+    yields no calls, so the caller falls through to a clean re-emit nudge.
+
+    Unknown tool names are never returned (nothing we can check against the
     request), exact duplicates are deduped, and param values are coerced to
     their declared schema types where possible (kept as raw strings when
-    coercion fails — the tool decides). ``saw_blocks`` reports whether any
-    ``<tool_call>`` block was visible at all — it selects the
-    stutter-specific retry text when parsing comes up empty.
+    coercion fails, matching the native path — a present-but-malformed arg
+    still satisfies the required-set check and the tool decides). ``saw_blocks``
+    reports whether any ``<tool_call>`` block was visible at all — it selects
+    the stutter-specific retry text when parsing comes up empty.
     """
     try:
         message = json.loads(error_body).get("error", {}).get("message", "")
@@ -165,13 +170,15 @@ def _rescue_tool_calls(
         spec = requirements.get(name)
         if spec is None:
             continue  # unknown tool — never fabricate a call we can't check
-        _required, types = spec
+        required, types = spec
         args: dict[str, Any] = {}
         for key, raw_value in _TOOL_PARAM_RE.findall(params_text):
             try:
                 args[key] = _coerce_param(raw_value, types.get(key))
             except ValueError:
                 args[key] = raw_value
+        if not required.issubset(args):
+            continue  # skeleton/preview block missing a required param — drop it
         dedupe_key = (name, json.dumps(args, sort_keys=True, default=str))
         if dedupe_key in seen:
             continue
@@ -560,10 +567,10 @@ class LlamafileClient:
                 async for line in response.aiter_lines():
                     error_body += line
                 if _is_malformed_tool_call_500(error_body):
-                    # Leniently re-parse the model's calls out of the 500 body
-                    # and hand them downstream: complete calls execute,
-                    # skeletons get rejected by dispatch as [ToolError] on the
-                    # tool channel.
+                    # Re-parse the model's COMPLETE calls out of the 500 body
+                    # and hand them downstream to execute; skeletons missing a
+                    # required param are dropped inside _rescue_tool_calls so
+                    # they never reach dispatch.
                     calls, saw_blocks = _rescue_tool_calls(
                         error_body, body.get("tools")
                     )
@@ -586,8 +593,8 @@ class LlamafileClient:
                         ),
                     )
                     return
-                # Arbitrary backend 500 — cascade.
-                raise BackendError(500, error_body)
+                # Arbitrary backend 500 — cascade. Raw body off the message.
+                raise BackendError(500, raw_body=error_body)
             async for line in response.aiter_lines():
                 line = line.strip()
                 if not line or not line.startswith("data: "):
@@ -757,9 +764,10 @@ class LlamafileClient:
         if resp.status_code == 500:
             is_parse = _is_malformed_tool_call_500(resp.text)
             if is_parse:
-                # Leniently re-parse the model's calls out of the 500 body and
-                # hand them downstream: complete calls execute, skeletons get
-                # rejected by dispatch as [ToolError] on the tool channel.
+                # Re-parse the model's COMPLETE calls out of the 500 body and
+                # hand them downstream to execute; skeletons missing a required
+                # param are dropped inside _rescue_tool_calls so they never
+                # reach dispatch.
                 calls, saw_blocks = _rescue_tool_calls(resp.text, body.get("tools"))
                 if calls:
                     self.rescued_tool_calls += len(calls)
@@ -775,8 +783,8 @@ class LlamafileClient:
                     content=_STUTTER_RETRY_TEXT if saw_blocks
                     else _MALFORMED_TOOL_CALL_RETRY_TEXT
                 )
-            # Arbitrary backend 500 — cascade.
-            raise BackendError(500, resp.text)
+            # Arbitrary backend 500 — cascade. Raw body off the message.
+            raise BackendError(500, raw_body=resp.text)
         if resp.status_code != 200:
             raise BackendError(resp.status_code, raw_body=resp.text)
         data = resp.json()
@@ -784,7 +792,11 @@ class LlamafileClient:
 
         choices = data.get("choices") or []
         if not choices:
-            raise BackendError(500, f"response has no choices: {data}")
+            # Raw envelope off the message (a gateway could echo a credential
+            # into a 200 body too); kept on exc.body for debugging.
+            raise BackendError(
+                500, "response has no choices", raw_body=json.dumps(data, default=str)
+            )
         choice = choices[0].get("message", {})
         raw_tool_calls = choice.get("tool_calls")
         if raw_tool_calls:

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -48,10 +48,17 @@ _KNOWN_GGUF_EXTENSIONS: tuple[str, ...] = (".gguf", ".llamafile")
 # — NOT an arbitrary backend error. This one is a transient sampling artifact and
 # recoverable by re-sampling, so we surface it as a retryable text response (the
 # run_inference retry loop nudges the model to re-emit a clean call) instead of
-# echoing the raw error JSON into the conversation. Every OTHER 500 cascades as a
-# BackendError.
+# echoing the raw error JSON into the conversation. Every OTHER 500 cascades.
+#
+# The gate is STRUCTURAL, not phrase-based: a 500 is rescuable iff its body
+# carries generated tool-call XML (``<tool_call>``/``<function=``). Only the
+# model generating such a call and the backend choking on it puts that syntax in
+# a 500 body — genuine faults (OOM/slot/context/CUDA) never echo generation, and
+# a request-parse failure dumps JSON, not this XML. It is robust to every
+# llama.cpp error-string rename across builds (the phrase it used to pin on,
+# "Failed to parse input", was renamed in later builds).
 def _is_malformed_tool_call_500(body: str) -> bool:
-    return "Failed to parse input" in body and ("tool_call" in body or "<function=" in body)
+    return "<tool_call>" in body or "<function=" in body
 
 
 _MALFORMED_TOOL_CALL_RETRY_TEXT = (

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -54,9 +54,15 @@ _KNOWN_GGUF_EXTENSIONS: tuple[str, ...] = (".gguf", ".llamafile")
 # carries generated tool-call XML (``<tool_call>``/``<function=``). Only the
 # model generating such a call and the backend choking on it puts that syntax in
 # a 500 body — genuine faults (OOM/slot/context/CUDA) never echo generation, and
-# a request-parse failure dumps JSON, not this XML. It is robust to every
-# llama.cpp error-string rename across builds (the phrase it used to pin on,
-# "Failed to parse input", was renamed in later builds).
+# a request-parse failure dumps JSON, not this XML.
+#
+# VERSION BOUNDARY: rescue only fires on llama.cpp builds that echo the raw
+# rejected generation into the 500 body. That ended at commit 581e8eca8
+# ("chat: harden peg-native tool call parsing", PR #24329, first in tag b9656,
+# 2026-06-15): the exception became a generic "...does not match the expected
+# <format> format" and the raw generation moved to server logs only. On b9656+
+# this gate never matches, and grammar hardening in the same series makes the
+# malformed call rare anyway, so the 500 just cascades. Effective only on <= b9647.
 def _is_malformed_tool_call_500(body: str) -> bool:
     return "<tool_call>" in body or "<function=" in body
 

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -51,10 +51,14 @@ _KNOWN_GGUF_EXTENSIONS: tuple[str, ...] = (".gguf", ".llamafile")
 # echoing the raw error JSON into the conversation. Every OTHER 500 cascades.
 #
 # The gate is STRUCTURAL, not phrase-based: a 500 is rescuable iff its body
-# carries generated tool-call XML (``<tool_call>``/``<function=``). Only the
+# carries generated tool-call XML (``<tool_call``/``<function=``). Only the
 # model generating such a call and the backend choking on it puts that syntax in
 # a 500 body — genuine faults (OOM/slot/context/CUDA) never echo generation, and
-# a request-parse failure dumps JSON, not this XML.
+# a request-parse failure dumps JSON, not this XML. ``<tool_call`` is
+# deliberately unclosed: an echo truncated mid-open-tag (EOS or token budget
+# landing inside the tag) is the same re-sampleable artifact as a complete one,
+# and the leading ``<`` keeps the gate structural — request and schema dumps
+# carry ``"tool_calls"`` as quoted JSON, never the tag.
 #
 # VERSION BOUNDARY: rescue only fires on llama.cpp builds that echo the raw
 # rejected generation into the 500 body. That ended at commit 581e8eca8
@@ -64,7 +68,7 @@ _KNOWN_GGUF_EXTENSIONS: tuple[str, ...] = (".gguf", ".llamafile")
 # this gate never matches, and grammar hardening in the same series makes the
 # malformed call rare anyway, so the 500 just cascades. Effective only on <= b9647.
 def _is_malformed_tool_call_500(body: str) -> bool:
-    return "<tool_call>" in body or "<function=" in body
+    return "<tool_call" in body or "<function=" in body
 
 
 _MALFORMED_TOOL_CALL_RETRY_TEXT = (

--- a/tests/unit/test_llamafile_client.py
+++ b/tests/unit/test_llamafile_client.py
@@ -43,6 +43,23 @@ def _malformed_500_body(raw_input: str) -> str:
     })
 
 
+def _renamed_500_body(raw_input: str) -> str:
+    """A 500 from a hypothetical llama.cpp build that RENAMED the parse-error
+    phrase but still embeds the raw generation — deliberately contains NO
+    "Failed to parse input". Proves the rescue gate is structural, not pinned
+    to any error string."""
+    return json.dumps({
+        "error": {
+            "code": 500,
+            "message": (
+                "The model produced output that does not match the expected "
+                f"format: {raw_input}"
+            ),
+            "type": "server_error",
+        }
+    })
+
+
 _SKELETON_BLOCK = (
     "<tool_call>\n<function=write>\n<parameter=file_path>\ntests/test_x.py\n"
     "</parameter>\n</function>\n</tool_call>"
@@ -333,6 +350,61 @@ class TestLlamafileNativeSend:
             )
         assert "CUDA out of memory" not in str(excinfo.value)  # raw body off message
         assert "CUDA out of memory" in excinfo.value.body      # but kept for debugging
+
+    @pytest.mark.asyncio
+    async def test_malformed_500_rescued_without_parse_phrase(self) -> None:
+        # A build that RENAMED the parse-error phrase (no "Failed to parse
+        # input") but still embeds the generation must still rescue: the gate
+        # is structural (tool-call XML present), not phrase-pinned.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = _renamed_500_body(_COMPLETE_BLOCK)
+        assert "Failed to parse input" not in resp.text  # the point of the test
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+        )
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].args["content"].startswith("import unittest")
+        assert client.rescued_tool_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_500_no_phrase_skeleton_only_returns_nudge(self) -> None:
+        # Renamed phrase + skeleton only → skeleton dropped, stutter nudge.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = _renamed_500_body(_SKELETON_BLOCK)
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+        )
+        assert isinstance(result, TextResponse)
+        assert "ONE complete" in result.content
+        assert client.rescued_tool_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_tools_schema_dump_500_cascades(self) -> None:
+        # "Failed to parse tools" dumps the tools JSON schema (contains
+        # "function" but never the <function=/<tool_call> XML tokens) → not a
+        # rescuable generation artifact → cascade.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = json.dumps({
+            "error": {
+                "message": 'Failed to parse tools: bad schema; tools = '
+                           '[{"type":"function","function":{"name":"write"}}]',
+                "type": "server_error",
+            }
+        })
+        client._http.post.return_value = resp
+        with pytest.raises(BackendError):
+            await client.send(
+                [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+            )
 
     @pytest.mark.asyncio
     async def test_missing_choices_raises_backend_error(self) -> None:
@@ -993,6 +1065,25 @@ class TestLlamafileSendStream:
         assert isinstance(finals[0].response, list)
         assert len(finals[0].response) == 1
         assert finals[0].response[0].args["content"].startswith("import unittest")
+        assert client.rescued_tool_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_malformed_500_rescued_without_parse_phrase(self) -> None:
+        # Streaming twin: the shared gate is structural, so a renamed-phrase
+        # body embedding a complete block rescues on the streaming path too.
+        client = _make_client("native")
+        client._http.stream.return_value = _MockSSE500Response(
+            _renamed_500_body(_COMPLETE_BLOCK)
+        )
+        chunks = [
+            c async for c in client.send_stream(
+                [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+            )
+        ]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(finals) == 1
+        assert isinstance(finals[0].response, list)
+        assert len(finals[0].response) == 1
         assert client.rescued_tool_calls == 1
 
     @pytest.mark.asyncio

--- a/tests/unit/test_llamafile_client.py
+++ b/tests/unit/test_llamafile_client.py
@@ -24,6 +24,10 @@ class WriteParams(BaseModel):
     content: str = Field(description="File body")
 
 
+class _NoRequiredParams(BaseModel):
+    note: str | None = Field(default=None, description="Optional note")
+
+
 def _make_write_spec() -> ToolSpec:
     return ToolSpec(name="write", description="Write a file", parameters=WriteParams)
 
@@ -171,11 +175,12 @@ class TestLlamafileNativeSend:
         assert "Failed to parse input" not in result.content  # raw JSON must not leak
 
     @pytest.mark.asyncio
-    async def test_malformed_500_reparses_skeleton_and_complete_call(self) -> None:
+    async def test_malformed_500_stutter_returns_only_complete_call(self) -> None:
         # The write-stutter: a skeleton (path-only) block followed by the same
         # call complete WITH content. llama.cpp 500s the whole generation; both
-        # calls ride in the error body — return BOTH and let downstream decide
-        # (skeleton TypeErrors on the tool channel, complete call executes).
+        # ride in the error body. Rescue drops the skeleton (missing required
+        # `content`) and returns ONLY the complete call — dispatching the
+        # skeleton would [ToolError] and drive tool-error exhaustion.
         client = _make_client("native")
         resp = MagicMock()
         resp.status_code = 500
@@ -185,18 +190,17 @@ class TestLlamafileNativeSend:
             [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
         )
         assert isinstance(result, list)
-        assert len(result) == 2
+        assert len(result) == 1
         assert result[0].tool == "write"
-        assert result[0].args == {"file_path": "tests/test_x.py"}  # skeleton, as emitted
-        assert result[1].tool == "write"
-        assert result[1].args["file_path"] == "tests/test_x.py"
-        assert result[1].args["content"].startswith("import unittest")
-        assert result[1].args["content"].endswith("    pass")
-        assert client.rescued_tool_calls == 2
+        assert result[0].args["file_path"] == "tests/test_x.py"
+        assert result[0].args["content"].startswith("import unittest")
+        assert result[0].args["content"].endswith("    pass")
+        assert client.rescued_tool_calls == 1
 
     @pytest.mark.asyncio
     async def test_malformed_500_rescue_dedupes_repeated_blocks(self) -> None:
-        # Stutters can repeat blocks — identical (tool, args) collapse to one.
+        # Stutters can repeat blocks. Skeletons drop (missing `content`); the
+        # two identical completes collapse to one via the (tool, args) dedupe.
         client = _make_client("native")
         resp = MagicMock()
         resp.status_code = 500
@@ -208,13 +212,16 @@ class TestLlamafileNativeSend:
             [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
         )
         assert isinstance(result, list)
-        assert len(result) == 2  # one skeleton + one complete
+        assert len(result) == 1  # skeletons dropped, completes deduped
+        assert result[0].args["content"].startswith("import unittest")
+        assert client.rescued_tool_calls == 1
 
     @pytest.mark.asyncio
-    async def test_malformed_500_skeleton_only_returned_as_call(self) -> None:
-        # Skeleton block alone: returned as a real ToolCall so the runner's
-        # dispatch rejects it with [ToolError] TypeError on the tool channel —
-        # the canonical corrective signal — instead of canned self-talk text.
+    async def test_malformed_500_skeleton_only_returns_nudge(self) -> None:
+        # Skeleton block alone (missing required `content`): dropped by rescue,
+        # so no call is dispatched. The caller falls through to the stutter
+        # nudge (a clean re-emit instruction) instead of a broken tool call —
+        # this is what breaks the rig-04 tool-error exhaustion loop.
         client = _make_client("native")
         resp = MagicMock()
         resp.status_code = 500
@@ -223,11 +230,56 @@ class TestLlamafileNativeSend:
         result = await client.send(
             [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
         )
+        assert isinstance(result, TextResponse)
+        assert "ONE complete" in result.content  # stutter-specific nudge
+        assert "Failed to parse input" not in result.content  # raw JSON must not leak
+        assert client.rescued_tool_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_malformed_500_no_required_params_partial_survives(self) -> None:
+        # A tool with NO required params: even a bare block satisfies the
+        # required-set check (empty set ⊆ anything) and must be returned, not
+        # over-suppressed by the skeleton filter.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        # PartParams.part is required in _make_spec; build a no-required spec.
+        no_req_spec = ToolSpec(
+            name="ping", description="ping", parameters=_NoRequiredParams
+        )
+        resp.text = _malformed_500_body(
+            "<tool_call>\n<function=ping>\n</function>\n</tool_call>"
+        )
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[no_req_spec]
+        )
         assert isinstance(result, list)
         assert len(result) == 1
-        assert result[0].tool == "write"
-        assert result[0].args == {"file_path": "tests/test_x.py"}
+        assert result[0].tool == "ping"
+        assert result[0].args == {}
         assert client.rescued_tool_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_500_two_distinct_complete_calls_both_survive(self) -> None:
+        # The required filter must not over-drop: two distinct COMPLETE calls
+        # both pass and are returned.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        second_complete = _COMPLETE_BLOCK.replace("tests/test_x.py", "tests/test_y.py")
+        resp.text = _malformed_500_body(f"{_COMPLETE_BLOCK}\n{second_complete}")
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+        )
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert {c.args["file_path"] for c in result} == {
+            "tests/test_x.py",
+            "tests/test_y.py",
+        }
+        assert client.rescued_tool_calls == 2
 
     @pytest.mark.asyncio
     async def test_malformed_500_without_blocks_keeps_generic_nudge(self) -> None:
@@ -267,16 +319,20 @@ class TestLlamafileNativeSend:
     @pytest.mark.asyncio
     async def test_arbitrary_500_cascades_as_backend_error(self) -> None:
         # A real backend 500 (not a tool-call parse rejection) must cascade, not
-        # be swallowed as a retryable text response.
+        # be swallowed as a retryable text response. The raw body is passed as
+        # raw_body= — kept off the message (a gateway could echo a credential
+        # into it) but available on exc.body for debugging.
         client = _make_client("native")
         resp = MagicMock()
         resp.status_code = 500
         resp.text = '{"error":{"message":"CUDA out of memory","type":"server_error"}}'
         client._http.post.return_value = resp
-        with pytest.raises(BackendError):
+        with pytest.raises(BackendError) as excinfo:
             await client.send(
                 [{"role": "user", "content": "test"}], tools=[_make_spec()]
             )
+        assert "CUDA out of memory" not in str(excinfo.value)  # raw body off message
+        assert "CUDA out of memory" in excinfo.value.body      # but kept for debugging
 
     @pytest.mark.asyncio
     async def test_missing_choices_raises_backend_error(self) -> None:
@@ -687,6 +743,39 @@ class _MockSSEStreamResponse:
         pass
 
 
+class _MockSSE500Response:
+    """Mock httpx streaming response that returns a 500 error body.
+
+    Yields the body as a SINGLE line — llama.cpp's 500 is compact single-line
+    JSON (embedded newlines are JSON-escaped), matching how send_stream
+    reassembles error_body by concatenation.
+    """
+
+    status_code = 500
+
+    def __init__(self, body: str, split: bool = False) -> None:
+        self._body = body
+        self._split = split
+
+    async def aiter_lines(self):
+        # aiter_lines() strips terminators; send_stream reassembles via
+        # concatenation. When split=True, deliver the body across several
+        # lines to exercise that reassembly (llama.cpp's compact JSON escapes
+        # its own newlines, so splitting on ", " is a faithful stand-in).
+        if self._split:
+            parts = self._body.split(",")
+            for i, part in enumerate(parts):
+                yield part + ("," if i < len(parts) - 1 else "")
+        else:
+            yield self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
 class TestLlamafileSendStream:
     @pytest.mark.asyncio
     async def test_yields_text_deltas_and_final(self) -> None:
@@ -805,6 +894,122 @@ class TestLlamafileSendStream:
         final = [c for c in chunks if c.type == ChunkType.FINAL][0]
         assert isinstance(final.response, list)
         assert final.response[0].reasoning is None
+
+    # ── send_stream — malformed-500 rescue (streaming twins) ──────────
+
+    @pytest.mark.asyncio
+    async def test_stream_malformed_500_stutter_returns_only_complete(self) -> None:
+        # Streaming twin: skeleton+complete stutter → FINAL is the complete
+        # call alone; the skeleton is dropped inside rescue.
+        client = _make_client("native")
+        client._http.stream.return_value = _MockSSE500Response(
+            _malformed_500_body(f"{_SKELETON_BLOCK}\n{_COMPLETE_BLOCK}")
+        )
+        chunks = [
+            c async for c in client.send_stream(
+                [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+            )
+        ]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(finals) == 1
+        assert isinstance(finals[0].response, list)
+        assert len(finals[0].response) == 1
+        assert finals[0].response[0].tool == "write"
+        assert finals[0].response[0].args["content"].startswith("import unittest")
+        assert client.rescued_tool_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_malformed_500_skeleton_only_returns_nudge(self) -> None:
+        # Streaming twin of the inverted native test: skeleton alone → dropped,
+        # FINAL is the stutter nudge TextResponse, nothing rescued.
+        client = _make_client("native")
+        client._http.stream.return_value = _MockSSE500Response(
+            _malformed_500_body(_SKELETON_BLOCK)
+        )
+        chunks = [
+            c async for c in client.send_stream(
+                [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+            )
+        ]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(finals) == 1
+        assert isinstance(finals[0].response, TextResponse)
+        assert "ONE complete" in finals[0].response.content
+        assert "Failed to parse input" not in finals[0].response.content
+        assert client.rescued_tool_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_stream_malformed_500_no_blocks_keeps_generic_nudge(self) -> None:
+        # Fingerprint matches but no <tool_call> block visible → generic nudge.
+        client = _make_client("native")
+        client._http.stream.return_value = _MockSSE500Response(
+            _malformed_500_body("<function=write> garbled fragment")
+        )
+        chunks = [
+            c async for c in client.send_stream(
+                [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+            )
+        ]
+        final = [c for c in chunks if c.type == ChunkType.FINAL][0]
+        assert isinstance(final.response, TextResponse)
+        assert "Re-emitting a single, complete, well-formed tool call" in final.response.content
+        assert client.rescued_tool_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_stream_malformed_500_unknown_tool_not_fabricated(self) -> None:
+        # A block naming a tool absent from the request → never fabricated.
+        client = _make_client("native")
+        client._http.stream.return_value = _MockSSE500Response(
+            _malformed_500_body(
+                "<tool_call>\n<function=rm_rf>\n<parameter=path>\n/\n</parameter>\n"
+                "</function>\n</tool_call>"
+            )
+        )
+        chunks = [
+            c async for c in client.send_stream(
+                [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+            )
+        ]
+        final = [c for c in chunks if c.type == ChunkType.FINAL][0]
+        assert isinstance(final.response, TextResponse)
+        assert client.rescued_tool_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_stream_malformed_500_reassembles_multiline_body(self) -> None:
+        # The one path unique to streaming: error_body is reassembled from
+        # aiter_lines() by concatenation. Deliver the body across multiple
+        # lines and confirm the complete call still parses out of it.
+        client = _make_client("native")
+        client._http.stream.return_value = _MockSSE500Response(
+            _malformed_500_body(f"{_SKELETON_BLOCK}\n{_COMPLETE_BLOCK}"), split=True
+        )
+        chunks = [
+            c async for c in client.send_stream(
+                [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+            )
+        ]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(finals) == 1
+        assert isinstance(finals[0].response, list)
+        assert len(finals[0].response) == 1
+        assert finals[0].response[0].args["content"].startswith("import unittest")
+        assert client.rescued_tool_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_arbitrary_500_cascades(self) -> None:
+        # A real backend 500 must cascade; raw body kept off the message but on
+        # exc.body (same guarantee as the native path).
+        client = _make_client("native")
+        client._http.stream.return_value = _MockSSE500Response(
+            '{"error":{"message":"CUDA out of memory","type":"server_error"}}'
+        )
+        with pytest.raises(BackendError) as excinfo:
+            async for _ in client.send_stream(
+                [{"role": "user", "content": "test"}], tools=[_make_spec()]
+            ):
+                pass
+        assert "CUDA out of memory" not in str(excinfo.value)
+        assert "CUDA out of memory" in excinfo.value.body
 
 
 # ── mode ─────────────────────────────────────────────────────────

--- a/tests/unit/test_llamafile_client.py
+++ b/tests/unit/test_llamafile_client.py
@@ -60,6 +60,22 @@ def _renamed_500_body(raw_input: str) -> str:
     })
 
 
+def _b9656_generic_parse_500_body() -> str:
+    """The post-581e8eca8 (b9656+) parse-rejection body: a generic format
+    complaint with the rejected generation moved to server logs — no tool-call
+    XML tokens in the body. Shape confirmed against a live b9656+ build."""
+    return json.dumps({
+        "error": {
+            "code": 500,
+            "message": (
+                "Failed to parse tool call: generated output does not match "
+                "the expected format"
+            ),
+            "type": "server_error",
+        }
+    })
+
+
 _SKELETON_BLOCK = (
     "<tool_call>\n<function=write>\n<parameter=file_path>\ntests/test_x.py\n"
     "</parameter>\n</function>\n</tool_call>"
@@ -405,6 +421,47 @@ class TestLlamafileNativeSend:
             await client.send(
                 [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
             )
+
+    @pytest.mark.asyncio
+    async def test_truncated_open_tag_500_returns_generic_nudge(self) -> None:
+        # Echo cut off mid-open-tag (EOS/token budget inside "<tool_call") is
+        # still a generation artifact: the unclosed-prefix gate matches, no
+        # block parses, and the GENERIC nudge (not stutter — no visible block)
+        # comes back retryable instead of cascading.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = json.dumps({
+            "error": {
+                "code": 500,
+                "message": "Failed to parse input at pos 84: <tool_call",
+                "type": "server_error",
+            }
+        })
+        client._http.post.return_value = resp
+        result = await client.send(
+            [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+        )
+        assert isinstance(result, TextResponse)
+        assert "ONE complete" not in result.content  # generic, not stutter
+        assert client.rescued_tool_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_b9656_generic_parse_500_cascades(self) -> None:
+        # VERSION BOUNDARY (see _is_malformed_tool_call_500): b9656+ no longer
+        # echoes the rejected generation into the 500 body, so the structural
+        # gate must NOT match — the parse 500 cascades as a real BackendError
+        # instead of entering the retry-nudge loop with nothing to rescue.
+        client = _make_client("native")
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = _b9656_generic_parse_500_body()
+        client._http.post.return_value = resp
+        with pytest.raises(BackendError):
+            await client.send(
+                [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+            )
+        assert client.rescued_tool_calls == 0
 
     @pytest.mark.asyncio
     async def test_missing_choices_raises_backend_error(self) -> None:
@@ -1101,6 +1158,45 @@ class TestLlamafileSendStream:
                 pass
         assert "CUDA out of memory" not in str(excinfo.value)
         assert "CUDA out of memory" in excinfo.value.body
+
+    @pytest.mark.asyncio
+    async def test_stream_truncated_open_tag_500_returns_generic_nudge(self) -> None:
+        # Streaming twin: a mid-open-tag truncation stays retryable here too.
+        client = _make_client("native")
+        client._http.stream.return_value = _MockSSE500Response(
+            json.dumps({
+                "error": {
+                    "code": 500,
+                    "message": "Failed to parse input at pos 84: <tool_call",
+                    "type": "server_error",
+                }
+            })
+        )
+        chunks = [
+            c async for c in client.send_stream(
+                [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+            )
+        ]
+        finals = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(finals) == 1
+        assert isinstance(finals[0].response, TextResponse)
+        assert "ONE complete" not in finals[0].response.content
+        assert client.rescued_tool_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_stream_b9656_generic_parse_500_cascades(self) -> None:
+        # Streaming twin: the no-echo b9656+ parse rejection cascades on the
+        # streaming path too (shared structural gate).
+        client = _make_client("native")
+        client._http.stream.return_value = _MockSSE500Response(
+            _b9656_generic_parse_500_body()
+        )
+        with pytest.raises(BackendError):
+            async for _ in client.send_stream(
+                [{"role": "user", "content": "test"}], tools=[_make_write_spec()]
+            ):
+                pass
+        assert client.rescued_tool_calls == 0
 
 
 # ── mode ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Hotfix to the v0.8.1 malformed tool-call 500 rescue:

- **Drop skeleton tool calls in rescue.** Skeleton/preview blocks (missing a required parameter per the request's `tools` array) were passed through to dispatch, where each rejection burned the runner's tool-error budget — a stuttering model could exhaust it. Skeletons are now dropped during rescue: complete blocks still execute directly, and a skeleton-only body returns the stutter retry nudge, which consumes the retry budget instead. Schemas that declare no `required` fail open; a coercion failure keeps the parameter present so a mistyped-but-present param never causes an over-drop.
- **Gate structurally, not on the error phrase.** Rescue eligibility is now decided by generated tool-call XML in the 500 body (`<tool_call` / `<function=`) instead of the `Failed to parse input` message, so it survives upstream error-message rewording. The `<tool_call` prefix is deliberately unclosed: an echo truncated mid-open-tag (EOS or token budget landing inside the tag) is the same re-sampleable artifact as a complete block and returns the generic retry nudge rather than cascading. Genuine faults (OOM/CUDA/slot) never echo generation and request/schema dumps carry `"tool_calls"` as quoted JSON, so they all still cascade as `BackendError` (raw body on `exc.body`, kept off the message).
- **Document the llama.cpp version boundary.** Builds from b9656 (commit 581e8eca8, PR #24329) no longer echo the rejected generation into the 500 body, so the gate never matches there and the 500 cascades — confirmed against a live b9656+ build and pinned by test.

## Testing

- 16 net-new tests across `send()` and `send_stream()`: skeleton-drop behavior (two prior tests inverted in place), phrase-independent gating, truncated open-tag nudge, b9656+ generic-body cascade, schema-dump false-positive guard, no-`required` fail-open, distinct-complete-calls survival.
- Full suite: **1394 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)