### PR TITLE
feat(proxy): forward llamacpp endpoints, /v1/models, and /health

### DIFF
--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -641,3 +641,22 @@ class AnthropicClient:
         ignores ``extra_headers``.
         """
         return 200_000
+
+    def forward_request(
+        self,
+        method: str,
+        target: str,
+        body: bytes = b"",
+        extra_headers: dict[str, str] | None = None,
+        stream: bool = False,
+    ) -> None:
+        """No raw HTTP surface to forward to — returns None.
+
+        This client speaks through the Anthropic SDK, not a raw httpx pool,
+        and the llama.cpp-native endpoints don't exist on Anthropic-shape
+        backends (Anthropic's own ``GET /v1/models`` speaks a different,
+        paginated wire shape). The proxy answers 404 itself — except
+        ``/v1/models``, where it falls back to synthesizing a single-entry
+        list from this client's identity.
+        """
+        return None

--- a/src/forge/clients/base.py
+++ b/src/forge/clients/base.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import json
 from collections.abc import AsyncIterator, Mapping
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Protocol, runtime_checkable
 
+import httpx
+
 from forge.core.workflow import LLMResponse, ToolSpec
-from forge.errors import MultipleCredentialsError
+from forge.errors import BackendError, MultipleCredentialsError
 
 # Verbatim OpenAI-shape payloads forwarded by the proxy. The proxy hands the
 # client the user's original ``tools`` array so the backend sees the exact
@@ -372,6 +375,70 @@ class LLMClient(Protocol):
         """
         ...
 
+    def forward_request(
+        self,
+        method: str,
+        target: str,
+        body: bytes = b"",
+        extra_headers: dict[str, str] | None = None,
+        stream: bool = False,
+    ) -> AbstractAsyncContextManager[Any] | None:
+        """Open a verbatim HTTP forward to the backend's server root.
+
+        The proxy's passthrough channel for llama.cpp-native endpoints
+        (``/props``, the ``/models`` router family, ``/v1/models``): the raw
+        inbound body rides through unchanged and the backend's response —
+        status code included — is the answer, never remapped, so a backend
+        that doesn't serve ``target`` answers with its own 404. ``target`` is
+        the root-relative path plus raw query string; clients whose
+        ``base_url`` carries a ``/v1`` suffix strip it. ``stream=True``
+        disables the read timeout (SSE feeds are silent between events).
+
+        Returns an async context manager yielding the streaming
+        ``httpx.Response`` (``status_code`` / ``aread()`` / ``aiter_raw()``),
+        or None when the client has no raw HTTP surface to forward to (the
+        Anthropic SDK path); the proxy then answers 404 itself. Entering the
+        context manager raises ``BackendError`` when the backend is
+        unreachable.
+        """
+        ...
+
     async def aclose(self) -> None:
         """Release held network resources (e.g. the httpx connection pool)."""
         ...
+
+
+@asynccontextmanager
+async def open_backend_forward(
+    http: httpx.AsyncClient,
+    url: str,
+    method: str,
+    body: bytes = b"",
+    headers: dict[str, str] | None = None,
+    stream: bool = False,
+) -> Any:
+    """Shared ``forward_request`` implementation for OpenAI-shape clients.
+
+    Opens ``method url`` on the client's httpx pool in streaming mode and
+    yields the response for the proxy to relay verbatim — the caller decides
+    whether to buffer (``aread``) or stream (``aiter_raw``). ``stream=True``
+    disables the read timeout for long-lived SSE feeds that are legitimately
+    silent between events; buffered forwards keep the pool's configured
+    timeout so a hung backend still fails loud. Raises ``BackendError`` on a
+    connection-level failure; an HTTP error status is the backend's answer
+    and is yielded, never raised.
+    """
+
+    timeout = httpx.Timeout(None) if stream else httpx.USE_CLIENT_DEFAULT
+    ctx = http.stream(
+        method, url, content=body or None, headers=headers, timeout=timeout,
+    )
+    try:
+        resp = await ctx.__aenter__()
+    except httpx.HTTPError as exc:
+        raise BackendError(502, f"backend {url} unreachable: {exc}") from exc
+    try:
+        yield resp
+    finally:
+        await ctx.__aexit__(None, None, None)
+

--- a/src/forge/clients/llamafile.py
+++ b/src/forge/clients/llamafile.py
@@ -6,6 +6,7 @@ import json
 import logging
 import re
 from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,7 @@ from forge.clients.base import (
     TokenUsage,
     decode_tool_args,
     format_tool,
+    open_backend_forward,
     resolve_request_headers,
     static_auth_present,
 )
