### PR TITLE
eval: make generation provenance explicit and resume-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 .coverage
 htmlcov/
 .pytest_cache/
+.ticket-run/
 
 # IDE
 .vscode/

--- a/docs/EVAL_GUIDE.md
+++ b/docs/EVAL_GUIDE.md
@@ -121,6 +121,7 @@ Run large-scale model comparisons across all backends. Results append to JSONL w
 |------|--------|---------|-------------|
 | `--config` | `all`, `ollama`, `llamaserver`, `llamafile`, `llamaserver-native`, `llamaserver-prompt`, `anthropic`, `anthropic-any`, `haiku`, `sonnet`, `opus`, `haiku-any`, `sonnet-any`, `opus-any` | `all` | Config set to run |
 | `--runs` | int | `50` | Runs per scenario |
+| `--generation` | non-negative int | `0` | Comparability epoch written to every row; released runs select a nonzero generation |
 | `--output` | path | `eval_results.jsonl` | JSONL output path |
 | `--scenario` | name(s) | all | Run specific scenario(s) |
 | `--tags` | tag(s) | all | Filter scenarios by tag |
@@ -153,7 +154,8 @@ python -m tests.eval.batch_eval --config llamaserver --model 8b-reasoning --runs
 python -m tests.eval.batch_eval --config ollama --runs 50 --scenario basic_2step sequential_reasoning
 ```
 
-Resume is automatic: re-run the same command and it skips completed scenarios.
+Resume is automatic: re-run the same command with the same generation and
+policy and it skips completed scenarios.
 
 ---
 
@@ -173,11 +175,33 @@ python -m tests.eval.report \
 
 Generating from a single file is fine for a quick look at one release in isolation, but it drops every model not present in that file — including the carried-forward older generations — so do not commit a single-file render as the shipped dashboard. `batch_eval` writes to `eval_results.jsonl` by default; rename to a versioned filename before committing to the repo.
 
-### Eval generations and post-release addenda
+### Eval generations and collection
 
-The `gen` field (an integer injected per-row, legend in `report.py:GEN_INFO`) is a **comparability epoch, not a release version**. It is bumped only when a change is judged eval-material; many releases can share one gen, and a single gen can span several eval waves merged across files (`dedup_latest_gen` keeps the newest gen per config). This decouples "did we add models / re-sweep" from "did we cut a release" — adding models does not require a version bump.
+The `gen` field is a **comparability epoch, not a release version**. It is
+bumped only when a change is judged eval-material; many releases can share one
+generation, and one generation can span several eval waves merged across files
+(`dedup_latest_gen` keeps the newest generation per config). Generation 0 is
+reserved for scratch runs and legacy rows that predate the field. Every new row
+records an explicit generation; invoke a released collection with, for example,
+`--generation 4` rather than adding the field after collection.
 
-To fold new models into an existing dataset, stamp them with that dataset's `gen` and append the rows. Because they are net-new configs, no existing number is recomputed and they slot into the leaderboard as same-gen peers (no carry-forward badge).
+One output file carries only one effective generation. Before dry-run or live
+collection starts a client/server or appends a row, `batch_eval` streams the
+existing file and rejects generation mismatches, mixed generations, malformed
+generation values, malformed JSON, and ambiguous resume rows. A legacy file
+whose rows all omit `gen` is generation 0 and can only resume with generation
+0. For resume identity, historical rows without `reasoning_replay` mean `full`
+(the behavior they actually ran); they do not collide with an explicit modern
+`none` arm. Same-generation, same-policy resume remains count-based.
+
+To fold new models into an existing dataset, run the collector with that
+dataset's generation and append the rows. Because they are net-new configs, no
+existing number is recomputed and they slot into the leaderboard as
+same-generation peers (no carry-forward badge).
+
+An output is single-process owned while collection is active. Concurrent
+writers and file locking are unsupported; schedule separate output files and
+merge them only after validating their generation.
 
 Addenda to date:
 

--- a/tests/eval/batch_eval.py
+++ b/tests/eval/batch_eval.py
@@ -27,6 +27,7 @@ from forge.server import BudgetMode, ServerManager
 
 from tests.eval.ablation import ABLATION_PRESETS, AblationConfig
 from tests.eval.eval_runner import EvalConfig, RunResult, run_scenario
+from tests.eval.generation import effective_generation, effective_reasoning_replay
 from tests.eval.metrics import analyze_history, compute_metrics, count_wire_reasoning
 from tests.eval.scenarios import ALL_SCENARIOS, EvalScenario
 
@@ -350,42 +351,115 @@ def _run_key(
     )
 
 
-def _count_completed_runs(
+def _validate_generation(generation: Any, *, context: str = "generation") -> int:
+    """Return a valid eval generation or fail closed."""
+    if type(generation) is not int or generation < 0:
+        raise ValueError(
+            f"{context} must be a non-negative integer (bool is not allowed), "
+            f"got {generation!r}"
+        )
+    return generation
+
+
+def _parse_generation(value: str) -> int:
+    """Argparse type for non-negative eval generations."""
+    try:
+        generation = int(value)
+    except ValueError as exc:
+        raise ValueError("generation must be a non-negative integer") from exc
+    return _validate_generation(generation)
+
+
+def _preflight_completed_runs(
     jsonl_path: Path,
+    requested_generation: int,
     ablation_name: str = "reforged",
 ) -> dict[str, int]:
-    """Scan JSONL and count completed runs per resume key (see ``_run_key``).
+    """Validate append compatibility and count runs in one streaming pass.
 
-    Returns dict mapping the canonical run key → count. Records without an
-    ablation field are treated as "reforged", without tool_choice as "auto",
-    and without reasoning_replay as the default policy (none) — so
-    pre-knob dumps resume cleanly under the default and are re-run under a
-    different policy.
+    Every stored row participates in the single-generation check, while only
+    rows for ``ablation_name`` contribute to the resume map. Historical rows
+    without ``gen`` are generation 0 and rows without ``reasoning_replay`` used
+    the historical ``full`` behavior.
     """
+    requested_generation = _validate_generation(requested_generation)
     counts: dict[str, int] = {}
     if not jsonl_path.exists():
         return counts
-    with jsonl_path.open() as f:
-        for line in f:
+
+    file_generation: int | None = None
+    with jsonl_path.open("rb") as f:
+        for line_number, raw_line in enumerate(f, 1):
+            try:
+                line = raw_line.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ValueError(
+                    f"{jsonl_path}:{line_number}: invalid UTF-8 JSONL row"
+                ) from exc
             line = line.strip()
             if not line:
                 continue
             try:
                 row = json.loads(line)
-            except json.JSONDecodeError:
-                continue
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"{jsonl_path}:{line_number}: malformed JSON: {exc.msg}"
+                ) from exc
+            if not isinstance(row, dict):
+                raise ValueError(
+                    f"{jsonl_path}:{line_number}: JSONL row must be an object"
+                )
+            try:
+                row_generation = _validate_generation(
+                    effective_generation(row), context="gen"
+                )
+            except ValueError as exc:
+                raise ValueError(f"{jsonl_path}:{line_number}: {exc}") from exc
+            if file_generation is None:
+                file_generation = row_generation
+            elif row_generation != file_generation:
+                raise ValueError(
+                    f"{jsonl_path}:{line_number}: mixed effective generations "
+                    f"{file_generation} and {row_generation}"
+                )
+
             row_ablation = row.get("ablation", "reforged")
             if row_ablation != ablation_name:
                 continue
-            row_tc = row.get("tool_choice", "auto")
-            row_rr = row.get("reasoning_replay", DEFAULT_REASONING_REPLAY)
-            row_rl = row.get("reasoning_level", "default")
-            key = _run_key(
-                row["model"], row["backend"], row["mode"],
-                row_ablation, row_tc, row_rr, row_rl, row["scenario"],
-            )
+            try:
+                key = _run_key(
+                    row["model"], row["backend"], row["mode"],
+                    row_ablation, row.get("tool_choice", "auto"),
+                    effective_reasoning_replay(row),
+                    row.get("reasoning_level", "default"), row["scenario"],
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"{jsonl_path}:{line_number}: cannot build resume key: {exc}"
+                ) from exc
             counts[key] = counts.get(key, 0) + 1
+
+    if file_generation is not None and file_generation != requested_generation:
+        raise ValueError(
+            f"{jsonl_path}: existing effective generation {file_generation} "
+            f"does not match requested generation {requested_generation}"
+        )
     return counts
+
+
+def _append_jsonl_row(jsonl_path: Path, row: dict[str, Any]) -> None:
+    """Append one UTF-8 row, separating an unterminated existing final row."""
+    payload = (json.dumps(row) + "\n").encode("utf-8")
+    with jsonl_path.open("ab+") as f:
+        f.seek(0, os.SEEK_END)
+        size = f.tell()
+        separator = b""
+        if size:
+            f.seek(-1, os.SEEK_END)
+            if f.read(1) != b"\n":
+                separator = b"\n"
+        f.seek(0, os.SEEK_END)
+        f.write(separator + payload)
 
 
 def _run_result_to_row(
@@ -393,12 +467,16 @@ def _run_result_to_row(
     config: BatchConfig,
     scenario: EvalScenario,
     run_idx: int,
+    *,
+    generation: int,
     budget_tokens: int | None = None,
     ablation_name: str = "reforged",
     reasoning_replay: str = DEFAULT_REASONING_REPLAY,
 ) -> dict[str, Any]:
     """Convert a RunResult into a flat dict for JSONL output."""
+    generation = _validate_generation(generation)
     row: dict[str, Any] = {
+        "gen": generation,
         "model": config.model,
         "backend": config.backend,
         "mode": config.mode,
@@ -798,6 +876,7 @@ async def run_batch(
     scenario_names: list[str] | None = None,
     ablation: AblationConfig | None = None,
     reasoning_replay: ReasoningReplay = DEFAULT_REASONING_REPLAY,
+    generation: int = 0,
 ) -> None:
     """Run all configs × scenarios, appending each result to JSONL.
 
@@ -807,6 +886,8 @@ async def run_batch(
     """
     from forge.context.strategies import TieredCompact
     from tests.eval.eval_runner import _COMPACTION_SCENARIOS
+
+    generation = _validate_generation(generation)
 
     if scenario_names:
         name_set = set(scenario_names)
@@ -822,7 +903,9 @@ async def run_batch(
         scenarios = ALL_SCENARIOS
 
     ablation_name = ablation.name if ablation is not None else "reforged"
-    completed_counts = _count_completed_runs(output_path, ablation_name=ablation_name)
+    completed_counts = _preflight_completed_runs(
+        output_path, generation, ablation_name=ablation_name
+    )
 
     # Precompute total expected runs (excluding skips and unavailable models)
     total_expected = 0
@@ -954,12 +1037,12 @@ async def run_batch(
 
                         row = _run_result_to_row(
                             result, config, scenario, run_idx + 1,
+                            generation=generation,
                             budget_tokens=scenario_budget,
                             ablation_name=ablation_name,
                             reasoning_replay=reasoning_replay,
                         )
-                        with output_path.open("a") as f:
-                            f.write(json.dumps(row) + "\n")
+                        _append_jsonl_row(output_path, row)
 
                         completed_counts[key] = completed_counts.get(key, 0) + 1
                 continue
@@ -1141,12 +1224,12 @@ async def run_batch(
 
                     row = _run_result_to_row(
                         result, config, scenario, run_idx + 1,
+                        generation=generation,
                         budget_tokens=scenario_budget,
                         ablation_name=ablation_name,
                         reasoning_replay=reasoning_replay,
                     )
-                    with output_path.open("a") as f:
-                        f.write(json.dumps(row) + "\n")
+                    _append_jsonl_row(output_path, row)
 
                     # Update in-memory count for resume correctness
                     completed_counts[key] = completed_counts.get(key, 0) + 1
@@ -1179,6 +1262,12 @@ async def main() -> None:
     budget_choices = [m.value for m in BudgetMode]
     parser = argparse.ArgumentParser(description="Forge batch eval runner")
     parser.add_argument("--runs", type=int, default=50, help="Runs per scenario")
+    parser.add_argument(
+        "--generation",
+        type=_parse_generation,
+        default=0,
+        help="Non-negative eval comparability generation (default: 0)",
+    )
     parser.add_argument(
         "--output", type=str, default=None, help="JSONL output path"
     )
@@ -1262,6 +1351,7 @@ async def main() -> None:
     print(f"  Budget mode:   {budget_mode.value}")
     print(f"  Ablation:      {ablation.name}")
     print(f"  Reasoning replay: {args.reasoning_replay}")
+    print(f"  Generation:     {args.generation}")
     if args.scenario:
         print(f"  Scenarios:     {', '.join(args.scenario)}")
     elif args.tags:
@@ -1287,6 +1377,7 @@ async def main() -> None:
         scenario_names=args.scenario,
         ablation=ablation,
         reasoning_replay=args.reasoning_replay,
+        generation=args.generation,
     )
 
 

--- a/tests/eval/generation.py
+++ b/tests/eval/generation.py
@@ -1,0 +1,73 @@
+"""Shared eval-generation and historical replay semantics.
+
+This module is deliberately independent of Forge runtime imports so reporting
+and collection can use one small contract for interpreting stored eval rows.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+BaseConfigurationIdentity = tuple[Any, Any, Any, Any, Any, Any]
+ExplicitPolicyIdentity = tuple[Any, Any, Any, Any, Any, Any, Any]
+
+
+def effective_generation(row: dict[str, Any]) -> int:
+    """Return a row's generation, treating a missing field as generation 0."""
+    return row.get("gen", 0)
+
+
+def effective_reasoning_replay(row: dict[str, Any]) -> str:
+    """Return replay policy, treating a legacy missing field as ``full``."""
+    return row.get("reasoning_replay", "full")
+
+
+def base_configuration_identity(row: dict[str, Any]) -> BaseConfigurationIdentity:
+    """Return the whole-configuration identity used for legacy supersession."""
+    return (
+        row["model"],
+        row["backend"],
+        row["mode"],
+        row.get("ablation", "reforged"),
+        row.get("tool_choice", "auto"),
+        row.get("reasoning_level", "default"),
+    )
+
+
+def explicit_policy_identity(row: dict[str, Any]) -> ExplicitPolicyIdentity:
+    """Return base identity plus the row's stored replay-policy value."""
+    return base_configuration_identity(row) + (row.get("reasoning_replay"),)
+
+
+def select_latest_generation(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Select report-compatible newest-generation rows in input order.
+
+    Legacy rows without an explicit replay field are superseded by the newest
+    generation of their base configuration. Rows with an explicit replay field
+    are superseded only by newer rows of the same explicit policy. Every row at
+    the relevant maximum generation is retained.
+
+    Selection is whole-configuration rather than per-scenario. The returned
+    list contains the original row objects and preserves their input order.
+    """
+    base_max: dict[BaseConfigurationIdentity, int] = {}
+    policy_max: dict[ExplicitPolicyIdentity, int] = {}
+    for row in rows:
+        generation = effective_generation(row)
+        base_identity = base_configuration_identity(row)
+        policy_identity = explicit_policy_identity(row)
+        if generation > base_max.get(base_identity, -1):
+            base_max[base_identity] = generation
+        if generation > policy_max.get(policy_identity, -1):
+            policy_max[policy_identity] = generation
+
+    selected: list[dict[str, Any]] = []
+    for row in rows:
+        generation = effective_generation(row)
+        if "reasoning_replay" in row:
+            if generation == policy_max[explicit_policy_identity(row)]:
+                selected.append(row)
+        elif generation == base_max[base_configuration_identity(row)]:
+            selected.append(row)
+    return selected

--- a/tests/eval/report.py
+++ b/tests/eval/report.py
@@ -22,6 +22,12 @@ from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
+from tests.eval.generation import (
+    effective_generation,
+    effective_reasoning_replay,
+    select_latest_generation as dedup_latest_gen,
+)
+
 # Scenarios and their ideal iteration counts (from scenarios.py)
 # Hardcoded here so the report script has zero forge imports and can
 # run on any machine with just Python + the JSONL file.
@@ -217,102 +223,6 @@ def load_jsonl(path: Path) -> list[dict]:
     return rows
 
 
-def _row_replay(row: dict) -> str:
-    """Row-level reasoning_replay, defaulting pre-knob rows to "full".
-
-    Pre-knob rows (no field) ran unbounded replay, which the knob names
-    "full" — so carried-forward older generations surface with an honest
-    ':full' tag rather than masquerading as the current default.
-    """
-    return row.get("reasoning_replay", "full")
-
-
-def _config_tuple(row: dict) -> tuple[str, str, str, str, str, str]:
-    """The BASE identity a config is deduped on — ConfigKey's fields minus reasoning_replay.
-
-    reasoning_replay is not part of this base identity because pre-knob rows have
-    no field at all: they ran unbounded replay under the old default, and a
-    newer-gen re-sweep of the config should supersede them regardless of which
-    policies it ran (else every v0.7.0 row would survive as a stale ':full'
-    duplicate next to its re-swept config). See _policy_tuple for how rows that
-    DO carry an explicit policy are kept distinct.
-
-    reasoning_level, by contrast, IS part of the dedup identity: effort variants
-    of one stem (e.g. medium vs high) are parallel configs that must coexist,
-    not supersede each other. Pre-axis rows default to "default".
-    """
-    return (
-        row["model"],
-        row["backend"],
-        row["mode"],
-        row.get("ablation", "reforged"),
-        row.get("tool_choice", "auto"),
-        row.get("reasoning_level", "default"),
-    )
-
-
-def _policy_tuple(row: dict) -> tuple:
-    """Base identity plus the row's EXPLICIT reasoning_replay policy.
-
-    Legacy pre-knob rows (no field) key on None, so they never collide with an
-    explicit policy arm. Used to scope supersession for explicit rows only.
-    """
-    return _config_tuple(row) + (row.get("reasoning_replay"),)
-
-
-def dedup_latest_gen(rows: list[dict]) -> list[dict]:
-    """Keep only the highest-``gen`` rows for each config.
-
-    Eval generations (the ``gen`` field, injected per-row) let a single
-    dashboard fold multiple eval waves run against different code states.
-    When the same config appears in more than one generation — e.g. a model
-    re-swept in a newer suite — the newest generation wins and the older
-    rows are dropped. Configs that only ever ran in an older generation
-    (e.g. the Anthropic ablation, or Retired models) are carried forward at
-    that older gen and surface with a superscript badge.
-
-    Rows with no ``gen`` field count as gen 0, so a lone legacy file with no
-    generations renders exactly as before (everything at gen 0, no badges).
-
-    Supersession is scoped by whether a row carries an EXPLICIT reasoning_replay
-    policy, because the two cases mean different things:
-
-    * Legacy pre-knob rows (no field) are an artifact of the old unbounded-replay
-      default, not a deliberate measurement. Any newer-gen sweep of the config
-      supersedes them — scoped on the base identity — so they never linger as
-      phantom ':full' twins.
-    * Explicit policy rows (none/keep-last/full) are deliberate measurements of
-      that policy, so they are superseded only by a newer gen of the SAME policy
-      — scoped on the base identity plus the policy. An explicit arm that only
-      ever ran in an older gen carries forward with a badge rather than being
-      destroyed by a newer sweep that happened to run different policies.
-
-    Note: dedup is whole-config, not per-scenario — a partial re-run would
-    shadow the older gen's other scenarios. Not a concern today (re-swept
-    configs are full-suite), but worth knowing before partial re-runs land.
-    """
-    base_max: dict[tuple, int] = {}
-    policy_max: dict[tuple, int] = {}
-    for r in rows:
-        g = r.get("gen", 0)
-        bk = _config_tuple(r)
-        pk = _policy_tuple(r)
-        if g > base_max.get(bk, -1):
-            base_max[bk] = g
-        if g > policy_max.get(pk, -1):
-            policy_max[pk] = g
-
-    kept: list[dict] = []
-    for r in rows:
-        g = r.get("gen", 0)
-        if "reasoning_replay" in r:
-            if g == policy_max[_policy_tuple(r)]:
-                kept.append(r)
-        elif g == base_max[_config_tuple(r)]:
-            kept.append(r)
-    return kept
-
-
 def group_rows(
     rows: list[dict],
 ) -> dict[ConfigKey, dict[str, list[dict]]]:
@@ -325,7 +235,7 @@ def group_rows(
         tc = row.get("tool_choice", "auto")
         key = ConfigKey(
             row["model"], row["backend"], row["mode"], ablation, tc,
-            _row_replay(row), row.get("reasoning_level", "default"),
+            effective_reasoning_replay(row), row.get("reasoning_level", "default"),
         )
         grouped[key][row["scenario"]].append(row)
     return grouped
@@ -521,7 +431,7 @@ def compute_config_metrics(
     gen = 0
     for runs in scenario_runs.values():
         for r in runs:
-            g = r.get("gen", 0)
+            g = effective_generation(r)
             if g > gen:
                 gen = g
     retired = extract_family(key.model) in RETIRED_FAMILIES
@@ -1533,7 +1443,7 @@ def main() -> None:
     # Filter by reasoning_replay policy if requested
     if args.reasoning_replay:
         rr_set = set(args.reasoning_replay)
-        rows = [r for r in rows if _row_replay(r) in rr_set]
+        rows = [r for r in rows if effective_reasoning_replay(r) in rr_set]
         if not rows:
             print(f"No data for reasoning_replay polic(ies): {', '.join(args.reasoning_replay)}")
             sys.exit(0)

--- a/tests/unit/test_batch_eval_resume.py
+++ b/tests/unit/test_batch_eval_resume.py
@@ -1,25 +1,18 @@
-"""Resume-key behavior for the eval policy axes (batch_eval).
-
-reasoning_replay is part of the canonical run key: distinct policies
-(none / keep-last / full) on the same model+scenario are independent runs
-and must not collide in resume counting, or a multi-policy sweep would
-under-count and skip work it never actually ran. reasoning_level is likewise
-independent so effort variants of the same model do not clobber one another.
-"""
+"""Generation-aware row capture and resume behavior for batch evals."""
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from typing import Any
 
 import pytest
-
-from forge.core.reasoning import DEFAULT_REASONING_REPLAY
 
 import tests.eval.batch_eval as batch_eval
 from tests.eval.batch_eval import (
     BatchConfig,
     _compute_cost,
-    _count_completed_runs,
+    _preflight_completed_runs,
     _run_key,
     _run_result_to_row,
     run_batch,
@@ -28,20 +21,80 @@ from tests.eval.eval_runner import RunResult
 from tests.eval.scenarios import basic_2step
 
 
-def _row(model: str, scenario: str, reasoning_replay: str) -> dict:
-    """Build a JSONL row via the production path for a given policy."""
-    cfg = BatchConfig(model=model, backend="llamaserver", mode="native", think=None)
-    res = RunResult(
+def _result(scenario: str = "basic_2step") -> RunResult:
+    return RunResult(
         scenario_name=scenario,
         completeness=True,
         iterations_used=3,
         accuracy=True,
         messages=None,
     )
+
+
+def _row(
+    model: str = "M",
+    scenario: str = "basic_2step",
+    reasoning_replay: str = "none",
+    generation: int = 0,
+    run_idx: int = 1,
+) -> dict[str, Any]:
+    """Build a JSONL row via the production serializer."""
+    cfg = BatchConfig(model=model, backend="llamaserver", mode="native", think=None)
     return _run_result_to_row(
-        res, cfg, basic_2step, run_idx=1,
-        ablation_name="reforged", reasoning_replay=reasoning_replay,
+        _result(scenario), cfg, basic_2step, run_idx,
+        generation=generation,
+        ablation_name="reforged",
+        reasoning_replay=reasoning_replay,
     )
+
+
+def _write_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+
+
+def _managed_config() -> BatchConfig:
+    return BatchConfig(model="M", backend="ollama", mode="native", think=None)
+
+
+def _anthropic_config() -> BatchConfig:
+    return BatchConfig(
+        model="claude-sonnet-4-6", backend="anthropic", mode="native", think=True
+    )
+
+
+def _install_inert_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeServerManager:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def start_with_budget(self, **kwargs):
+            return 4096
+
+        async def resolve_budget(self, *args, **kwargs):
+            return 4096
+
+        async def stop(self):
+            pass
+
+    monkeypatch.setattr(batch_eval, "ALL_SCENARIOS", [basic_2step])
+    monkeypatch.setattr(batch_eval, "_check_model_available", lambda *args: None)
+    monkeypatch.setattr(batch_eval, "ServerManager", FakeServerManager)
+    monkeypatch.setattr(batch_eval, "_build_client", lambda *args: object())
+
+    async def fake_run_with_timeout(client, scenario, eval_config, ablation):
+        return _result(scenario.name)
+
+    monkeypatch.setattr(batch_eval, "_run_with_timeout", fake_run_with_timeout)
+
+
+def _fail_if_backend_reached(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(*args, **kwargs):
+        pytest.fail("backend construction was reached before generation preflight")
+
+    monkeypatch.setattr(batch_eval, "ServerManager", fail)
+    monkeypatch.setattr(batch_eval, "_build_client", fail)
 
 
 def test_run_key_distinguishes_reasoning_replay() -> None:
@@ -50,15 +103,11 @@ def test_run_key_distinguishes_reasoning_replay() -> None:
         ablation_name="reforged", tool_choice="auto",
         reasoning_level="default", scenario="s",
     )
-    k_none = _run_key(reasoning_replay="none", **base)
-    k_keep = _run_key(reasoning_replay="keep-last", **base)
-    k_full = _run_key(reasoning_replay="full", **base)
-
-    # All three policies yield distinct keys...
-    assert len({k_none, k_keep, k_full}) == 3
-    # ...and the key is stable for the same inputs.
-    assert _run_key(reasoning_replay="none", **base) == k_none
-    assert "none" in k_none
+    keys = {
+        _run_key(reasoning_replay=policy, **base)
+        for policy in ("none", "keep-last", "full")
+    }
+    assert len(keys) == 3
 
 
 def test_run_key_distinguishes_reasoning_level() -> None:
@@ -67,102 +116,297 @@ def test_run_key_distinguishes_reasoning_level() -> None:
         ablation_name="reforged", tool_choice="auto",
         reasoning_replay="none", scenario="s",
     )
-    k_default = _run_key(reasoning_level="default", **base)
-    k_high = _run_key(reasoning_level="high", **base)
-
-    assert k_default != k_high
-    assert "default" in k_default
-    assert "high" in k_high
+    assert _run_key(reasoning_level="default", **base) != _run_key(
+        reasoning_level="high", **base
+    )
 
 
-def test_run_result_to_row_records_reasoning_replay() -> None:
-    row = _row("M", "sc", "none")
-    assert row["reasoning_replay"] == "none"
-    assert row["reasoning_level"] == "default"
+def test_run_result_to_row_records_generation_and_replay() -> None:
+    scratch = _row(reasoning_replay="none", generation=0)
+    released = _row(reasoning_replay="full", generation=7)
 
-    # Default when the caller doesn't pass one (legacy callers / inert axis).
+    assert scratch["gen"] == 0
+    assert scratch["reasoning_replay"] == "none"
+    assert released["gen"] == 7
+    assert released["reasoning_replay"] == "full"
+    assert released["reasoning_level"] == "default"
+
+
+def test_run_result_to_row_requires_generation_keyword() -> None:
     cfg = BatchConfig(model="M", backend="llamaserver", mode="native", think=None)
-    res = RunResult(scenario_name="sc", completeness=True, iterations_used=2, messages=None)
-    default_row = _run_result_to_row(res, cfg, basic_2step, run_idx=1)
-    assert default_row["reasoning_replay"] == DEFAULT_REASONING_REPLAY
+    with pytest.raises(TypeError, match="generation"):
+        _run_result_to_row(_result(), cfg, basic_2step, 1)  # type: ignore[call-arg]
 
 
 @pytest.mark.asyncio
-async def test_anthropic_batch_rows_record_selected_reasoning_replay(
-    tmp_path, monkeypatch,
+async def test_anthropic_append_records_nonzero_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Anthropic rows must use the runtime policy, not the module default."""
-    cfg = BatchConfig(
-        model="claude-sonnet-4-6",
-        backend="anthropic",
-        mode="native",
-        think=True,
-    )
     output = tmp_path / "results.jsonl"
-
-    monkeypatch.setattr(batch_eval, "ALL_SCENARIOS", [basic_2step])
-    monkeypatch.setattr(batch_eval, "_build_client", lambda config, models_dir: object())
-
-    async def fake_run_with_timeout(client, scenario, eval_config, ablation):
-        assert eval_config.reasoning_replay == "none"
-        return RunResult(
-            scenario_name=scenario.name,
-            completeness=True,
-            iterations_used=3,
-            accuracy=True,
-            messages=None,
-        )
-
-    monkeypatch.setattr(batch_eval, "_run_with_timeout", fake_run_with_timeout)
+    _install_inert_backend(monkeypatch)
 
     await run_batch(
-        configs=[cfg],
+        configs=[_anthropic_config()],
         runs_per_scenario=1,
         output_path=output,
-        tags=["plumbing"],
         reasoning_replay="none",
+        generation=4,
     )
 
-    row = json.loads(output.read_text().strip())
-    assert row["model"] == "claude-sonnet-4-6"
+    row = json.loads(output.read_text(encoding="utf-8"))
     assert row["backend"] == "anthropic"
+    assert row["gen"] == 4
     assert row["reasoning_replay"] == "none"
 
 
-def test_count_completed_runs_separates_policies(tmp_path) -> None:
-    rows = [
-        _row("M", "sc", "none"),
-        _row("M", "sc", "none"),
-        _row("M", "sc", "full"),
-        _row("M", "sc", "keep-last"),
-    ]
-    # A pre-knob row (no reasoning_replay field) must fold into the default
-    # policy, so a default-policy resume skips it and a different policy re-runs.
-    legacy = _row("M", "sc", "keep-last")
+@pytest.mark.asyncio
+async def test_new_output_defaults_to_generation_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "results.jsonl"
+    _install_inert_backend(monkeypatch)
+
+    await run_batch(
+        configs=[_anthropic_config()], runs_per_scenario=1, output_path=output
+    )
+
+    assert json.loads(output.read_text(encoding="utf-8"))["gen"] == 0
+
+
+@pytest.mark.asyncio
+async def test_managed_server_append_records_nonzero_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "results.jsonl"
+    _install_inert_backend(monkeypatch)
+
+    await run_batch(
+        configs=[_managed_config()],
+        runs_per_scenario=1,
+        output_path=output,
+        generation=5,
+    )
+
+    row = json.loads(output.read_text(encoding="utf-8"))
+    assert row["backend"] == "ollama"
+    assert row["gen"] == 5
+
+
+@pytest.mark.asyncio
+async def test_empty_output_accepts_requested_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "results.jsonl"
+    output.write_bytes(b"")
+    _install_inert_backend(monkeypatch)
+
+    await run_batch(
+        configs=[_anthropic_config()], runs_per_scenario=1,
+        output_path=output, generation=6,
+    )
+
+    assert json.loads(output.read_text(encoding="utf-8"))["gen"] == 6
+
+
+@pytest.mark.asyncio
+async def test_same_generation_resume_uses_exact_next_run_number(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "results.jsonl"
+    first = _row(model="claude-sonnet-4-6", generation=3, run_idx=1)
+    first["backend"] = "anthropic"
+    _write_rows(output, [first])
+    _install_inert_backend(monkeypatch)
+
+    await run_batch(
+        configs=[_anthropic_config()], runs_per_scenario=2,
+        output_path=output, reasoning_replay="none", generation=3,
+    )
+
+    rows = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+    assert [row["run"] for row in rows] == [1, 2]
+    assert {row["gen"] for row in rows} == {3}
+
+
+@pytest.mark.parametrize("backend_path", ["anthropic", "managed"])
+@pytest.mark.asyncio
+async def test_resume_safely_separates_unterminated_final_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    backend_path: str,
+) -> None:
+    output = tmp_path / "results.jsonl"
+    config = _anthropic_config() if backend_path == "anthropic" else _managed_config()
+    first = _row(model=config.model, generation=4, run_idx=1)
+    first["backend"] = config.backend
+    first["mode"] = config.mode
+    original = json.dumps(first).encode("utf-8")
+    output.write_bytes(original)
+    _install_inert_backend(monkeypatch)
+
+    await run_batch(
+        configs=[config], runs_per_scenario=2,
+        output_path=output, reasoning_replay="none", generation=4,
+    )
+
+    appended = output.read_bytes()
+    assert appended.startswith(original + b"\n")
+    rows = [json.loads(line) for line in appended.splitlines()]
+    assert [row["run"] for row in rows] == [1, 2]
+    assert {row["gen"] for row in rows} == {4}
+
+
+def test_legacy_missing_replay_counts_as_full_not_none(tmp_path: Path) -> None:
+    legacy = _row(reasoning_replay="none")
     del legacy["reasoning_replay"]
-    rows.append(legacy)
+    del legacy["gen"]
+    output = tmp_path / "legacy.jsonl"
+    _write_rows(output, [legacy])
 
-    path = tmp_path / "results.jsonl"
-    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    counts = _preflight_completed_runs(output, requested_generation=0)
 
-    counts = _count_completed_runs(path, ablation_name="reforged")
-
-    def key(rr: str) -> str:
+    def key(policy: str) -> str:
         return _run_key(
             "M", "llamaserver", "native", "reforged", "auto",
-            rr, "default", "sc",
+            policy, "default", "basic_2step",
         )
 
-    # explicit none ×2 + the legacy row defaulting to none
-    assert counts[key("none")] == 3
     assert counts[key("full")] == 1
-    assert counts[key("keep-last")] == 1
-    assert counts[key("none")] + counts[key("full")] + counts[key("keep-last")] == 5
+    assert counts.get(key("none"), 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_legacy_full_resume_skips_existing_generation_zero_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "legacy.jsonl"
+    legacy = _row(model="claude-sonnet-4-6", reasoning_replay="full")
+    legacy["backend"] = "anthropic"
+    del legacy["reasoning_replay"]
+    del legacy["gen"]
+    _write_rows(output, [legacy])
+    before = output.read_bytes()
+    _install_inert_backend(monkeypatch)
+
+    await run_batch(
+        configs=[_anthropic_config()], runs_per_scenario=1,
+        output_path=output, reasoning_replay="full", generation=0,
+    )
+
+    assert output.read_bytes() == before
+
+
+@pytest.mark.asyncio
+async def test_explicit_none_does_not_collide_with_legacy_full(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "legacy.jsonl"
+    legacy = _row(model="claude-sonnet-4-6")
+    legacy["backend"] = "anthropic"
+    del legacy["reasoning_replay"]
+    del legacy["gen"]
+    _write_rows(output, [legacy])
+    _install_inert_backend(monkeypatch)
+
+    await run_batch(
+        configs=[_anthropic_config()], runs_per_scenario=1,
+        output_path=output, reasoning_replay="none", generation=0,
+    )
+
+    rows = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 2
+    assert "reasoning_replay" not in rows[0]
+    assert rows[1]["reasoning_replay"] == "none"
+    assert rows[1]["gen"] == 0
+
+
+@pytest.mark.parametrize(
+    ("payload", "requested_generation", "message"),
+    [
+        (json.dumps(_row(generation=1)).encode() + b"\n", 2, "does not match"),
+        (json.dumps({k: v for k, v in _row().items() if k != "gen"}).encode() + b"\n", 1, "does not match"),
+        ((json.dumps(_row(generation=1)) + "\n" + json.dumps(_row(generation=2)) + "\n").encode(), 1, "mixed effective generations"),
+        (b"{not-json}\n", 0, "malformed JSON"),
+        (b"[]\n", 0, "must be an object"),
+        (b"\xff\n", 0, "invalid UTF-8"),
+        (
+            json.dumps({k: v for k, v in _row().items() if k != "scenario"}).encode()
+            + b"\n",
+            0,
+            "cannot build resume key",
+        ),
+        (json.dumps({**_row(), "gen": True}).encode() + b"\n", 0, "non-negative integer"),
+        (json.dumps({**_row(), "gen": -1}).encode() + b"\n", 0, "non-negative integer"),
+        (json.dumps({**_row(), "gen": 1.0}).encode() + b"\n", 0, "non-negative integer"),
+        (json.dumps({**_row(), "gen": "1"}).encode() + b"\n", 0, "non-negative integer"),
+        (json.dumps({**_row(), "gen": None}).encode() + b"\n", 0, "non-negative integer"),
+    ],
+    ids=[
+        "requested-mismatch", "genless-nonzero", "mixed", "malformed-json",
+        "non-object", "invalid-utf8", "missing-resume-field", "bool", "negative",
+        "float", "string", "null",
+    ],
+)
+@pytest.mark.asyncio
+async def test_rejected_output_preflight_is_before_backend_and_byte_identical(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: bytes,
+    requested_generation: int,
+    message: str,
+) -> None:
+    output = tmp_path / "results.jsonl"
+    output.write_bytes(payload)
+    before = output.read_bytes()
+    _fail_if_backend_reached(monkeypatch)
+
+    with pytest.raises(ValueError, match=message):
+        await run_batch(
+            configs=[_managed_config()], runs_per_scenario=1,
+            output_path=output, generation=requested_generation,
+        )
+
+    assert output.read_bytes() == before
+
+
+@pytest.mark.asyncio
+async def test_dry_run_still_rejects_generation_mismatch_before_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "results.jsonl"
+    _write_rows(output, [_row(generation=2)])
+    before = output.read_bytes()
+    _fail_if_backend_reached(monkeypatch)
+
+    with pytest.raises(ValueError, match="does not match"):
+        await run_batch(
+            configs=[_managed_config()], runs_per_scenario=1,
+            output_path=output, generation=3, dry_run=True,
+        )
+
+    assert output.read_bytes() == before
+
+
+@pytest.mark.parametrize("generation", [True, -1, 1.0, "1", None])
+@pytest.mark.asyncio
+async def test_invalid_programmatic_generation_creates_nothing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    generation: Any,
+) -> None:
+    output = tmp_path / "not-created.jsonl"
+    _fail_if_backend_reached(monkeypatch)
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        await run_batch(
+            configs=[_managed_config()], runs_per_scenario=1,
+            output_path=output, generation=generation,
+        )
+
+    assert not output.exists()
 
 
 def test_compute_cost_prices_cache_tokens() -> None:
-    """Cache writes bill 1.25× and reads 0.1× of the input rate; uncached input
-    and output keep their base rates. (sonnet: $3 input / $15 output per Mtok.)"""
     cost = _compute_cost(
         "claude-sonnet-4-6",
         input_tokens=1_000,
@@ -177,20 +421,18 @@ def test_compute_cost_prices_cache_tokens() -> None:
         + 500 * 15.0
     ) / 1_000_000
     assert cost == expected
-
-    # Back-compat: omitting cache args matches the old input+output formula.
     assert _compute_cost("claude-sonnet-4-6", 1_000, 500) == (
         1_000 * 3.0 + 500 * 15.0
     ) / 1_000_000
-
-    # Opus 4.8 is priced (placeholder rate), not an unknown-model 0.0.
     assert _compute_cost("claude-opus-4-8", 1_000, 0) > 0
 
 
 def test_run_result_to_row_emits_cache_tokens() -> None:
-    cfg = BatchConfig(model="claude-sonnet-4-6", backend="anthropic", mode="native", think=None)
-    res = RunResult(
-        scenario_name="sc",
+    cfg = BatchConfig(
+        model="claude-sonnet-4-6", backend="anthropic", mode="native", think=None
+    )
+    result = RunResult(
+        scenario_name="basic_2step",
         completeness=True,
         iterations_used=3,
         accuracy=True,
@@ -200,7 +442,7 @@ def test_run_result_to_row_emits_cache_tokens() -> None:
         cache_creation_tokens=2_000,
         cache_read_tokens=4_000,
     )
-    row = _run_result_to_row(res, cfg, basic_2step, run_idx=1)
+    row = _run_result_to_row(result, cfg, basic_2step, 1, generation=0)
 
     assert row["cache_creation_input_tokens"] == 2_000
     assert row["cache_read_input_tokens"] == 4_000

--- a/tests/unit/test_eval_generation.py
+++ b/tests/unit/test_eval_generation.py
@@ -1,0 +1,193 @@
+"""Regression coverage for the shared eval-generation contract."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.eval import report
+from tests.eval.generation import (
+    base_configuration_identity,
+    effective_generation,
+    effective_reasoning_replay,
+    explicit_policy_identity,
+    select_latest_generation,
+)
+
+
+def _row(marker: str, **overrides: Any) -> dict[str, Any]:
+    row = {
+        "marker": marker,
+        "model": "model-a",
+        "backend": "backend-a",
+        "mode": "native",
+        "scenario": "basic_2step",
+    }
+    row.update(overrides)
+    return row
+
+
+def _assert_selected(
+    rows: list[dict[str, Any]], expected: list[dict[str, Any]]
+) -> None:
+    selected = select_latest_generation(rows)
+    assert selected == expected
+    assert len(selected) == len(expected)
+    assert all(actual is wanted for actual, wanted in zip(selected, expected))
+
+
+def _report_row(**overrides: Any) -> dict[str, Any]:
+    row = _row(
+        "report",
+        completeness=False,
+        accuracy=None,
+    )
+    row.update(overrides)
+    return row
+
+
+def test_effective_legacy_defaults() -> None:
+    row = _row("legacy")
+
+    assert effective_generation(row) == 0
+    assert effective_reasoning_replay(row) == "full"
+    assert effective_generation(_row("modern", gen=3)) == 3
+    assert effective_reasoning_replay(
+        _row("modern", reasoning_replay="keep-last")
+    ) == "keep-last"
+
+
+@pytest.mark.parametrize(
+    ("field", "default", "nondefault"),
+    [
+        ("reasoning_level", "default", "high"),
+        ("ablation", "reforged", "bare"),
+        ("tool_choice", "auto", "required"),
+    ],
+)
+def test_base_identity_normalizes_defaults_but_separates_nondefaults(
+    field: str, default: str, nondefault: str
+) -> None:
+    missing = _row("missing")
+    explicit_default = _row("default", **{field: default})
+    explicit_nondefault = _row("nondefault", **{field: nondefault})
+
+    assert base_configuration_identity(missing) == base_configuration_identity(
+        explicit_default
+    )
+    assert base_configuration_identity(missing) != base_configuration_identity(
+        explicit_nondefault
+    )
+
+
+def test_explicit_policy_identity_separates_replay_arms() -> None:
+    none = _row("none", reasoning_replay="none")
+    full = _row("full", reasoning_replay="full")
+
+    assert explicit_policy_identity(none) != explicit_policy_identity(full)
+    assert explicit_policy_identity(none)[:-1] == base_configuration_identity(none)
+
+
+def test_missing_generation_and_equal_generation_legacy_rows_are_retained() -> None:
+    missing = _row("missing")
+    explicit_zero = _row("zero", gen=0)
+
+    _assert_selected([missing, explicit_zero], [missing, explicit_zero])
+
+
+def test_newer_sweep_supersedes_legacy_row_regardless_of_replay_policies() -> None:
+    legacy = _row("legacy", gen=1)
+    newer_none = _row("none", gen=2, reasoning_replay="none")
+    newer_keep = _row("keep", gen=2, reasoning_replay="keep-last")
+
+    _assert_selected([legacy, newer_none, newer_keep], [newer_none, newer_keep])
+
+
+def test_explicit_arm_uses_same_policy_supersession_and_other_arm_carries() -> None:
+    old_none = _row("old-none", gen=1, reasoning_replay="none")
+    old_full = _row("old-full", gen=1, reasoning_replay="full")
+    new_none = _row("new-none", gen=2, reasoning_replay="none")
+
+    _assert_selected([old_none, old_full, new_none], [old_full, new_none])
+
+
+def test_older_configuration_without_newer_counterpart_carries_forward() -> None:
+    old_unique = _row("old-unique", model="model-unique", gen=1)
+    old_repeated = _row("old-repeated", gen=1)
+    new_repeated = _row("new-repeated", gen=2)
+
+    _assert_selected(
+        [old_unique, old_repeated, new_repeated],
+        [old_unique, new_repeated],
+    )
+
+
+def test_equal_generation_explicit_rows_and_interleaved_order_are_retained() -> None:
+    first = _row("first", gen=2, reasoning_replay="full")
+    interleaved = _row("interleaved", model="model-b", gen=1)
+    second = _row("second", gen=2, reasoning_replay="full")
+    dropped = _row("dropped", model="model-b", gen=0)
+
+    _assert_selected(
+        [first, interleaved, second, dropped],
+        [first, interleaved, second],
+    )
+
+
+def test_report_reexports_shared_selector() -> None:
+    assert report.dedup_latest_gen is select_latest_generation
+
+
+def test_report_groups_legacy_replay_as_full() -> None:
+    legacy = _report_row()
+
+    grouped = report.group_rows([legacy])
+    key, scenarios = next(iter(grouped.items()))
+
+    assert key.reasoning_replay == "full"
+    assert scenarios["basic_2step"] == [legacy]
+    assert scenarios["basic_2step"][0] is legacy
+
+
+def test_report_replay_filter_includes_legacy_as_full_and_excludes_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source = tmp_path / "legacy.jsonl"
+    source.write_text(json.dumps(_report_row()) + "\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["report", str(source), "--reasoning-replay", "full", "--list-only"],
+    )
+    report.main()
+    assert "Loaded 1 rows" in capsys.readouterr().out
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["report", str(source), "--reasoning-replay", "none", "--list-only"],
+    )
+    with pytest.raises(SystemExit) as exit_info:
+        report.main()
+    assert exit_info.value.code == 0
+    assert "No data for reasoning_replay polic(ies): none" in capsys.readouterr().out
+
+
+def test_report_metric_aggregation_uses_effective_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = _report_row()
+    grouped = report.group_rows([row])
+    key, scenario_runs = next(iter(grouped.items()))
+    monkeypatch.setattr(report, "effective_generation", lambda _row: 7)
+
+    metrics = report.compute_config_metrics(
+        key, scenario_runs, scenarios=["basic_2step"]
+    )
+
+    assert metrics.gen == 7


### PR DESCRIPTION
## Summary

- Extract eval-generation selection and historical replay interpretation into a shared, dependency-free contract used by reporting and collection.
- Add `--generation` to `batch_eval` and write `gen` directly into every collected row.
- Preflight existing JSONL files before client/server construction or output mutation.
- Reject malformed, mixed, or mismatched generations and ambiguous resume rows.
- Document the generation and collection contract in the eval guide.

## Why

Generation metadata was previously understood only by reporting and added to released rows after collection. Collection also interpreted legacy rows without `reasoning_replay` using the modern default, even though those rows actually ran with full replay.

That left reporting and resume behavior with different historical semantics and made it possible to append an incompatible generation to an existing output.

This change gives both paths one contract:

- Missing `gen` means generation 0.
- Missing historical `reasoning_replay` means `full`.
- Legacy rows are superseded by newer base configurations.
- Explicit replay policies are superseded only by newer rows of the same policy.
- An output file may contain only one effective generation.
- Resume is allowed only when the requested and existing generations match.

## Collection behavior

`batch_eval` now:

- accepts a non-negative `--generation` value, defaulting to 0 for scratch runs;
- records that generation on every output row;
- validates the complete existing file in one streaming pass;
- rejects malformed JSON, invalid generation values, mixed generations, generation mismatches, and rows that cannot produce an unambiguous resume key;
- performs those checks before constructing a client or server and before appending data;
- preserves same-generation, same-policy count-based resume behavior.

Concurrent writers remain unsupported and are documented as such.

## Compatibility

The reporting refactor is behavior-preserving. Existing generation selection, ordering, legacy replay interpretation, and dashboard results remain unchanged.

No released eval JSONL, generated dashboard, version, or changelog files are modified.

## Validation

- Focused generation/resume tests: **48 passed**
- Full unit suite: **1,437 passed**
- Released corpus:
  - **518,700** input rows
  - **378,300** selected rows
  - identical ordered source-row identity
  - identical canonical payload digest
  - exact agreement between report and shared selectors
- All five released JSONL SHA-256 hashes unchanged
- Regenerated dashboard:
  - **291** rows
  - **26** scenarios
  - generation metadata and template identical after timestamp normalization
  - all **7** Markdown views identical after timestamp normalization
  - visual smoke check passed