### PR TITLE
feat(proxy): serve /chat/completions as an alias of /v1/chat/completions

### DIFF
--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -190,7 +190,10 @@ class HTTPServer:
                 await self._handle_health(writer)
             elif method == "GET" and path == "/v1/models":
                 await self._handle_models(writer)
-            elif method == "POST" and path == "/v1/chat/completions":
+            elif method == "POST" and path in ("/v1/chat/completions", "/chat/completions"):
+                # llama.cpp serves the OpenAI chat endpoint on both spellings;
+                # llama.cpp-native clients (pi-llama-cpp) POST the unprefixed
+                # one, so a transparent front must accept it too.
                 await self._handle_completions(
                     writer, body_bytes, protocol="openai", headers=headers,
                 )

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -644,6 +644,23 @@ class TestStreamingErrorStatus:
             await srv.stop()
 
 
+class TestChatCompletionsAlias:
+    """POST /chat/completions (no /v1 prefix) is served like the canonical
+    route — llama.cpp serves both spellings and llama.cpp-native clients
+    (pi-llama-cpp) POST the unprefixed one."""
+
+    @pytest.mark.asyncio
+    async def test_unprefixed_chat_completions_routes(self, server_factory):
+        srv, port = await server_factory(TextResponse(content="Hello!"))
+        body = {"messages": [{"role": "user", "content": "hi"}]}
+        status, response_body = await _http_request(
+            port, "POST", "/chat/completions", body,
+        )
+        assert status == 200
+        data = json.loads(response_body)
+        assert data["choices"][0]["message"]["content"] == "Hello!"
+
+
 class TestCorsAllowsApiKey:
     @pytest.mark.asyncio
     async def test_preflight_allows_x_api_key(self):


### PR DESCRIPTION
Together with #130, this PR adds support for https://pi.dev/packages/pi-llama-cpp.

Exposes llama-server extension /chat/completions.
Fixes pi-llama-cpp.

### AI disclosure
This PR is Claude-generated and human-reviewed.