@@ -742,6 +744,30 @@ class LlamafileClient:
             return int(n_ctx)
         except (ValueError, TypeError) as exc:
             raise BackendError(502, f"llama.cpp /props n_ctx not an integer: {exc}") from exc
+
+    def forward_request(
+        self,
+        method: str,
+        target: str,
+        body: bytes = b"",
+        extra_headers: dict[str, str] | None = None,
+        stream: bool = False,
+    ) -> AbstractAsyncContextManager[Any]:
+        """Verbatim passthrough to the llama-server root (see LLMClient).
+
+        llama.cpp's bespoke endpoints (``/props``, the ``/models`` router
+        family) live on the server root, so the ``/v1`` suffix is stripped
+        from ``base_url``; ``target`` already carries its own prefix when it
+        needs one (``/v1/models``). Status codes are answers here — 400
+        "model is not loaded" from ``/props?model=``, 400 "already running" /
+        404 unknown-name from ``/models/load`` — and ride through unmapped.
+        """
+        root = self.base_url.rstrip("/").removesuffix("/v1")
+        return open_backend_forward(
+            self._http, f"{root}{target}", method, body,
+            self._request_headers(extra_headers), stream=stream,
+        )
+
 
     async def _send_native(
         self,

--- a/src/forge/clients/ollama.py
+++ b/src/forge/clients/ollama.py
@@ -15,6 +15,7 @@ from forge.clients.base import (
     decode_tool_args,
     flatten_content_to_text,
     format_tool,
+    open_backend_forward,
     resolve_request_headers,
     static_auth_present,
 )
@@ -466,3 +467,25 @@ class OllamaClient:
         and ignores ``extra_headers``.
         """
         return self._num_ctx
+
+    def forward_request(
+        self,
+        method: str,
+        target: str,
+        body: bytes = b"",
+        extra_headers: dict[str, str] | None = None,
+        stream: bool = False,
+    ) -> AbstractAsyncContextManager[Any]:
+        """Verbatim passthrough to the backend's server root (see LLMClient).
+
+        The backend decides which endpoints exist — one that doesn't serve
+        ``target`` answers its own 404, and that answer rides through
+        unmapped. Ollama's ``base_url`` is already the
+        server root (its OpenAI shim lives under ``/v1``, which ``target``
+        carries when needed), so nothing is stripped.
+        """
+        root = self.base_url.rstrip("/").removesuffix("/v1")
+        return open_backend_forward(
+            self._http, f"{root}{target}", method, body,
+            self._request_headers(extra_headers), stream=stream,
+        )

--- a/src/forge/clients/openai_compat.py
+++ b/src/forge/clients/openai_compat.py
@@ -24,6 +24,7 @@ from forge.clients.base import (
     TokenUsage,
     decode_tool_args,
     format_tool,
+    open_backend_forward,
     resolve_request_headers,
     static_auth_present,
 )
@@ -442,3 +443,23 @@ class OpenAICompatClient:
         into the proxy's deferred external path.
         """
         return None
+
+    def forward_request(
+        self,
+        method: str,
+        target: str,
+        body: bytes = b"",
+        extra_headers: dict[str, str] | None = None,
+        stream: bool = False,
+    ) -> AbstractAsyncContextManager[Any]:
+        """Verbatim passthrough to the backend's server root (see LLMClient).
+
+        The backend decides which endpoints exist — one that doesn't serve
+        ``target`` answers its own 404, and that answer rides through
+        unmapped.
+        """
+        root = self.base_url.rstrip("/").removesuffix("/v1")
+        return open_backend_forward(
+            self._http, f"{root}{target}", method, body,
+            self._request_headers(extra_headers), stream=stream,
+        )

--- a/src/forge/clients/vllm.py
+++ b/src/forge/clients/vllm.py
@@ -32,6 +32,7 @@ from forge.clients.base import (
     TokenUsage,
     decode_tool_args,
     format_tool,
+    open_backend_forward,
     resolve_request_headers,
     static_auth_present,
 )
@@ -542,3 +543,23 @@ class VLLMClient:
                 "report one",
             )
         return int(max_model_len)
+
+    def forward_request(
+        self,
+        method: str,
+        target: str,
+        body: bytes = b"",
+        extra_headers: dict[str, str] | None = None,
+        stream: bool = False,
+    ) -> AbstractAsyncContextManager[Any]:
+        """Verbatim passthrough to the backend's server root (see LLMClient).
+
+        The backend decides which endpoints exist — one that doesn't serve
+        ``target`` answers its own 404, and that answer rides through
+        unmapped.
+        """
+        root = self.base_url.rstrip("/").removesuffix("/v1")
+        return open_backend_forward(
+            self._http, f"{root}{target}", method, body,
+            self._request_headers(extra_headers), stream=stream,
+        )

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -34,6 +34,25 @@ logger = logging.getLogger("forge.proxy")
 # Maximum request body size (16 MB)
 _MAX_BODY = 16 * 1024 * 1024
 
