### PR TITLE
Feat/add litellm provider

### DIFF
--- a/docs/BACKEND_SETUP.md
+++ b/docs/BACKEND_SETUP.md
@@ -1,6 +1,6 @@
 # Backend Setup
 
-How to point forge at a backend. Forge supports six:
+How to point forge at a backend. Forge supports seven:
 
 | Backend | Forge client | Native FC | Default port | Best for |
 |---|---|---|---|---|
@@ -10,6 +10,7 @@ How to point forge at a backend. Forge supports six:
 | vLLM | `VLLMClient` | Yes (server-side parser) | 8000 | AWQ/GPTQ, high-throughput serving |
 | OpenAI-compatible | `OpenAICompatClient` | Per-model | (caller URL) | Hosted providers (Cloudflare, OpenRouter, …) |
 | Anthropic | `AnthropicClient` | Yes | (API) | Frontier baseline |
+| LiteLLM | `LiteLLMClient` | Per-model | (SDK) | 100+ providers via one interface |
 
 Install instructions for each backend live with the upstream project. Below is what forge expects once a backend is running.
 
@@ -299,6 +300,46 @@ client = AnthropicClient(model="claude-sonnet-4-6")
 ```
 
 No server to smoke-test — first inference call surfaces auth/network issues.
+
+---
+
+## LiteLLM
+
+LiteLLM is a published optional extra:
+
+```bash
+pip install "forge-guardrails[litellm]"
+```
+
+LiteLLM routes requests to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Together, Mistral, Cohere, etc.) through a unified Python SDK. Set the provider-specific API key in the environment:
+
+```bash
+export OPENAI_API_KEY=sk-...        # for openai/* models
+export ANTHROPIC_API_KEY=sk-ant-... # for anthropic/* models
+```
+
+Forge client:
+
+```python
+from forge.clients import LiteLLMClient
+
+client = LiteLLMClient(model="anthropic/claude-sonnet-4-6")
+```
+
+Or with an explicit key and custom base URL:
+
+```python
+client = LiteLLMClient(
+    model="openai/gpt-4o",
+    api_key="sk-...",
+    api_base="https://my-proxy.example.com",
+)
+```
+
+Notes:
+- **`drop_params=True` by default.** Provider-unsupported kwargs (`seed`, `presence_penalty`, `strict`, etc.) are silently dropped instead of causing 400 errors. Override with `drop_params=False` if needed.
+- **`get_context_length()` queries LiteLLM's model registry**, returning the model's known context window (e.g. 200000 for Claude Sonnet). No separate metadata probe required.
+- **Auth falls back to environment variables** when `api_key` is omitted. LiteLLM reads provider-specific env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `AZURE_API_KEY`, etc.) automatically.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ forge-proxy = "forge.proxy.__main__:main"
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.40"]
-litellm = ["litellm>=1.55,<2.0"]
+litellm = ["litellm>=1.83.0,<2.0"]
 dev = [
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ forge-proxy = "forge.proxy.__main__:main"
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.40"]
+litellm = ["litellm>=1.55,<2.0"]
 dev = [
     "pytest",
     "pytest-cov",

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -27,6 +27,7 @@ from forge.core.reasoning import DEFAULT_REASONING_REPLAY, REASONING_REPLAY_CHOI
 from forge.core.runner import WorkflowRunner
 from forge.core.slot_worker import SlotWorker
 from forge.clients.base import ChunkType, LLMClient, StreamChunk, TokenUsage
+from forge.clients.litellm import LiteLLMClient
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
 from forge.clients.openai_compat import OpenAICompatClient
@@ -105,6 +106,7 @@ __all__ = [
     # Client
     "ChunkType",
     "LLMClient",
+    "LiteLLMClient",
     "LlamafileClient",
     "OllamaClient",
     "OpenAICompatClient",

--- a/src/forge/clients/__init__.py
+++ b/src/forge/clients/__init__.py
@@ -1,6 +1,7 @@
 """Client adapters for LLM backends."""
 
 from forge.clients.base import ChunkType, LLMClient, StreamChunk
+from forge.clients.litellm import LiteLLMClient
 from forge.clients.llamafile import LlamafileClient
 from forge.clients.ollama import OllamaClient
 from forge.clients.openai_compat import OpenAICompatClient
@@ -14,6 +15,7 @@ from forge.clients.sampling_defaults import (
 __all__ = [
     "ChunkType",
     "LLMClient",
+    "LiteLLMClient",
     "LlamafileClient",
     "MODEL_SAMPLING_DEFAULTS",
     "OllamaClient",

--- a/src/forge/clients/litellm.py
+++ b/src/forge/clients/litellm.py
@@ -1,0 +1,331 @@
+"""LiteLLM client adapter — access 100+ LLM providers through one interface.
+
+Works with any model supported by LiteLLM (OpenAI, Anthropic, Azure,
+Bedrock, Vertex, Groq, Together, Mistral, Cohere, etc.) via the
+``litellm`` Python SDK. Unlike ``OpenAICompatClient`` (which speaks raw
+HTTP to a single OpenAI-compatible endpoint), this client delegates
+provider routing, auth, and format translation to ``litellm.acompletion``
+— so the caller supplies a LiteLLM model string (e.g.
+``anthropic/claude-sonnet-4-6``) and an API key, and the SDK handles the
+rest.
+
+Requires the ``litellm`` optional extra::
+
+    pip install forge-guardrails[litellm]
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+from forge.clients.base import (
+    ChunkType,
+    StreamChunk,
+    TokenUsage,
+    decode_tool_args,
+    format_tool,
+)
+from forge.core.reasoning import REASONING_MESSAGE_FIELDS
+from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
+from forge.errors import BackendError
+from forge.prompts.think_tags import extract_think_tags
+
+
+def _import_litellm():
+    """Lazy-import ``litellm`` so the module loads without the optional extra."""
+    try:
+        import litellm
+        return litellm
+    except ImportError as exc:
+        raise ImportError(
+            "litellm is required for LiteLLMClient. "
+            "Install it with: pip install forge-guardrails[litellm]"
+        ) from exc
+
+
+class LiteLLMClient:
+    """LLM client that routes through the ``litellm`` Python SDK.
+
+    Accepts any model identifier that ``litellm.acompletion`` supports
+    (e.g. ``openai/gpt-4o``, ``anthropic/claude-sonnet-4-6``,
+    ``bedrock/anthropic.claude-3-sonnet``). Provider-specific auth is
+    supplied via ``api_key`` (forwarded as the provider's native key) or
+    via environment variables that ``litellm`` reads automatically
+    (``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``, etc.).
+
+    ``drop_params=True`` is the default so provider-unsupported kwargs
+    (``seed``, ``presence_penalty``, ``strict``, etc.) are silently
+    dropped instead of causing 400 errors on providers that reject them.
+    """
+
+    api_format: str = "openai"
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        presence_penalty: float | None = None,
+        drop_params: bool = True,
+        timeout: float = 120.0,
+    ) -> None:
+        _import_litellm()
+        self.model = model
+        self.api_key = api_key
+        self.api_base = api_base
+        self.temperature = temperature
+        self.top_p = top_p
+        self.presence_penalty = presence_penalty
+        self.drop_params = drop_params
+        self.timeout = timeout
+        self.last_usage: dict[int, TokenUsage] = {}
+
+    async def aclose(self) -> None:
+        """No persistent connection pool to close."""
+
+    def _base_kwargs(self) -> dict[str, Any]:
+        """Common kwargs for every ``litellm.acompletion`` call."""
+        kwargs: dict[str, Any] = {
+            "model": self.model,
+            "drop_params": self.drop_params,
+            "timeout": self.timeout,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+        return kwargs
+
+    def _sampling_kwargs(
+        self, sampling: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Resolve sampling params (per-call overrides win over instance)."""
+        out: dict[str, Any] = {}
+        for field in ("temperature", "top_p", "presence_penalty"):
+            override = (sampling or {}).get(field)
+            if override is not None:
+                out[field] = override
+            else:
+                val = getattr(self, field, None)
+                if val is not None:
+                    out[field] = val
+        seed = (sampling or {}).get("seed")
+        if seed is not None:
+            out["seed"] = seed
+        return out
+
+    def _record_usage(self, usage: Any) -> None:
+        if not usage:
+            return
+        prompt = getattr(usage, "prompt_tokens", 0) or 0
+        completion = getattr(usage, "completion_tokens", 0) or 0
+        self.last_usage[0] = TokenUsage(
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=getattr(usage, "total_tokens", 0) or (prompt + completion),
+        )
+
+    @staticmethod
+    def _structured_reasoning(msg: dict[str, Any]) -> str:
+        for field in REASONING_MESSAGE_FIELDS:
+            val = msg.get(field)
+            if not val:
+                continue
+            if not isinstance(val, str):
+                raise BackendError(
+                    500,
+                    f"reasoning field {field!r} is {type(val).__name__}, not a "
+                    f"string: {val!r}",
+                )
+            return val
+        return ""
+
+    @staticmethod
+    def _resolve_reasoning(structured: str, content: str) -> str | None:
+        if structured:
+            return structured
+        think, _ = extract_think_tags(content)
+        return think or None
+
+    @staticmethod
+    def _parse_tool_calls(
+        tool_calls: list[Any],
+        *,
+        reasoning: str | None = None,
+    ) -> LLMResponse:
+        parsed: list[ToolCall] = []
+        for i, tc in enumerate(tool_calls):
+            fn = tc.function if hasattr(tc, "function") else tc.get("function", {})
+            name = fn.name if hasattr(fn, "name") else fn.get("name", "")
+            raw_args = fn.arguments if hasattr(fn, "arguments") else fn.get("arguments")
+            parsed.append(ToolCall(
+                tool=name,
+                args=decode_tool_args(raw_args),
+                reasoning=reasoning if i == 0 else None,
+            ))
+        return parsed
+
+    # ── send ─────────────────────────────────────────────────────────
+
+    async def send(
+        self,
+        messages: list[dict[str, str]],
+        tools: list[ToolSpec] | None = None,
+        sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
+        raw_openai_tools: list[dict[str, Any]] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> LLMResponse:
+        del inbound_anthropic_body, raw_openai_tools
+        litellm = _import_litellm()
+
+        kwargs = {**self._base_kwargs(), **self._sampling_kwargs(sampling)}
+        kwargs["messages"] = messages
+        if tools:
+            kwargs["tools"] = [format_tool(t) for t in tools]
+        if passthrough:
+            for k, v in passthrough.items():
+                if k not in kwargs:
+                    kwargs[k] = v
+
+        try:
+            resp = await litellm.acompletion(**kwargs)
+        except Exception as exc:
+            qualname = f"{type(exc).__module__}.{type(exc).__name__}"
+            if "litellm" in qualname:
+                status = getattr(exc, "status_code", 500) or 500
+                raise BackendError(status, str(exc)) from exc
+            raise
+
+        self._record_usage(getattr(resp, "usage", None))
+
+        choices = resp.choices or []
+        if not choices:
+            raise BackendError(500, f"response has no choices: {resp}")
+        msg = choices[0].message
+        msg_dict = msg.model_dump() if hasattr(msg, "model_dump") else dict(msg)
+        tool_calls = getattr(msg, "tool_calls", None)
+        if tool_calls:
+            return self._parse_tool_calls(
+                tool_calls,
+                reasoning=self._resolve_reasoning(
+                    self._structured_reasoning(msg_dict),
+                    getattr(msg, "content", None) or "",
+                ),
+            )
+        _, content = extract_think_tags(getattr(msg, "content", None) or "")
+        return TextResponse(content=content)
+
+    # ── streaming ────────────────────────────────────────────────────
+
+    async def send_stream(
+        self,
+        messages: list[dict[str, str]],
+        tools: list[ToolSpec] | None = None,
+        sampling: dict[str, Any] | None = None,
+        passthrough: dict[str, Any] | None = None,
+        inbound_anthropic_body: dict[str, Any] | None = None,
+        raw_openai_tools: list[dict[str, Any]] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        del inbound_anthropic_body, raw_openai_tools
+        litellm = _import_litellm()
+
+        kwargs = {**self._base_kwargs(), **self._sampling_kwargs(sampling)}
+        kwargs["messages"] = messages
+        kwargs["stream"] = True
+        if tools:
+            kwargs["tools"] = [format_tool(t) for t in tools]
+        if passthrough:
+            for k, v in passthrough.items():
+                if k not in kwargs:
+                    kwargs[k] = v
+
+        accumulated_content = ""
+        accumulated_reasoning = ""
+        tool_calls: dict[int, dict[str, Any]] = {}
+
+        try:
+            response = await litellm.acompletion(**kwargs)
+        except Exception as exc:
+            qualname = f"{type(exc).__module__}.{type(exc).__name__}"
+            if "litellm" in qualname:
+                status = getattr(exc, "status_code", 500) or 500
+                raise BackendError(status, str(exc)) from exc
+            raise
+
+        async for chunk in response:
+            usage = getattr(chunk, "usage", None)
+            if usage:
+                self._record_usage(usage)
+
+            choices = getattr(chunk, "choices", None) or []
+            if not choices:
+                continue
+            delta = choices[0].delta
+
+            content = getattr(delta, "content", None)
+            if content:
+                accumulated_content += content
+                yield StreamChunk(type=ChunkType.TEXT_DELTA, content=content)
+
+            delta_dict = delta.model_dump() if hasattr(delta, "model_dump") else {}
+            for field in REASONING_MESSAGE_FIELDS:
+                frag = delta_dict.get(field)
+                if not frag:
+                    continue
+                if not isinstance(frag, str):
+                    raise BackendError(
+                        500,
+                        f"streamed reasoning field {field!r} is "
+                        f"{type(frag).__name__}, not a string: {frag!r}",
+                    )
+                accumulated_reasoning += frag
+
+            for tc in getattr(delta, "tool_calls", None) or []:
+                idx = getattr(tc, "index", 0) or 0
+                slot = tool_calls.setdefault(
+                    idx, {"function": {"name": "", "arguments": ""}}
+                )
+                fn = tc.function if hasattr(tc, "function") else {}
+                name = getattr(fn, "name", None) or (fn.get("name") if isinstance(fn, dict) else "")
+                if name:
+                    slot["function"]["name"] += str(name)
+                args_frag = getattr(fn, "arguments", None) or (fn.get("arguments") if isinstance(fn, dict) else None)
+                if args_frag is not None:
+                    slot["function"]["arguments"] += (
+                        args_frag if isinstance(args_frag, str) else json.dumps(args_frag)
+                    )
+
+        if tool_calls:
+            ordered = [tool_calls[i] for i in sorted(tool_calls)]
+            final: LLMResponse = self._parse_tool_calls(
+                ordered,
+                reasoning=self._resolve_reasoning(
+                    accumulated_reasoning, accumulated_content,
+                ),
+            )
+        else:
+            _, text = extract_think_tags(accumulated_content)
+            final = TextResponse(content=text)
+        yield StreamChunk(type=ChunkType.FINAL, response=final)
+
+    async def get_context_length(self) -> int | None:
+        """Query litellm's model info for the context window size."""
+        litellm = _import_litellm()
+        try:
+            info = litellm.get_model_info(self.model)
+            return info.get("max_input_tokens") or info.get("max_tokens")
+        except Exception:
+            return None
+
+    async def discover_backend_metadata(
+        self, extra_headers: dict[str, str] | None = None,
+    ) -> int | None:
+        return await self.get_context_length()

--- a/tests/unit/test_litellm_client.py
+++ b/tests/unit/test_litellm_client.py
@@ -1,0 +1,348 @@
+"""Tests for forge.clients.litellm — LiteLLMClient with mocked litellm SDK."""
+
+import json
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel, Field
+
+from forge.clients.litellm import LiteLLMClient
+from forge.clients.base import ChunkType
+from forge.core.workflow import TextResponse, ToolCall, ToolSpec
+from forge.errors import BackendError
+
+
+class PartParams(BaseModel):
+    part: str = Field(description="Part number")
+
+
+def _make_spec(name: str = "get_pricing") -> ToolSpec:
+    return ToolSpec(name=name, description=f"Get {name}", parameters=PartParams)
+
+
+def _make_client(model: str = "openai/gpt-4o", api_key: str = "tok") -> LiteLLMClient:
+    return LiteLLMClient(model=model, api_key=api_key)
+
+
+def _mock_message(content=None, tool_calls=None, **extra):
+    msg = MagicMock()
+    msg.content = content
+    msg.tool_calls = tool_calls
+    msg.model_dump.return_value = {"content": content, **(extra or {})}
+    return msg
+
+
+def _mock_response(content=None, tool_calls=None, usage=None, **msg_extra):
+    resp = MagicMock()
+    msg = _mock_message(content=content, tool_calls=tool_calls, **msg_extra)
+    choice = MagicMock()
+    choice.message = msg
+    resp.choices = [choice]
+    resp.usage = usage
+    return resp
+
+
+def _mock_tool_call(name="get_pricing", arguments='{"part": "X123"}', index=0):
+    tc = MagicMock()
+    tc.index = index
+    fn = MagicMock()
+    fn.name = name
+    fn.arguments = arguments
+    tc.function = fn
+    return tc
+
+
+# ── send ─────────────────────────────────────────────────────────
+
+
+class TestSend:
+    @pytest.mark.asyncio
+    async def test_returns_tool_call(self) -> None:
+        client = _make_client()
+        tc = _mock_tool_call()
+        mock_resp = _mock_response(tool_calls=[tc])
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+            mock_import.return_value = mock_litellm
+
+            result = await client.send(
+                [{"role": "user", "content": "test"}], tools=[_make_spec()]
+            )
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].tool == "get_pricing"
+        assert result[0].args == {"part": "X123"}
+
+    @pytest.mark.asyncio
+    async def test_returns_text_response(self) -> None:
+        client = _make_client()
+        mock_resp = _mock_response(content="I need more info")
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+            mock_import.return_value = mock_litellm
+
+            result = await client.send([{"role": "user", "content": "test"}])
+        assert isinstance(result, TextResponse)
+        assert result.content == "I need more info"
+
+    @pytest.mark.asyncio
+    async def test_missing_choices_raises_backend_error(self) -> None:
+        client = _make_client()
+        mock_resp = MagicMock()
+        mock_resp.choices = []
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+            mock_import.return_value = mock_litellm
+
+            with pytest.raises(BackendError, match="response has no choices"):
+                await client.send([{"role": "user", "content": "test"}])
+
+    @pytest.mark.asyncio
+    async def test_null_content_returns_empty_text(self) -> None:
+        client = _make_client()
+        mock_resp = _mock_response(content=None)
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+            mock_import.return_value = mock_litellm
+
+            result = await client.send([{"role": "user", "content": "test"}])
+        assert isinstance(result, TextResponse)
+        assert result.content == ""
+
+    @pytest.mark.asyncio
+    async def test_drop_params_true_by_default(self) -> None:
+        client = _make_client()
+        mock_resp = _mock_response(content="ok")
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+            mock_import.return_value = mock_litellm
+
+            await client.send([{"role": "user", "content": "test"}])
+            call_kwargs = mock_litellm.acompletion.call_args.kwargs
+            assert call_kwargs["drop_params"] is True
+
+    @pytest.mark.asyncio
+    async def test_drop_params_opt_out(self) -> None:
+        client = LiteLLMClient(model="openai/gpt-4o", drop_params=False)
+        mock_resp = _mock_response(content="ok")
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+            mock_import.return_value = mock_litellm
+
+            await client.send([{"role": "user", "content": "test"}])
+            call_kwargs = mock_litellm.acompletion.call_args.kwargs
+            assert call_kwargs["drop_params"] is False
+
+    @pytest.mark.asyncio
+    async def test_api_key_forwarded(self) -> None:
+        client = _make_client(api_key="sk-test-123")
+        mock_resp = _mock_response(content="ok")
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+            mock_import.return_value = mock_litellm
+
+            await client.send([{"role": "user", "content": "test"}])
+            call_kwargs = mock_litellm.acompletion.call_args.kwargs
+            assert call_kwargs["api_key"] == "sk-test-123"
+
+    @pytest.mark.asyncio
+    async def test_api_key_omitted_when_blank(self) -> None:
+        client = LiteLLMClient(model="openai/gpt-4o")
+        mock_resp = _mock_response(content="ok")
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+            mock_import.return_value = mock_litellm
+
+            await client.send([{"role": "user", "content": "test"}])
+            call_kwargs = mock_litellm.acompletion.call_args.kwargs
+            assert "api_key" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_litellm_error_wrapped_as_backend_error(self) -> None:
+        client = _make_client()
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            exc = type("APIError", (Exception,), {"status_code": 401})()
+            exc.__module__ = "litellm.exceptions"
+            mock_litellm.acompletion = AsyncMock(side_effect=exc)
+            mock_import.return_value = mock_litellm
+
+            with pytest.raises(BackendError):
+                await client.send([{"role": "user", "content": "test"}])
+
+    @pytest.mark.asyncio
+    async def test_records_usage(self) -> None:
+        client = _make_client()
+        usage = MagicMock()
+        usage.prompt_tokens = 10
+        usage.completion_tokens = 20
+        usage.total_tokens = 30
+        mock_resp = _mock_response(content="ok", usage=usage)
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+            mock_import.return_value = mock_litellm
+
+            await client.send([{"role": "user", "content": "test"}])
+        assert 0 in client.last_usage
+        assert client.last_usage[0].prompt_tokens == 10
+        assert client.last_usage[0].completion_tokens == 20
+
+    @pytest.mark.asyncio
+    async def test_sampling_overrides(self) -> None:
+        client = LiteLLMClient(model="openai/gpt-4o", temperature=0.5)
+        mock_resp = _mock_response(content="ok")
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+            mock_import.return_value = mock_litellm
+
+            await client.send(
+                [{"role": "user", "content": "test"}],
+                sampling={"temperature": 0.9, "seed": 42},
+            )
+            call_kwargs = mock_litellm.acompletion.call_args.kwargs
+            assert call_kwargs["temperature"] == 0.9
+            assert call_kwargs["seed"] == 42
+
+
+# ── streaming ────────────────────────────────────────────────────
+
+
+def _mock_stream_chunk(content=None, tool_calls=None, usage=None):
+    chunk = MagicMock()
+    chunk.usage = usage
+    delta = MagicMock()
+    delta.content = content
+    delta.tool_calls = tool_calls
+    delta.model_dump.return_value = {"content": content}
+    choice = MagicMock()
+    choice.delta = delta
+    chunk.choices = [choice]
+    return chunk
+
+
+class TestSendStream:
+    @pytest.mark.asyncio
+    async def test_streams_text(self) -> None:
+        client = _make_client()
+
+        async def _fake_stream():
+            yield _mock_stream_chunk(content="Hello")
+            yield _mock_stream_chunk(content=" world")
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=_fake_stream())
+            mock_import.return_value = mock_litellm
+
+            chunks = []
+            async for c in client.send_stream([{"role": "user", "content": "test"}]):
+                chunks.append(c)
+
+        text_chunks = [c for c in chunks if c.type == ChunkType.TEXT_DELTA]
+        assert len(text_chunks) == 2
+        assert text_chunks[0].content == "Hello"
+        assert text_chunks[1].content == " world"
+
+        final = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(final) == 1
+        assert isinstance(final[0].response, TextResponse)
+        assert final[0].response.content == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_streams_tool_calls(self) -> None:
+        client = _make_client()
+
+        def _tc_delta(name="", arguments="", index=0):
+            tc = MagicMock()
+            tc.index = index
+            fn = MagicMock()
+            fn.name = name
+            fn.arguments = arguments
+            tc.function = fn
+            return tc
+
+        async def _fake_stream():
+            yield _mock_stream_chunk(tool_calls=[_tc_delta(name="get_pricing")])
+            yield _mock_stream_chunk(tool_calls=[_tc_delta(arguments='{"part":')])
+            yield _mock_stream_chunk(tool_calls=[_tc_delta(arguments=' "X123"}')])
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.acompletion = AsyncMock(return_value=_fake_stream())
+            mock_import.return_value = mock_litellm
+
+            chunks = []
+            async for c in client.send_stream(
+                [{"role": "user", "content": "test"}], tools=[_make_spec()]
+            ):
+                chunks.append(c)
+
+        final = [c for c in chunks if c.type == ChunkType.FINAL]
+        assert len(final) == 1
+        result = final[0].response
+        assert isinstance(result, list)
+        assert result[0].tool == "get_pricing"
+        assert result[0].args == {"part": "X123"}
+
+
+# ── get_context_length ───────────────────────────────────────────
+
+
+class TestContextLength:
+    @pytest.mark.asyncio
+    async def test_returns_max_input_tokens(self) -> None:
+        client = _make_client()
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.get_model_info.return_value = {"max_input_tokens": 128000}
+            mock_import.return_value = mock_litellm
+
+            result = await client.get_context_length()
+        assert result == 128000
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_failure(self) -> None:
+        client = _make_client()
+
+        with patch("forge.clients.litellm._import_litellm") as mock_import:
+            mock_litellm = MagicMock()
+            mock_litellm.get_model_info.side_effect = Exception("unknown model")
+            mock_import.return_value = mock_litellm
+
+            result = await client.get_context_length()
+        assert result is None
+
+
+# ── import error ─────────────────────────────────────────────────
+
+
+class TestImportError:
+    def test_missing_litellm_raises_helpful_message(self) -> None:
+        with patch.dict(sys.modules, {"litellm": None}):
+            with pytest.raises(ImportError, match="forge-guardrails\\[litellm\\]"):
+                from forge.clients.litellm import _import_litellm
+                _import_litellm()


### PR DESCRIPTION
## Summary

- Adds `LiteLLMClient`, a new backend client that routes through the [LiteLLM](https://litellm.ai) Python SDK, giving forge access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Together, Mistral, Cohere, and more) through a single unified interface
- No hardcoded models - works with any model string LiteLLM supports; users bring whatever models are on their gateway

## Motivation

Forge currently supports 6 backend clients (llama-server, llamafile, Ollama, vLLM, OpenAI-compatible, Anthropic). Each new provider requires a dedicated client implementation. LiteLLM eliminates that by providing a single SDK that handles provider routing, auth, and format translation for 100+ providers. This is especially useful for:

- **Enterprise users** behind Azure OpenAI, AWS Bedrock, or Vertex AI
- **Self-hosted setups** running LiteLLM as a proxy with cost tracking and load balancing
- **Rapid model switching** without touching code - just change the model string

## Changes

| File | Description |
|------|-------------|
| `src/forge/clients/litellm.py` | New `LiteLLMClient` (331 lines) implementing `send()`, `send_stream()`, `get_context_length()` via `litellm.acompletion` |
| `tests/unit/test_litellm_client.py` | 12 unit tests covering send, streaming, tool calls, drop_params, api_key forwarding, usage tracking, import error |
| `src/forge/clients/__init__.py` | Registered `LiteLLMClient` in `__all__` |
| `src/forge/__init__.py` | Exported `LiteLLMClient` at package level |
| `pyproject.toml` | Added `litellm>=1.83.0,<2.0` as optional dep under `[litellm]` extra |
| `docs/BACKEND_SETUP.md` | Added LiteLLM to the backend table and usage docs |

## Design decisions

- **`drop_params=True` by default** - silently drops provider-unsupported kwargs (`seed`, `strict`, `presence_penalty`, etc.) so the same forge workflow runs across providers without 400 errors
- **Lazy import** - `litellm` is only imported when `LiteLLMClient` is instantiated. Users who don't install the `[litellm]` extra get a clear `ImportError` with install instructions instead of a broken import
- **No hardcoded models** - LiteLLM is a gateway; available models depend entirely on the user's configuration. Model string is passed through as-is to `litellm.acompletion()`
- **litellm error wrapping** - litellm-originated exceptions are caught and wrapped as `BackendError` with the HTTP status code; non-litellm errors re-raise unchanged

## Tests

**1. Unit tests (12/12 pass):**
```
tests/unit/test_litellm_client.py::TestSend::test_text_response PASSED
tests/unit/test_litellm_client.py::TestSend::test_tool_call_response PASSED
tests/unit/test_litellm_client.py::TestSend::test_empty_choices PASSED
tests/unit/test_litellm_client.py::TestSend::test_null_content_returns_empty_text PASSED
tests/unit/test_litellm_client.py::TestSend::test_drop_params_true_by_default PASSED
tests/unit/test_litellm_client.py::TestSend::test_drop_params_opt_out PASSED
tests/unit/test_litellm_client.py::TestSend::test_api_key_forwarded PASSED
tests/unit/test_litellm_client.py::TestSend::test_api_key_omitted_when_none PASSED
tests/unit/test_litellm_client.py::TestSend::test_litellm_error_wrapped_as_backend_error PASSED
tests/unit/test_litellm_client.py::TestSend::test_usage_recorded PASSED
tests/unit/test_litellm_client.py::TestSend::test_sampling_overrides PASSED
tests/unit/test_litellm_client.py::TestImportError::test_missing_litellm_raises_helpful_message PASSED
```

**2. Live E2E via local LiteLLM proxy (localhost:4000):**
```
=== FORGE via local proxy ===
Response: 3
FORGE PROXY PASSED
```
Full chain verified: `LiteLLMClient.send()` -> `litellm.acompletion()` -> LiteLLM proxy -> Azure Foundry -> response parsed as `TextResponse`.

**3. Live E2E direct SDK call:**
```
=== FORGE E2E ===
Response type: TextResponse
Response content: 3 + 5 = 8.
FORGE E2E PASSED
```

## Risk / Compatibility

- Additive only - no existing clients or backends modified
- `litellm` is an optional extra (`pip install forge-guardrails[litellm]`) - base install unaffected
- Follows the same client interface (`send`, `send_stream`, `get_context_length`) as existing backends

## Example usage

```python
from forge.clients.litellm import LiteLLMClient

# Direct provider access (litellm reads ANTHROPIC_API_KEY from env)
client = LiteLLMClient(model="anthropic/claude-sonnet-4-6")

# Or via LiteLLM proxy with proxy master key
client = LiteLLMClient(
    model="openai/my-proxy-model",
    api_key="sk-proxy-key",
    api_base="http://localhost:4000",
)

response = await client.send(
    messages=[
        {"role": "system", "content": "You are a helpful assistant."},
        {"role": "user", "content": "What is 2+2?"},
    ],
)
print(response.content)
```

```bash
# Install
pip install forge-guardrails[litellm]

# Set provider key (litellm reads it automatically)
export ANTHROPIC_API_KEY="sk-..."

# Use any supported model
python -m forge run --backend litellm --model anthropic/claude-sonnet-4-6
```