+# llama.cpp-native endpoints forwarded to the backend verbatim, mirroring
+# llama-server's own route registrations (tools/server/server.cpp): the
+# bespoke root-only surface — /props and the router's /models management
+# family. The backend's answer, status code included, IS the client's answer
+# (400 "model is not loaded" from /props?model=, 400/404 from /models/load,
+# and a backend that doesn't serve the endpoint answers its own 404). The
+# value flags the router's SSE feed, relayed unbuffered with the read
+# timeout off. GET /models — llama-server's root alias of /v1/models — is
+# routed through _handle_models instead, for the Anthropic-path fallback.
+_PASSTHROUGH_ROUTES: dict[tuple[str, str], bool] = {
+    ("GET", "/props"): False,
+    ("POST", "/props"): False,
+    ("POST", "/models"): False,        # router: add a model
+    ("DELETE", "/models"): False,      # router: remove a model
+    ("POST", "/models/load"): False,
+    ("POST", "/models/unload"): False,
+    ("GET", "/models/sse"): True,      # router: model-status SSE feed
+}
+
 
 @dataclass
 class _QueueItem:
@@ -165,7 +184,9 @@ class HTTPServer:
             # Strip the query string before routing. Real clients append
             # query params (e.g. Claude Code POSTs /v1/messages?beta=true);
             # exact-matching the raw target would 404 every such request.
+            # Kept separately ("" or "?...") for routes that forward it.
             path = raw_path.split("?", 1)[0]
+            query = raw_path[len(path):]
 
             # Read headers
             headers = await self._read_headers(reader)
@@ -186,10 +207,17 @@ class HTTPServer:
                 )
 
             # Route
-            if method == "GET" and path == "/health":
-                await self._handle_health(writer)
-            elif method == "GET" and path == "/v1/models":
-                await self._handle_models(writer)
+            # /health, /v1/health, /models, /v1/models require special
+            # casing when proxying OpenAI client -> forge -> Anthropic API
+            if method == "GET" and path in ("/health", "/v1/health"):
+                await self._handle_health(writer, path, query, headers)
+            elif method == "GET" and path in ("/v1/models", "/models"):
+                await self._handle_models(writer, path, query, headers)
+            elif (method, path) in _PASSTHROUGH_ROUTES:
+                await self._handle_passthrough(
+                    writer, method, path, query, body_bytes, headers,
+                    sse=_PASSTHROUGH_ROUTES[(method, path)],
+                )
             elif method == "POST" and path == "/v1/chat/completions":
                 await self._handle_completions(
                     writer, body_bytes, protocol="openai", headers=headers,
@@ -237,18 +265,123 @@ class HTTPServer:
                 headers[key] = value.strip()
         return headers
 
-    async def _handle_health(self, writer: asyncio.StreamWriter) -> None:
-        """GET /health — returns OK."""
-        body = json.dumps({"status": "ok"})
-        await self._send_json(writer, 200, body)
+    async def _handle_health(
+        self, writer: asyncio.StreamWriter, path: str, query: str,
+        headers: dict[str, str],
+    ) -> None:
+        """GET /health (and llama-server's /v1/health alias).
+        Forward request to OpenAI-compatible API.
+        Return a dummy answer when an OpenAI client queries Anthropic API.
+        """
+        # Capability probe only — constructing the CM performs no I/O
+        if self._client.forward_request("GET", path) is None:
+            # Fallback for OpenAI client -> forge -> Anthropic API
+            body = json.dumps({"status": "ok"})
+            await self._send_json(writer, 200, body)
+            return
 
-    async def _handle_models(self, writer: asyncio.StreamWriter) -> None:
-        """GET /v1/models — report the backend model the proxy is fronting."""
-        body = json.dumps({
-            "object": "list",
-            "data": [{"id": self._client.model, "object": "model"}],
-        })
-        await self._send_json(writer, 200, body)
+        await self._handle_passthrough(writer, "GET", path, query, b"", headers)
+
+    async def _handle_models(
+        self, writer: asyncio.StreamWriter, path: str, query: str,
+        headers: dict[str, str],
+    ) -> None:
+        """GET /v1/models (and llama-server's /health alias).
+        Forward request to OpenAI-compatible API.
+        Return a dummy answer when an OpenAI client queries Anthropic API.
+        """
+        # Capability probe only — constructing the CM performs no I/O
+        if self._client.forward_request("GET", path) is None:
+            # Fallback for OpenAI client -> forge -> Anthropic API
+            body = json.dumps({
+                "object": "list",
+                "data": [{"id": self._client.model, "object": "model"}],
+            })
+            await self._send_json(writer, 200, body)
+            return
+
+        await self._handle_passthrough(writer, "GET", path, query, b"", headers)
+
+    async def _handle_passthrough(
+        self,
+        writer: asyncio.StreamWriter,
+        method: str,
+        path: str,
+        query: str,
+        body_bytes: bytes,
+        headers: dict[str, str],
+        sse: bool = False,
+    ) -> None:
+        """Forward a request to the backend and relay the answer, verbatim.
+
+        The table-driven passthrough lane for llama.cpp-native endpoints
+        (_PASSTHROUGH_ROUTES) and the /v1/models family: raw body and query
+        string ride through unchanged, and the backend's status and body come
+        back unmapped — statuses are answers on this surface (400 "model is
+        not loaded", the backend's own 404 for an endpoint it doesn't serve).
+        The single inbound credential is relocated exactly like the
+        completions path; a connection-level failure is the proxy's 502.
+        Backends with no raw HTTP surface (Anthropic SDK path) return None
+        and get forge's own 404.
+
+        ``sse=True`` relays chunks as they arrive instead of buffering — the
+        router's status feed is long-lived and silent between model state
+        changes. A disconnected client is noticed at the next event write; an
+        idle relay holds its backend connection until then, which is fine for
+        a status feed. A refused subscription (non-200) buffers and forwards
+        like any other answer.
+        """
+        try:
+            extra_headers = resolve_inbound_credential(
+                headers,
+                source_protocol="openai",
+                target_protocol=self._backend_protocol,
+                backend_api_key_present=self._backend_api_key_present,
+            )
+            cm = self._client.forward_request(
+                method, f"{path}{query}", body=body_bytes,
+                extra_headers=extra_headers, stream=sse,
+            )
+        except Exception as exc:
+            await self._send_exception(writer, exc, "openai", as_stream=False)
+            return
+        if cm is None:
+            await self._send_error(writer, 404, "Not found")
+            return
+        flushed = False
+        try:
+            async with cm as resp:
+                if not sse or resp.status_code != 200:
+                    body = await resp.aread()
+                    await self._send_json(
+                        writer, resp.status_code,
+                        body.decode("utf-8", errors="replace"),
+                    )
+                    return
+                await self._send_sse_header(writer)
+                flushed = True
+                async for chunk in resp.aiter_raw():
+                    if writer.is_closing():
+                        return
+                    if not chunk:
+                        # A zero-length chunk is the chunked-encoding
+                        # terminator — emitting one would end the stream.
+                        continue
+                    writer.write(f"{len(chunk):x}\r\n".encode() + chunk + b"\r\n")
+                    await writer.drain()
+                if not writer.is_closing():
+                    writer.write(b"0\r\n\r\n")
+                    await writer.drain()
+        except Exception as exc:
+            if not flushed:
+                await self._send_exception(writer, exc, "openai", as_stream=False)
+            else:
+                # Headers are already on the wire — a status can't change and
+                # writing an error body would corrupt the SSE stream. Ending
+                # the connection (the caller closes it) is the only honest
+                # signal left; SSE clients reconnect by design.
+                logger.info("<< passthrough relay ended: %s", str(exc)[:120])
+
 
     async def _handle_completions(
         self,

--- a/tests/unit/test_clients_base.py
+++ b/tests/unit/test_clients_base.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
-from forge.clients.base import decode_tool_args
+import httpx
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from forge.clients.anthropic import AnthropicClient
+from forge.clients.base import decode_tool_args, open_backend_forward
+from forge.clients.llamafile import LlamafileClient
+from forge.clients.ollama import OllamaClient
+from forge.clients.openai_compat import OpenAICompatClient
+from forge.clients.vllm import VLLMClient
+from forge.errors import BackendError
 
 
 class TestDecodeToolArgs:
@@ -45,3 +55,161 @@ class TestDecodeToolArgs:
         # Any other already-decoded shape is left for the validator to judge.
         assert decode_tool_args(123) == 123
         assert decode_tool_args([1, 2]) == [1, 2]
+
+
+# ── forward_request / open_backend_forward (proxy passthrough) ────
+#
+# The passthrough engine is implemented ONCE (open_backend_forward) and each
+# OpenAI-shape client wires it to its own server root, so the engine contract
+# is tested once and the per-client wiring is a parameterized matrix.
+class _FakeStreamCtx:
+    """httpx stream CM stand-in; optionally raises on enter (connect fail)."""
+
+    def __init__(self, status: int = 200, enter_exc: Exception | None = None):
+        self.status_code = status
+        self._enter_exc = enter_exc
+
+    async def __aenter__(self):
+        if self._enter_exc is not None:
+            raise self._enter_exc
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _mock_http(status: int = 200, enter_exc: Exception | None = None) -> AsyncMock:
+    http = AsyncMock()
+    http.stream = MagicMock(return_value=_FakeStreamCtx(status, enter_exc))
+    return http
+
+
+class TestOpenBackendForward:
+    """The shared passthrough engine: verbatim, fail-loud only on transport.
+
+    Contract: the backend's response object is yielded whatever its status
+    (an HTTP error status is the backend's answer, never raised); only a
+    connection-level failure raises BackendError(502); the read timeout is
+    disabled for stream=True (SSE feeds are silent between events) and left
+    at the pool default otherwise.
+    """
+
+    @pytest.mark.asyncio
+    async def test_yields_response_and_wires_request(self) -> None:
+        http = _mock_http()
+        cm = open_backend_forward(
+            http, "http://t:8080/props?x=1", "GET", b"", {"h": "v"},
+        )
+        async with cm as resp:
+            assert resp.status_code == 200
+        args = http.stream.call_args
+        assert args.args == ("GET", "http://t:8080/props?x=1")
+        assert args.kwargs["headers"] == {"h": "v"}
+        assert args.kwargs["content"] is None  # empty body → no body
+
+    @pytest.mark.asyncio
+    async def test_body_bytes_ride_through(self) -> None:
+        http = _mock_http()
+        async with open_backend_forward(
+            http, "http://t:8080/models/load", "POST", b'{"model": "x"}',
+        ):
+            pass
+        assert http.stream.call_args.kwargs["content"] == b'{"model": "x"}'
+
+    @pytest.mark.asyncio
+    async def test_error_status_yielded_not_raised(self) -> None:
+        http = _mock_http(status=404)
+        async with open_backend_forward(http, "http://t:8080/nope", "GET") as resp:
+            assert resp.status_code == 404  # the backend's answer, not a fault
+
+    @pytest.mark.asyncio
+    async def test_connect_error_raises_502(self) -> None:
+        http = _mock_http(enter_exc=httpx.ConnectError("refused"))
+        with pytest.raises(BackendError) as exc_info:
+            async with open_backend_forward(http, "http://t:8080/props", "GET"):
+                pass
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_stream_disables_read_timeout(self) -> None:
+        http = _mock_http()
+        async with open_backend_forward(
+            http, "http://t:8080/models/sse", "GET", stream=True,
+        ):
+            pass
+        assert http.stream.call_args.kwargs["timeout"].read is None
+
+    @pytest.mark.asyncio
+    async def test_buffered_keeps_pool_timeout(self) -> None:
+        http = _mock_http()
+        async with open_backend_forward(http, "http://t:8080/props", "GET"):
+            pass
+        assert http.stream.call_args.kwargs["timeout"] is httpx.USE_CLIENT_DEFAULT
+
+
+# One row per OpenAI-shape client: factory and the server root its
+# forward_request must derive from base_url (/v1 suffix stripped; Ollama's
+# base_url is already the root).
+_CLIENT_ROOTS = [
+    pytest.param(
+        lambda: LlamafileClient(gguf_path="m", base_url="http://t:8080/v1"),
+        "http://t:8080", id="llamafile",
+    ),
+    pytest.param(
+        lambda: OpenAICompatClient(model="m", base_url="https://api.example.com/v1"),
+        "https://api.example.com", id="openai_compat",
+    ),
+    pytest.param(
+        lambda: VLLMClient(model_path="m", base_url="http://t:8000/v1"),
+        "http://t:8000", id="vllm",
+    ),
+    pytest.param(
+        lambda: OllamaClient(model="m", base_url="http://t:11434"),
+        "http://t:11434", id="ollama",
+    ),
+]
+
+
+class TestForwardRequestWiring:
+    """Per-client forward_request wiring over the shared engine."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("make_client,root", _CLIENT_ROOTS)
+    async def test_target_appended_to_server_root(self, make_client, root) -> None:
+        client = make_client()
+        client._http = _mock_http()
+        async with client.forward_request("GET", "/props?model=X&autoload=false"):
+            pass
+        args = client._http.stream.call_args
+        assert args.args == ("GET", f"{root}/props?model=X&autoload=false")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("make_client,root", _CLIENT_ROOTS)
+    async def test_v1_target_keeps_its_own_prefix(self, make_client, root) -> None:
+        # /v1/models carries its own prefix — the root derivation must not
+        # eat it (nor double it on clients whose base_url ends in /v1).
+        client = make_client()
+        client._http = _mock_http()
+        async with client.forward_request("GET", "/v1/models"):
+            pass
+        assert client._http.stream.call_args.args == ("GET", f"{root}/v1/models")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("make_client,root", _CLIENT_ROOTS)
+    async def test_extra_headers_threaded(self, make_client, root) -> None:
+        client = make_client()
+        client._http = _mock_http()
+        extra = {"Authorization": "Bearer inbound-token"}
+        async with client.forward_request("GET", "/props", extra_headers=extra):
+            pass
+        sent = client._http.stream.call_args.kwargs["headers"]
+        assert sent == client._request_headers(extra)
+
+
+class TestAnthropicForwardRequest:
+    def test_returns_none(self) -> None:
+        # The Anthropic client speaks through the SDK — no raw HTTP surface
+        # to forward to. The proxy answers 404 itself (synthesized entry for
+        # the /v1/models family). Sync method: called without await.
+        client = AnthropicClient(model="claude-test", api_key="dummy")
+        assert client.forward_request("GET", "/props") is None

--- a/tests/unit/test_llamafile_client.py
+++ b/tests/unit/test_llamafile_client.py
@@ -111,6 +111,7 @@ def _mock_response(data: dict, status_code: int = 200) -> MagicMock:
     """Create a mock httpx Response."""
     resp = MagicMock()
     resp.json.return_value = data
+    resp.text = json.dumps(data)
     resp.status_code = status_code
     if status_code >= 400:
         resp.raise_for_status.side_effect = httpx.HTTPStatusError(

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from forge.context.manager import ContextManager
 from forge.context.strategies import NoCompact
@@ -23,6 +23,11 @@ def _mock_client(response):
     client.api_format = "ollama"
     client.model = "mock-model"
     client.send = AsyncMock(return_value=response)
+    # No raw HTTP backend to forward to (passthrough tests override this).
+    # forward_request is called WITHOUT await — it returns an async context
+    # manager, not a coroutine — so it needs a sync mock, or the None check
+    # misfires on the auto-created coroutine.
+    client.forward_request = MagicMock(return_value=None)
     return client
 
 
@@ -138,6 +143,15 @@ class TestHealthAndModels:
         assert status == 200
         data = json.loads(body)
         assert data["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_v1_health_alias(self, server_factory):
+        # Mirrors llama-server's own /v1/health alias of its public health
+        # endpoint; same fallback as /health.
+        srv, port = await server_factory(TextResponse(content=""))
+        status, body = await _http_request(port, "GET", "/v1/health")
+        assert status == 200
+        assert json.loads(body)["status"] == "ok"
 
     @pytest.mark.asyncio
     async def test_models_endpoint(self, server_factory):
@@ -640,6 +654,302 @@ class TestStreamingErrorStatus:
             )
             assert status == 200
             assert "data:" in body
+        finally:
+            await srv.stop()
+
+
+# ── Verbatim passthrough (llama.cpp-native surface + /v1/models) ──
+
+
+class _FakeBackendResponse:
+    """Streaming-mode httpx.Response stand-in: status_code / aread / aiter_raw."""
+
+    def __init__(self, status, chunks):
+        self.status_code = status
+        self._chunks = chunks
+
+    async def aread(self):
+        return b"".join(self._chunks)
+
+    async def aiter_raw(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeForwardCM:
+    """Async CM standing in for LLMClient.forward_request()."""
+
+    def __init__(self, resp=None, enter_exc=None):
+        self._resp = resp
+        self._enter_exc = enter_exc
+
+    async def __aenter__(self):
+        if self._enter_exc is not None:
+            raise self._enter_exc
+        return self._resp
+
+    async def __aexit__(self, *args):
+        return False
+
+
+async def _passthrough_server(
+    *,
+    resp=None,
+    enter_exc=None,
+    forward_none=False,
+    backend_protocol="openai",
+    backend_api_key_present=False,
+):
+    client = _mock_client(TextResponse(content="ok"))
+    if forward_none:
+        client.forward_request = MagicMock(return_value=None)
+    else:
+        client.forward_request = MagicMock(
+            return_value=_FakeForwardCM(resp, enter_exc),
+        )
+    ctx = ContextManager(strategy=NoCompact(), budget_tokens=8192)
+    srv = HTTPServer(
+        client=client, context_manager=ctx, host="127.0.0.1", port=0,
+        serialize_requests=False, backend_protocol=backend_protocol,
+        backend_api_key_present=backend_api_key_present,
+    )
+    await srv.start()
+    return srv, srv._server.sockets[0].getsockname()[1], client
+
+
+async def _request(port, method, path, body=None, header_lines=()):
+    """Any-method HTTP request; returns (status, body_str, raw_response)."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        body_bytes = b"" if body is None else json.dumps(body).encode()
+        head = (
+            f"{method} {path} HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{port}\r\n"
+            + "".join(f"{line}\r\n" for line in header_lines)
+        )
+        if body_bytes:
+            head += (
+                f"Content-Type: application/json\r\n"
+                f"Content-Length: {len(body_bytes)}\r\n"
+            )
+        writer.write(head.encode() + b"\r\n" + body_bytes)
+        await writer.drain()
+        data = await asyncio.wait_for(reader.read(-1), timeout=10.0)
+        raw = data.decode("utf-8", errors="replace")
+        status = int(raw.split("\r\n", 1)[0].split(" ", 2)[1])
+        sep = raw.find("\r\n\r\n")
+        return status, (raw[sep + 4:] if sep >= 0 else ""), raw
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+# The full llama.cpp-native surface the proxy forwards — one case per route,
+# (method, inbound path[+query], request body or None). Mirrors
+# _PASSTHROUGH_ROUTES plus the /v1/models family (_handle_models) and the
+# health endpoints (_handle_health).
+PASSTHROUGH_CASES = [
+    ("GET", "/health", None),
+    ("GET", "/v1/health", None),
+    ("GET", "/props?model=Bonsai-27B&autoload=false", None),
+    ("POST", "/props", {"foo": 1}),
+    ("GET", "/v1/models", None),
+    ("GET", "/models", None),
+    ("POST", "/models", {"model": "x"}),
+    ("DELETE", "/models", {"model": "x"}),
+    ("POST", "/models/load", {"model": "Bonsai-27B"}),
+    ("POST", "/models/unload", {"model": "Bonsai-27B"}),
+]
+
+_MODELS_LISTINGS = ("/v1/models", "/models")
+_HEALTH_PATHS = ("/health", "/v1/health")
+
+
+class TestPassthroughForwarding:
+    """The whole passthrough family relays the backend verbatim.
+
+    One parameterized contract instead of a class per endpoint: the backend's
+    status and body are the answer (its own 404 for an endpoint it doesn't
+    serve, 400 "model is not loaded" from /props?model=), the raw method /
+    path / query / body reach the client's forward_request untouched, and
+    credential handling matches the completions path.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method,target,body", PASSTHROUGH_CASES)
+    async def test_answer_forwarded_verbatim(self, method, target, body):
+        payload = b'{"answer": 42}'
+        srv, port, client = await _passthrough_server(
+            resp=_FakeBackendResponse(200, [payload]),
+        )
+        try:
+            status, resp_body, _ = await _request(port, method, target, body)
+            assert status == 200
+            assert resp_body == payload.decode()
+            # Method, path + raw query, and raw body reach the client
+            # untouched (the last call — /v1/models probes capability first).
+            call = client.forward_request.call_args
+            assert call.args == (method, target)
+            expected_body = b"" if body is None else json.dumps(body).encode()
+            assert call.kwargs["body"] == expected_body
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method,target,body", PASSTHROUGH_CASES)
+    async def test_backend_status_is_the_answer(self, method, target, body):
+        # Error statuses ride through unmapped — never collapsed to 502.
+        err = b'{"error": {"code": 404, "message": "File Not Found"}}'
+        srv, port, _ = await _passthrough_server(
+            resp=_FakeBackendResponse(404, [err]),
+        )
+        try:
+            status, resp_body, _ = await _request(port, method, target, body)
+            assert status == 404
+            assert resp_body == err.decode()
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method,target,body", PASSTHROUGH_CASES)
+    async def test_no_raw_backend_404_except_local_fallbacks(self, method, target, body):
+        # forward_request → None (Anthropic SDK path): forge's own 404 —
+        # except the models listing (legacy synthesized single-identity
+        # entry) and health (the proxy's own liveness).
+        srv, port, _ = await _passthrough_server(forward_none=True)
+        try:
+            status, resp_body, _ = await _request(port, method, target, body)
+            # Only the GET spellings are the models LISTING; POST/DELETE
+            # /models are router management and 404 like the rest.
+            if method == "GET" and target in _MODELS_LISTINGS:
+                assert status == 200
+                assert json.loads(resp_body)["data"][0]["id"] == "mock-model"
+            elif method == "GET" and target in _HEALTH_PATHS:
+                assert status == 200
+                assert json.loads(resp_body)["status"] == "ok"
+            else:
+                assert status == 404
+                assert "Not found" in resp_body
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_unreachable_backend_maps_502(self):
+        srv, port, _ = await _passthrough_server(
+            enter_exc=BackendError(502, "backend unreachable"),
+        )
+        try:
+            status, _, _ = await _request(port, "GET", "/props")
+            assert status == 502
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_inbound_credential_relocated(self):
+        # openai inbound → anthropic backend: Bearer stripped, token moved to
+        # x-api-key — identical to the completions path.
+        srv, port, client = await _passthrough_server(
+            resp=_FakeBackendResponse(200, [b"{}"]),
+            backend_protocol="anthropic",
+        )
+        try:
+            status, _, _ = await _request(
+                port, "GET", "/props", header_lines=["Authorization: Bearer INBOUND"],
+            )
+            assert status == 200
+            assert client.forward_request.call_args.kwargs["extra_headers"] == {
+                "x-api-key": "INBOUND",
+            }
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_auth_refused_400_no_secret(self):
+        srv, port, client = await _passthrough_server(
+            resp=_FakeBackendResponse(200, [b"{}"]),
+        )
+        try:
+            status, resp_body, _ = await _request(
+                port, "GET", "/props",
+                header_lines=[
+                    "Authorization: Bearer SECRET-ONE",
+                    "Authorization: Bearer SECRET-TWO",
+                ],
+            )
+            assert status == 400
+            assert "SECRET-ONE" not in resp_body and "SECRET-TWO" not in resp_body
+            client.forward_request.assert_not_called()
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_inbound_plus_static_key_refused_400(self):
+        srv, port, client = await _passthrough_server(
+            resp=_FakeBackendResponse(200, [b"{}"]),
+            backend_api_key_present=True,
+        )
+        try:
+            status, resp_body, _ = await _request(
+                port, "GET", "/props",
+                header_lines=["Authorization: Bearer SECRET-INBOUND"],
+            )
+            assert status == 400
+            assert "SECRET-INBOUND" not in resp_body
+            client.forward_request.assert_not_called()
+        finally:
+            await srv.stop()
+
+
+class TestModelsSseRelay:
+    """GET /models/sse is the one streaming row of the passthrough table:
+    chunks relay unbuffered with SSE headers; a refused subscription buffers
+    and forwards its real status like every other passthrough answer."""
+
+    @pytest.mark.asyncio
+    async def test_stream_relayed_with_sse_headers(self):
+        events = [b'event: models\ndata: {"loading": 1}\n\n', b"data: done\n\n"]
+        srv, port, client = await _passthrough_server(
+            resp=_FakeBackendResponse(200, events),
+        )
+        try:
+            _, _, raw = await _request(port, "GET", "/models/sse?api_key=sk-placeholder")
+            assert raw.startswith("HTTP/1.1 200 OK")
+            assert "text/event-stream" in raw
+            for event in events:
+                assert event.decode() in raw
+            assert raw.rstrip().endswith("0")  # chunked terminator sent
+            call = client.forward_request.call_args
+            assert call.args == ("GET", "/models/sse?api_key=sk-placeholder")
+            assert call.kwargs["stream"] is True  # read timeout disabled
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_refused_subscription_forwards_status_and_body(self):
+        err = json.dumps({"error": {"code": 403, "message": "nope"}}).encode()
+        srv, port, _ = await _passthrough_server(
+            resp=_FakeBackendResponse(403, [err]),
+        )
+        try:
+            _, _, raw = await _request(port, "GET", "/models/sse")
+            assert raw.startswith("HTTP/1.1 403")
+            assert '"nope"' in raw
+            assert "text/event-stream" not in raw
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_empty_chunk_does_not_end_stream(self):
+        # A zero-length backend chunk must not become the chunked-encoding
+        # terminator: the event after it still arrives.
+        events = [b"data: first\n\n", b"", b"data: second\n\n"]
+        srv, port, _ = await _passthrough_server(
+            resp=_FakeBackendResponse(200, events),
+        )
+        try:
+            _, _, raw = await _request(port, "GET", "/models/sse")
+            assert "data: first" in raw
+            assert "data: second" in raw
         finally:
             await srv.stop()
 


### PR DESCRIPTION
Together with #130, this PR adds support for https://pi.dev/packages/pi-llama-cpp.

Add forwarding for llama-server router mode endpoints:
- GET /props
- POST /props
- POST /models
- DELETE /models
- POST /models/load
- POST /models/unload
- GET /models/sse

Additionally:
- Change GET /v1/models and GET /v1/health to forward to the backend instead of returning a dummy. Preserve dummy response for the use case of OpenAI client -> forge -> Anthropic API.
- Add GET /models as an alias to GET /v1/models
- Add GET /v1/health as an alias to GET /health

### AI disclosure
This PR is Claude-generated and human-reviewed. 
Claude's prose style remain obvious in the comments; please let me know if this is acceptable or if the comments need to be reworked.