### PR TITLE
eval: add deterministic Hugging Face dataset builder

### DIFF
--- a/docs/EVAL_GUIDE.md
+++ b/docs/EVAL_GUIDE.md
@@ -175,6 +175,57 @@ python -m tests.eval.report \
 
 Generating from a single file is fine for a quick look at one release in isolation, but it drops every model not present in that file — including the carried-forward older generations — so do not commit a single-file render as the shipped dashboard. `batch_eval` writes to `eval_results.jsonl` by default; rename to a versioned filename before committing to the repo.
 
+### Hugging Face Parquet dataset bundle
+
+The upload-ready dataset is built locally from a Forge source checkout. The
+command is intentionally eval-local (`tests` is not packaged in the wheel),
+does not access the Hugging Face network, and needs no credentials. Install the
+dedicated writer extra, then build only into a path that does not already exist:
+
+```bash
+python -m pip install -e ".[dataset-builder]"
+python -m tests.eval.dataset_builder build --source-root . --output build/forge-eval-dataset-v1 --license mit --citation-url https://github.com/antoinezambelli/forge --reproduction-url https://github.com/antoinezambelli/forge/blob/main/docs/EVAL_GUIDE.md
+python -m tests.eval.dataset_builder verify --source-root . --bundle build/forge-eval-dataset-v1
+```
+
+The fixed v1 layout is:
+
+```text
+README.md
+data/latest/*.parquet
+data/snapshot/*.parquet
+data/history/*.parquet
+provenance/sources.json
+provenance/schema.json
+manifest.json
+```
+
+All configurations use the predecessor's ordered 51-field schema, Zstandard
+compression, batches of at most 8,192 rows, 100,000-row shards, and names of
+the form `part-NNNNN-of-NNNNN.parquet`. Configuration order is `latest`,
+`snapshot`, `history`; `latest` is the sole Dataset Card default. `history`
+contains every released row, `snapshot` retains selected policy arms (including
+carried evidence), and `latest` is the maximum-generation subset. The canonical
+score is `accuracy == true / all cohort rows`; validation-only accuracy is a
+separate diagnostic. Timing, cost, and budget fields are not comparable across
+different collection conditions.
+
+Build metadata is mandatory. `--license` accepts the frozen v1 identifier set
+shown by `python -m tests.eval.dataset_builder build --help`: `apache-2.0`,
+`bsd-2-clause`, `bsd-3-clause`, `cc-by-4.0`, `cc-by-sa-4.0`, `cc0-1.0`,
+`gpl-3.0`, `lgpl-3.0`, `mit`, `mpl-2.0`, `odc-by`, and `odbl`. It rejects
+`other` and custom licenses because those require a license name and/or a
+LICENSE file outside the fixed layout. Citation and reproduction values must
+be absolute HTTP(S) URLs. The builder verifies the five pinned source hashes
+and exact view counts before
+creating a sibling `.NAME.incomplete-*` staging directory. It hashes every
+finished non-manifest file, reads every shard back against the publication
+plan, and only then renames the complete directory into place. Any failure
+after staging begins retains that unmistakably incomplete directory for
+diagnosis and leaves the requested output unpublished. Generated bundles under
+the already-ignored `build/` directory are local artifacts and must not be
+committed.
+
 ### Eval generations and collection
 
 The `gen` field is a **comparability epoch, not a release version**. It is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,14 @@ forge-proxy = "forge.proxy.__main__:main"
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.40"]
+dataset-builder = ["pyarrow>=18.0.0"]
 dev = [
     "pytest",
     "pytest-cov",
     "pytest-asyncio",
     "anthropic>=0.40",
     "mpmath",
+    "pyarrow>=18.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/eval/dataset_builder.py
+++ b/tests/eval/dataset_builder.py
@@ -1,0 +1,886 @@
+"""Offline, deterministic Parquet materializer for the Forge eval corpus.
+
+This checkout-local command intentionally consumes only the verified publication
+contract in :mod:`tests.eval.publication`.  It does not upload data, contact the
+Hugging Face Hub, or require credentials.
+
+Build and verify the pinned corpus with::
+
+    python -m tests.eval.dataset_builder build --source-root . --output build/forge-eval-dataset-v1 --license mit --citation-url https://example.test/citation --reproduction-url https://example.test/reproduce
+    python -m tests.eval.dataset_builder verify --source-root . --bundle build/forge-eval-dataset-v1
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import json
+import platform
+import subprocess
+import sys
+import uuid
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from tests.eval import publication
+
+
+BUNDLE_VERSION = "forge-eval-parquet-v1"
+CONFIGURATION_NAMES = ("latest", "snapshot", "history")
+COMPRESSION = "zstd"
+RECORD_BATCH_ROWS = 8_192
+SHARD_ROWS = 100_000
+SHARD_TEMPLATE = "part-{index:05d}-of-{total:05d}.parquet"
+
+# Deliberately frozen for the fixed v1 card layout.  Identifiers that need a
+# license_name or a shipped LICENSE file (including "other") are unsupported.
+ACCEPTED_LICENSES = frozenset(
+    {
+        "apache-2.0",
+        "bsd-2-clause",
+        "bsd-3-clause",
+        "cc-by-4.0",
+        "cc-by-sa-4.0",
+        "cc0-1.0",
+        "gpl-3.0",
+        "lgpl-3.0",
+        "mit",
+        "mpl-2.0",
+        "odc-by",
+        "odbl",
+    }
+)
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+BUILDER_SOURCE_PATHS = (
+    "tests/eval/dataset_builder.py",
+    "tests/eval/publication.py",
+    "tests/eval/generation.py",
+    "tests/eval/provenance.py",
+)
+
+
+class DatasetBuilderError(RuntimeError):
+    """A compact bundle materialization or verification failure."""
+
+
+@dataclass(frozen=True)
+class ReleaseMetadata:
+    license: str
+    citation_url: str
+    reproduction_url: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "license": self.license,
+            "citation_url": self.citation_url,
+            "reproduction_url": self.reproduction_url,
+        }
+
+
+def _require_pyarrow() -> tuple[Any, Any]:
+    try:
+        pa = importlib.import_module("pyarrow")
+        pq = importlib.import_module("pyarrow.parquet")
+    except ImportError as exc:
+        raise DatasetBuilderError(
+            'Parquet materialization requires PyArrow; install it locally with '
+            '`python -m pip install -e ".[dataset-builder]"`.'
+        ) from exc
+    return pa, pq
+
+
+def _validate_url(value: str, label: str) -> str:
+    if not isinstance(value, str) or value != value.strip():
+        raise DatasetBuilderError(f"{label} must be an absolute HTTP(S) URL")
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise DatasetBuilderError(f"{label} must be an absolute HTTP(S) URL")
+    if parsed.username or parsed.password:
+        raise DatasetBuilderError(f"{label} must not contain URL credentials")
+    return value
+
+
+def validate_release_metadata(
+    license_id: str, citation_url: str, reproduction_url: str
+) -> ReleaseMetadata:
+    if not isinstance(license_id, str) or license_id != license_id.strip():
+        raise DatasetBuilderError("license must be a recognized Hugging Face identifier")
+    if license_id not in ACCEPTED_LICENSES:
+        accepted = ", ".join(sorted(ACCEPTED_LICENSES))
+        raise DatasetBuilderError(
+            f"unsupported Hugging Face license identifier {license_id!r}; "
+            f"accepted v1 identifiers: {accepted}"
+        )
+    return ReleaseMetadata(
+        license=license_id,
+        citation_url=_validate_url(citation_url, "citation URL"),
+        reproduction_url=_validate_url(reproduction_url, "reproduction URL"),
+    )
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return publication.canonical_json_bytes(value, sort_keys=True) + b"\n"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _physical_schema(pa: Any) -> Any:
+    types = {
+        "string": pa.string(),
+        "bool": pa.bool_(),
+        "int64": pa.int64(),
+        "float64": pa.float64(),
+    }
+    return pa.schema(
+        [
+            pa.field(field.name, types[field.logical_type], nullable=field.nullable)
+            for field in publication.NORMALIZED_SCHEMA
+        ]
+    )
+
+
+def _source_provenance(plan: publication.PublicationPlan) -> dict[str, Any]:
+    return {
+        "contract_version": publication.CONTRACT_VERSION,
+        "sources": [source.to_dict() for source in plan.sources],
+    }
+
+
+def _config_metadata(name: str) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "config_name": name,
+        "data_files": [{"split": "train", "path": f"data/{name}/*.parquet"}],
+    }
+    if name == "latest":
+        config["default"] = True
+    return config
+
+
+def _card_frontmatter(metadata: ReleaseMetadata) -> dict[str, Any]:
+    return {
+        "license": metadata.license,
+        "configs": [_config_metadata(name) for name in CONFIGURATION_NAMES],
+    }
+
+
+def _card_bytes(metadata: ReleaseMetadata) -> bytes:
+    frontmatter = publication.canonical_json(_card_frontmatter(metadata), sort_keys=False)
+    body = f"""---
+{frontmatter}
+---
+
+# Forge evaluation corpus
+
+This offline bundle materializes the verified Forge evaluation publication
+contract. `latest` is the default configuration and contains snapshot rows at
+the corpus-wide maximum generation. `snapshot` retains each selected policy arm,
+including carried evidence. `history` contains every released row, including
+superseded generations, in pinned source-file and source-line order.
+
+The canonical score is `correct / total`: `accuracy == true` divided by all
+cohort rows. Validation-only accuracy is a separate diagnostic and must not be
+reported as the canonical score. Generations describe released collection
+waves; replay policies and carried rows describe provenance and selection, not
+new eval executions.
+
+The raw `reasoning_replay` field preserves the value recorded by the source. A
+legacy row with missing raw `reasoning_replay` is inferred as effective `full`
+in `effective_reasoning_replay`; that legacy-inferred `full` remains distinct
+in arm identity from an explicitly recorded raw `full`. Likewise, the raw
+`reasoning_level` field preserves the optional source value, while
+`effective_reasoning_level` resolves a missing raw value to `default`. Carried
+evidence is an older selected cohort retained because no newer matching cohort
+exists.
+
+All 51 columns use one explicit schema. Sparse source fields are normalized to
+null, while provenance records the source file, physical line, source-file hash,
+and source-row hash. Timing, token budgets, and costs are operational
+measurements and should only be compared when backend, model, mode, rig, and
+collection conditions are compatible.
+
+License metadata is supplied explicitly at build time. Citation:
+{metadata.citation_url}
+
+Reproduction instructions:
+{metadata.reproduction_url}
+"""
+    return body.encode("utf-8")
+
+
+def _parse_card(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise DatasetBuilderError("README.md is not readable UTF-8") from exc
+    lines = text.splitlines()
+    if len(lines) < 3 or lines[0] != "---":
+        raise DatasetBuilderError("README.md has invalid metadata frontmatter")
+    try:
+        closing = lines.index("---", 1)
+        metadata = json.loads("\n".join(lines[1:closing]))
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise DatasetBuilderError("README.md has invalid metadata frontmatter") from exc
+    if not isinstance(metadata, dict):
+        raise DatasetBuilderError("README.md metadata must be an object")
+    return metadata
+
+
+def _builder_identity(pa: Any) -> dict[str, Any]:
+    files: list[dict[str, str]] = []
+    combined = hashlib.sha256()
+    for relative in BUILDER_SOURCE_PATHS:
+        path = _REPOSITORY_ROOT / relative
+        if not path.is_file():
+            raise DatasetBuilderError(f"builder source is missing: {relative}")
+        file_hash = _sha256_file(path)
+        files.append({"path": relative, "sha256": file_hash})
+        combined.update(
+            publication.canonical_json_bytes([relative, file_hash], sort_keys=False)
+            + b"\n"
+        )
+    try:
+        revision = subprocess.run(
+            ["git", "-C", str(_REPOSITORY_ROOT), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        revision = None
+    return {
+        "builder_source_sha256": combined.hexdigest(),
+        "source_files": files,
+        "git_revision": revision,
+        "python_version": platform.python_version(),
+        "parquet_writer": {"name": "pyarrow", "version": pa.__version__},
+    }
+
+
+def _shard_count(row_count: int) -> int:
+    return (row_count + SHARD_ROWS - 1) // SHARD_ROWS
+
+
+def _shard_relpaths(plan: publication.PublicationPlan, name: str) -> list[str]:
+    total = _shard_count(plan.views[name].row_count)
+    return [
+        f"data/{name}/" + SHARD_TEMPLATE.format(index=index, total=total)
+        for index in range(1, total + 1)
+    ]
+
+
+class _ViewWriter:
+    def __init__(
+        self,
+        *,
+        root: Path,
+        name: str,
+        row_count: int,
+        schema: Any,
+        pa: Any,
+        pq: Any,
+        observe_buffer: Callable[[str, int], None] | None,
+    ) -> None:
+        self.root = root
+        self.name = name
+        self.row_count = row_count
+        self.schema = schema
+        self.pa = pa
+        self.pq = pq
+        self.observe_buffer = observe_buffer
+        self.total_shards = _shard_count(row_count)
+        self.buffer: list[dict[str, Any]] = []
+        self.emitted = 0
+        self.shard_index = 1
+        self.shard_emitted = 0
+        self.writer: Any | None = None
+        self.shards: list[dict[str, Any]] = []
+
+    def _relative_path(self) -> str:
+        return f"data/{self.name}/" + SHARD_TEMPLATE.format(
+            index=self.shard_index, total=self.total_shards
+        )
+
+    def add(self, row: dict[str, Any]) -> None:
+        self.buffer.append(row)
+        if self.observe_buffer is not None:
+            self.observe_buffer(self.name, len(self.buffer))
+        shard_target = min(SHARD_ROWS, self.row_count - self.emitted + self.shard_emitted)
+        if len(self.buffer) >= RECORD_BATCH_ROWS or self.shard_emitted + len(self.buffer) == shard_target:
+            self._flush()
+
+    def _flush(self) -> None:
+        if not self.buffer:
+            return
+        if self.writer is None:
+            relative = self._relative_path()
+            path = self.root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self.writer = self.pq.ParquetWriter(
+                path,
+                self.schema,
+                compression=COMPRESSION,
+                version="2.6",
+                use_dictionary=False,
+                write_statistics=True,
+            )
+        table = self.pa.Table.from_pylist(self.buffer, schema=self.schema)
+        batch_rows = len(self.buffer)
+        self.writer.write_table(table, row_group_size=RECORD_BATCH_ROWS)
+        self.buffer.clear()
+        self.emitted += batch_rows
+        self.shard_emitted += batch_rows
+        if self.shard_emitted == SHARD_ROWS or self.emitted == self.row_count:
+            relative = self._relative_path()
+            self.writer.close()
+            self.writer = None
+            self.shards.append({"path": relative, "rows": self.shard_emitted})
+            self.shard_index += 1
+            self.shard_emitted = 0
+
+    def finish(self) -> list[dict[str, Any]]:
+        self._flush()
+        if self.writer is not None:
+            self.writer.close()
+            self.writer = None
+        if self.emitted != self.row_count:
+            raise DatasetBuilderError(f"{self.name} emitted row count does not match plan")
+        if len(self.shards) != self.total_shards:
+            raise DatasetBuilderError(f"{self.name} shard count does not match plan")
+        return self.shards
+
+    def close(self) -> None:
+        if self.writer is not None:
+            self.writer.close()
+            self.writer = None
+
+
+def _write_rows(
+    plan: publication.PublicationPlan,
+    root: Path,
+    pa: Any,
+    pq: Any,
+    *,
+    observe_buffer: Callable[[str, int], None] | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    schema = _physical_schema(pa)
+    writers = {
+        name: _ViewWriter(
+            root=root,
+            name=name,
+            row_count=plan.views[name].row_count,
+            schema=schema,
+            pa=pa,
+            pq=pq,
+            observe_buffer=observe_buffer,
+        )
+        for name in CONFIGURATION_NAMES
+    }
+    try:
+        for row in publication.iter_classified_history(plan):
+            writers["history"].add(row)
+            if publication.row_in_view(row, "snapshot"):
+                writers["snapshot"].add(row)
+            if publication.row_in_view(row, "latest"):
+                writers["latest"].add(row)
+        return {name: writers[name].finish() for name in CONFIGURATION_NAMES}
+    finally:
+        for writer in writers.values():
+            writer.close()
+
+
+def _expected_non_manifest_paths(
+    plan: publication.PublicationPlan,
+) -> list[str]:
+    paths = ["README.md", "provenance/sources.json", "provenance/schema.json"]
+    for name in CONFIGURATION_NAMES:
+        paths.extend(_shard_relpaths(plan, name))
+    return paths
+
+
+def _actual_files(root: Path) -> set[str]:
+    return {
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def _file_facts(
+    root: Path,
+    expected: Sequence[str],
+    shard_rows: Mapping[str, int],
+    *,
+    permitted_extra: Sequence[str] = (),
+) -> list[dict[str, Any]]:
+    actual = _actual_files(root)
+    expected_tree = set(expected) | set(permitted_extra)
+    if actual != expected_tree:
+        missing = sorted(expected_tree - actual)
+        extra = sorted(actual - expected_tree)
+        raise DatasetBuilderError(f"bundle tree mismatch; missing={missing}, extra={extra}")
+    facts = []
+    for relative in expected:
+        path = root / relative
+        fact: dict[str, Any] = {
+            "path": relative,
+            "sha256": _sha256_file(path),
+            "size_bytes": path.stat().st_size,
+        }
+        if relative in shard_rows:
+            fact["rows"] = shard_rows[relative]
+        facts.append(fact)
+    return facts
+
+
+def _format_facts() -> dict[str, Any]:
+    return {
+        "configuration_order": list(CONFIGURATION_NAMES),
+        "compression": COMPRESSION,
+        "record_batch_rows": RECORD_BATCH_ROWS,
+        "shard_rows": SHARD_ROWS,
+        "shard_template": SHARD_TEMPLATE,
+    }
+
+
+def _configuration_facts(
+    plan: publication.PublicationPlan,
+    shards: Mapping[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": name,
+            "default": name == "latest",
+            "data_files": f"data/{name}/*.parquet",
+            "row_count": plan.views[name].row_count,
+            "shards": shards[name],
+        }
+        for name in CONFIGURATION_NAMES
+    ]
+
+
+def _write_support_files(
+    root: Path, plan: publication.PublicationPlan, metadata: ReleaseMetadata
+) -> None:
+    (root / "provenance").mkdir(parents=True, exist_ok=True)
+    (root / "README.md").write_bytes(_card_bytes(metadata))
+    (root / "provenance" / "sources.json").write_bytes(
+        _canonical_bytes(_source_provenance(plan))
+    )
+    (root / "provenance" / "schema.json").write_bytes(
+        _canonical_bytes(publication.schema_manifest())
+    )
+
+
+def _manifest(
+    *,
+    plan: publication.PublicationPlan,
+    metadata: ReleaseMetadata,
+    builder: dict[str, Any],
+    configurations: list[dict[str, Any]],
+    files: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "bundle_version": BUNDLE_VERSION,
+        "release_metadata": metadata.to_dict(),
+        "format": _format_facts(),
+        "builder": builder,
+        "publication_plan": plan.to_dict(),
+        "configurations": configurations,
+        "files": files,
+    }
+
+
+def _load_manifest(root: Path) -> dict[str, Any]:
+    try:
+        raw = (root / "manifest.json").read_bytes()
+        value = json.loads(raw)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise DatasetBuilderError("manifest.json is missing or invalid") from exc
+    if not isinstance(value, dict):
+        raise DatasetBuilderError("manifest.json must contain an object")
+    if raw != _canonical_bytes(value):
+        raise DatasetBuilderError("manifest.json is not canonical JSON with LF")
+    return value
+
+
+class _DigestAccumulator:
+    def __init__(self) -> None:
+        self.rows = 0
+        self.identity = hashlib.sha256()
+        self.logical = hashlib.sha256()
+
+    def update(self, row: dict[str, Any]) -> None:
+        self.rows += 1
+        self.identity.update(
+            publication.canonical_json_bytes(
+                [row["source_file"], row["source_line"]], sort_keys=False
+            )
+            + b"\n"
+        )
+        self.logical.update(
+            publication.canonical_json_bytes(row, sort_keys=True) + b"\n"
+        )
+
+
+def _iter_parquet_rows(
+    root: Path,
+    shard_facts: Sequence[Mapping[str, Any]],
+    schema: Any,
+    pa: Any,
+    pq: Any,
+) -> Iterator[dict[str, Any]]:
+    for shard in shard_facts:
+        path = root / str(shard["path"])
+        try:
+            with pa.OSFile(str(path), "rb") as source:
+                parquet_file = pq.ParquetFile(source)
+                if not parquet_file.schema_arrow.equals(schema, check_metadata=True):
+                    raise DatasetBuilderError(
+                        f"Parquet schema mismatch: {shard['path']}"
+                    )
+                if parquet_file.metadata.num_rows != shard["rows"]:
+                    raise DatasetBuilderError(
+                        f"Parquet row count mismatch: {shard['path']}"
+                    )
+                for batch in parquet_file.iter_batches(batch_size=RECORD_BATCH_ROWS):
+                    for row in batch.to_pylist():
+                        yield row
+        except DatasetBuilderError:
+            raise
+        except Exception as exc:
+            raise DatasetBuilderError(
+                f"Parquet shard is unreadable: {shard['path']}"
+            ) from exc
+
+
+def _next_or_error(iterator: Iterator[dict[str, Any]], view: str) -> dict[str, Any]:
+    try:
+        return next(iterator)
+    except StopIteration as exc:
+        raise DatasetBuilderError(f"{view} materialized rows ended early") from exc
+
+
+def _assert_exhausted(iterator: Iterator[dict[str, Any]], view: str) -> None:
+    try:
+        next(iterator)
+    except StopIteration:
+        return
+    raise DatasetBuilderError(f"{view} materialized rows contain extras")
+
+
+def _metadata_from_manifest(manifest: Mapping[str, Any]) -> ReleaseMetadata:
+    try:
+        value = manifest["release_metadata"]
+        if not isinstance(value, dict) or set(value) != {
+            "license",
+            "citation_url",
+            "reproduction_url",
+        }:
+            raise KeyError
+        return validate_release_metadata(
+            value["license"], value["citation_url"], value["reproduction_url"]
+        )
+    except (KeyError, TypeError) as exc:
+        raise DatasetBuilderError("manifest release metadata is invalid") from exc
+
+
+def _verify_against_plan(
+    plan: publication.PublicationPlan,
+    bundle: str | Path,
+    *,
+    pa: Any | None = None,
+    pq: Any | None = None,
+) -> dict[str, Any]:
+    if pa is None or pq is None:
+        pa, pq = _require_pyarrow()
+    root = Path(bundle).resolve()
+    if not root.is_dir():
+        raise DatasetBuilderError(f"bundle is not a directory: {root}")
+    manifest = _load_manifest(root)
+    metadata = _metadata_from_manifest(manifest)
+
+    if manifest.get("bundle_version") != BUNDLE_VERSION:
+        raise DatasetBuilderError("bundle version mismatch")
+    if manifest.get("publication_plan") != plan.to_dict():
+        raise DatasetBuilderError("publication plan facts mismatch")
+    if manifest.get("format") != _format_facts():
+        raise DatasetBuilderError("physical format facts mismatch")
+
+    expected_builder = _builder_identity(pa)
+    actual_builder = manifest.get("builder")
+    if not isinstance(actual_builder, dict):
+        raise DatasetBuilderError("builder identity is missing")
+    for key in ("builder_source_sha256", "source_files"):
+        if actual_builder.get(key) != expected_builder[key]:
+            raise DatasetBuilderError(f"builder identity mismatch: {key}")
+    python_version = actual_builder.get("python_version")
+    writer = actual_builder.get("parquet_writer")
+    if not isinstance(python_version, str) or not python_version:
+        raise DatasetBuilderError("builder Python version is invalid")
+    if (
+        not isinstance(writer, dict)
+        or writer.get("name") != "pyarrow"
+        or not isinstance(writer.get("version"), str)
+        or not writer["version"]
+    ):
+        raise DatasetBuilderError("builder Parquet-writer version is invalid")
+
+    expected_configs = []
+    shard_rows: dict[str, int] = {}
+    try:
+        actual_configs = manifest["configurations"]
+        if not isinstance(actual_configs, list):
+            raise TypeError
+        for name in CONFIGURATION_NAMES:
+            shards = []
+            row_count = plan.views[name].row_count
+            for index, relative in enumerate(_shard_relpaths(plan, name)):
+                rows = min(SHARD_ROWS, row_count - index * SHARD_ROWS)
+                shards.append({"path": relative, "rows": rows})
+                shard_rows[relative] = rows
+            expected_configs.append(
+                {
+                    "name": name,
+                    "default": name == "latest",
+                    "data_files": f"data/{name}/*.parquet",
+                    "row_count": row_count,
+                    "shards": shards,
+                }
+            )
+    except (KeyError, TypeError) as exc:
+        raise DatasetBuilderError("configuration manifest is invalid") from exc
+    if actual_configs != expected_configs:
+        raise DatasetBuilderError("configuration or shard facts mismatch")
+
+    expected_non_manifest = _expected_non_manifest_paths(plan)
+    expected_tree = set(expected_non_manifest) | {"manifest.json"}
+    actual_tree = _actual_files(root)
+    if actual_tree != expected_tree:
+        missing = sorted(expected_tree - actual_tree)
+        extra = sorted(actual_tree - expected_tree)
+        raise DatasetBuilderError(f"finished bundle tree mismatch; missing={missing}, extra={extra}")
+    if (root / "provenance" / "sources.json").read_bytes() != _canonical_bytes(
+        _source_provenance(plan)
+    ):
+        raise DatasetBuilderError("source provenance mismatch")
+    if (root / "provenance" / "schema.json").read_bytes() != _canonical_bytes(
+        publication.schema_manifest()
+    ):
+        raise DatasetBuilderError("schema provenance mismatch")
+    if (root / "README.md").read_bytes() != _card_bytes(metadata):
+        raise DatasetBuilderError("Dataset Card content mismatch")
+    card = _parse_card(root / "README.md")
+    if card != _card_frontmatter(metadata):
+        raise DatasetBuilderError("Dataset Card metadata mismatch")
+    actual_files = manifest.get("files")
+    if not isinstance(actual_files, list):
+        raise DatasetBuilderError("manifest file facts are invalid")
+    expected_files = _file_facts(
+        root, expected_non_manifest, shard_rows, permitted_extra=("manifest.json",)
+    )
+    if actual_files != expected_files:
+        raise DatasetBuilderError("output file hash, size, or row facts mismatch")
+
+    schema = _physical_schema(pa)
+    readers = {
+        config["name"]: iter(
+            _iter_parquet_rows(root, config["shards"], schema, pa, pq)
+        )
+        for config in actual_configs
+    }
+    accumulators = {name: _DigestAccumulator() for name in CONFIGURATION_NAMES}
+    for expected in publication.iter_classified_history(plan):
+        actual = _next_or_error(readers["history"], "history")
+        if actual != expected:
+            raise DatasetBuilderError("history row content, provenance, or order mismatch")
+        accumulators["history"].update(actual)
+        for name in ("snapshot", "latest"):
+            if publication.row_in_view(expected, name):
+                actual = _next_or_error(readers[name], name)
+                if actual != expected:
+                    raise DatasetBuilderError(
+                        f"{name} row content, membership, provenance, or order mismatch"
+                    )
+                accumulators[name].update(actual)
+    for name in CONFIGURATION_NAMES:
+        _assert_exhausted(readers[name], name)
+        stats = plan.views[name]
+        accumulator = accumulators[name]
+        if accumulator.rows != stats.row_count:
+            raise DatasetBuilderError(f"{name} read-back row count mismatch")
+        if accumulator.identity.hexdigest() != stats.source_identity_sha256:
+            raise DatasetBuilderError(f"{name} source identity digest mismatch")
+        if accumulator.logical.hexdigest() != stats.normalized_logical_sha256:
+            raise DatasetBuilderError(f"{name} normalized logical digest mismatch")
+
+    return {
+        "bundle": str(root),
+        "counts": {name: plan.views[name].row_count for name in CONFIGURATION_NAMES},
+        "logical_digests": {
+            name: plan.views[name].normalized_logical_sha256
+            for name in CONFIGURATION_NAMES
+        },
+        "builder_source_sha256": actual_builder["builder_source_sha256"],
+        "pyarrow_version": actual_builder["parquet_writer"]["version"],
+        "verified": True,
+    }
+
+
+def _publish_staging(staging: Path, output: Path) -> None:
+    if output.exists():
+        raise DatasetBuilderError(f"output path appeared before publication: {output}")
+    staging.rename(output)
+
+
+def _build_from_plan(
+    plan: publication.PublicationPlan,
+    output: str | Path,
+    metadata: ReleaseMetadata,
+    *,
+    pa: Any | None = None,
+    pq: Any | None = None,
+    observe_buffer: Callable[[str, int], None] | None = None,
+) -> dict[str, Any]:
+    if pa is None or pq is None:
+        pa, pq = _require_pyarrow()
+    destination = Path(output).resolve()
+    if destination.exists():
+        raise DatasetBuilderError(f"output path already exists: {destination}")
+    parent = destination.parent
+    if parent.exists() and not parent.is_dir():
+        raise DatasetBuilderError(f"output parent is not a directory: {parent}")
+    parent.mkdir(parents=True, exist_ok=True)
+    staging = parent / f".{destination.name}.incomplete-{uuid.uuid4().hex}"
+    try:
+        staging.mkdir()
+        _write_support_files(staging, plan, metadata)
+        shards = _write_rows(
+            plan, staging, pa, pq, observe_buffer=observe_buffer
+        )
+        shard_rows = {
+            shard["path"]: shard["rows"]
+            for config_shards in shards.values()
+            for shard in config_shards
+        }
+        expected = _expected_non_manifest_paths(plan)
+        files = _file_facts(staging, expected, shard_rows)
+        builder = _builder_identity(pa)
+        manifest = _manifest(
+            plan=plan,
+            metadata=metadata,
+            builder=builder,
+            configurations=_configuration_facts(plan, shards),
+            files=files,
+        )
+        manifest_bytes = _canonical_bytes(manifest)
+        (staging / "manifest.json").write_bytes(manifest_bytes)
+        verified = _verify_against_plan(plan, staging, pa=pa, pq=pq)
+        manifest_sha256 = hashlib.sha256(manifest_bytes).hexdigest()
+        output_size = sum(
+            path.stat().st_size for path in staging.rglob("*") if path.is_file()
+        )
+        summary = {
+            **verified,
+            "bundle": str(destination),
+            "manifest_sha256": manifest_sha256,
+            "size_bytes": output_size,
+            "staging": str(staging),
+        }
+        _publish_staging(staging, destination)
+        return summary
+    except Exception as exc:
+        destination_absent = not destination.exists()
+        if staging.exists():
+            message = (
+                f"{exc}; incomplete staging retained at {staging}; requested "
+                f"destination {'remained absent' if destination_absent else 'exists'}: "
+                f"{destination}"
+            )
+            raise DatasetBuilderError(message) from exc
+        if isinstance(exc, DatasetBuilderError):
+            raise
+        raise DatasetBuilderError(str(exc)) from exc
+
+
+def build(
+    source_root: str | Path,
+    output: str | Path,
+    license_id: str,
+    citation_url: str,
+    reproduction_url: str,
+) -> dict[str, Any]:
+    """Build the pinned corpus into a fresh local bundle."""
+    metadata = validate_release_metadata(license_id, citation_url, reproduction_url)
+    pa, pq = _require_pyarrow()
+    destination = Path(output).resolve()
+    if destination.exists():
+        raise DatasetBuilderError(f"output path already exists: {destination}")
+    plan = publication.build_publication_plan(source_root)
+    return _build_from_plan(plan, destination, metadata, pa=pa, pq=pq)
+
+
+def verify(source_root: str | Path, bundle: str | Path) -> dict[str, Any]:
+    """Read-only verification of a finished bundle against the pinned corpus."""
+    pa, pq = _require_pyarrow()
+    plan = publication.build_publication_plan(source_root)
+    try:
+        return _verify_against_plan(plan, bundle, pa=pa, pq=pq)
+    except DatasetBuilderError:
+        raise
+    except Exception as exc:
+        raise DatasetBuilderError(f"bundle verification failed: {exc}") from exc
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build_parser = subparsers.add_parser("build", help="build a fresh pinned bundle")
+    build_parser.add_argument("--source-root", required=True, type=Path)
+    build_parser.add_argument("--output", required=True, type=Path)
+    build_parser.add_argument(
+        "--license",
+        required=True,
+        dest="license_id",
+        help="recognized v1 identifier: " + ", ".join(sorted(ACCEPTED_LICENSES)),
+    )
+    build_parser.add_argument("--citation-url", required=True)
+    build_parser.add_argument("--reproduction-url", required=True)
+    verify_parser = subparsers.add_parser("verify", help="verify a finished pinned bundle")
+    verify_parser.add_argument("--source-root", required=True, type=Path)
+    verify_parser.add_argument("--bundle", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        if args.command == "build":
+            summary = build(
+                args.source_root,
+                args.output,
+                args.license_id,
+                args.citation_url,
+                args.reproduction_url,
+            )
+        else:
+            summary = verify(args.source_root, args.bundle)
+    except (DatasetBuilderError, publication.PublicationError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    sys.stdout.write(publication.canonical_json(summary, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a command
+    raise SystemExit(main())

--- a/tests/eval/generation.py
+++ b/tests/eval/generation.py
@@ -6,11 +6,50 @@ and collection can use one small contract for interpreting stored eval rows.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Any
 
 
 BaseConfigurationIdentity = tuple[Any, Any, Any, Any, Any, Any]
 ExplicitPolicyIdentity = tuple[Any, Any, Any, Any, Any, Any, Any]
+
+
+@dataclass
+class GenerationMaxima:
+    """Bounded selection state keyed by configuration and explicit policy."""
+
+    base: dict[BaseConfigurationIdentity, int] = field(default_factory=dict)
+    explicit_policy: dict[ExplicitPolicyIdentity, int] = field(
+        default_factory=dict
+    )
+
+
+def accumulate_generation_maxima(
+    maxima: GenerationMaxima, row: dict[str, Any]
+) -> None:
+    """Include one row in the bounded maxima used by generation selection."""
+    generation = effective_generation(row)
+    base_identity = base_configuration_identity(row)
+    if generation > maxima.base.get(base_identity, -1):
+        maxima.base[base_identity] = generation
+    if "reasoning_replay" in row:
+        policy_identity = explicit_policy_identity(row)
+        if generation > maxima.explicit_policy.get(policy_identity, -1):
+            maxima.explicit_policy[policy_identity] = generation
+
+
+def selection_maximum_generation(
+    maxima: GenerationMaxima, row: dict[str, Any]
+) -> int:
+    """Return the maximum generation governing one row's selection."""
+    if "reasoning_replay" in row:
+        return maxima.explicit_policy[explicit_policy_identity(row)]
+    return maxima.base[base_configuration_identity(row)]
+
+
+def is_selected_generation(maxima: GenerationMaxima, row: dict[str, Any]) -> bool:
+    """Apply the report-compatible selection predicate to one row."""
+    return effective_generation(row) == selection_maximum_generation(maxima, row)
 
 
 def effective_generation(row: dict[str, Any]) -> int:
@@ -51,23 +90,8 @@ def select_latest_generation(rows: list[dict[str, Any]]) -> list[dict[str, Any]]
     Selection is whole-configuration rather than per-scenario. The returned
     list contains the original row objects and preserves their input order.
     """
-    base_max: dict[BaseConfigurationIdentity, int] = {}
-    policy_max: dict[ExplicitPolicyIdentity, int] = {}
+    maxima = GenerationMaxima()
     for row in rows:
-        generation = effective_generation(row)
-        base_identity = base_configuration_identity(row)
-        policy_identity = explicit_policy_identity(row)
-        if generation > base_max.get(base_identity, -1):
-            base_max[base_identity] = generation
-        if generation > policy_max.get(policy_identity, -1):
-            policy_max[policy_identity] = generation
+        accumulate_generation_maxima(maxima, row)
 
-    selected: list[dict[str, Any]] = []
-    for row in rows:
-        generation = effective_generation(row)
-        if "reasoning_replay" in row:
-            if generation == policy_max[explicit_policy_identity(row)]:
-                selected.append(row)
-        elif generation == base_max[base_configuration_identity(row)]:
-            selected.append(row)
-    return selected
+    return [row for row in rows if is_selected_generation(maxima, row)]

--- a/tests/eval/provenance.py
+++ b/tests/eval/provenance.py
@@ -1,0 +1,30 @@
+"""Shared human-readable provenance for Forge eval generations."""
+
+from __future__ import annotations
+
+
+# An eval generation is a comparability epoch, not a release version.  Keep
+# this object shared: report rendering and dataset publication both expose the
+# exact same provenance strings.
+GEN_INFO: dict[int, dict[str, str]] = {
+    1: {
+        "commit": "2b05dc4",
+        "date": "2026-05-08",
+        "note": "v0.6.0 suite — incl. Anthropic ablation",
+    },
+    2: {
+        "commit": "655e1f6",
+        "date": "2026-05-22",
+        "note": "v0.7.0 lineup refresh (8–14B) + 32GB tier debut (v0.7.4)",
+    },
+    # Tag ref, not a commit SHA: gen 3 landed via a branch whose squash-merge
+    # SHA didn't exist when this entry was written; the v0.7.5 tag resolves to it.
+    3: {
+        "commit": "v0.7.5",
+        "date": "2026-06-11",
+        "note": (
+            "reasoning-replay grid (8–14B × none/keep-last/full) "
+            "+ Claude thinking-on baseline"
+        ),
+    },
+}

--- a/tests/eval/publication.py
+++ b/tests/eval/publication.py
@@ -1,0 +1,893 @@
+"""Strict, streaming publication contract for the released Forge eval corpus.
+
+This module deliberately lives beside the eval harness and has no Forge
+runtime or optional writer dependencies.  A publication plan takes two
+bounded-memory passes: one to verify sources/build generation maxima, and one
+to classify rows and calculate logical digests.  Iterators perform the same
+strict verification again and must be exhausted for their final file
+hash/count checks to run.
+
+Run the read-only pinned-corpus audit with::
+
+    python -m tests.eval.publication --source-root .
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from tests.eval.generation import (
+    GenerationMaxima,
+    accumulate_generation_maxima,
+    base_configuration_identity,
+    effective_generation,
+    effective_reasoning_replay,
+    is_selected_generation,
+    selection_maximum_generation,
+)
+from tests.eval.provenance import GEN_INFO
+
+
+CONTRACT_VERSION = "forge-eval-publication-v1"
+SCHEMA_VERSION = 1
+REASONING_REPLAY_POLICIES = ("none", "keep-last", "full")
+SELECTION_STATUSES = (
+    "latest",
+    "carried",
+    "superseded_same_policy",
+    "superseded_base",
+)
+SUPERSESSION_SCOPES = ("explicit_policy", "base_configuration")
+VIEW_NAMES = ("history", "snapshot", "latest")
+
+PINNED_VIEW_COUNTS = {
+    "history": 518_700,
+    "snapshot": 378_300,
+    "latest": 260_000,
+}
+PINNED_SNAPSHOT_SOURCE_IDENTITY_SHA256 = (
+    "57618137e920a393e17a7c345b1bf97d8905d01584f16fef86befdc512de02ee"
+)
+PINNED_SNAPSHOT_SOURCE_PAYLOAD_SHA256 = (
+    "de38ab97fd8bc1db66bb45bfbda7d5dcca3865dcb49a165fb6d163da12cf98e1"
+)
+
+
+@dataclass(frozen=True)
+class SourceField:
+    """One allowed source field and its strict JSON value contract.
+
+    ``source_required`` controls omission in JSON. ``source_nullable`` controls
+    an explicit JSON null.  Every omitted source field is present as null in a
+    normalized row, so normalized nullability is the union of those flags.
+    """
+
+    name: str
+    logical_type: str
+    source_required: bool
+    source_nullable: bool = False
+
+    @property
+    def normalized_nullable(self) -> bool:
+        return self.source_nullable or not self.source_required
+
+
+# The 22 common fields are required.  The remaining 11 fields are sparse
+# across releases.  Only fields observed with actual JSON null permit an
+# explicit null; omission and null are intentionally separate source states.
+SOURCE_SCHEMA: tuple[SourceField, ...] = (
+    SourceField("ablation", "string", True),
+    SourceField("accuracy", "bool", True, True),
+    SourceField("backend", "string", True),
+    SourceField("budget_tokens", "int64", True),
+    SourceField("compaction_events", "int64", True),
+    SourceField("completeness", "bool", True),
+    SourceField("elapsed_s", "float64", True),
+    SourceField("error_message", "string", True, True),
+    SourceField("error_type", "string", True, True),
+    SourceField("gen", "int64", True),
+    SourceField("ideal_iterations", "int64", True),
+    SourceField("iterations", "int64", True),
+    SourceField("mode", "string", True),
+    SourceField("model", "string", True),
+    SourceField("reasoning_msgs", "int64", True, True),
+    SourceField("retry_nudges", "int64", True, True),
+    SourceField("run", "int64", True),
+    SourceField("scenario", "string", True),
+    SourceField("step_nudges", "int64", True, True),
+    SourceField("tool_choice", "string", True),
+    SourceField("tool_errors", "int64", True, True),
+    SourceField("wasted_calls", "int64", True, True),
+    SourceField("cache_creation_input_tokens", "int64", False),
+    SourceField("cache_read_input_tokens", "int64", False),
+    SourceField("cost_usd", "float64", False),
+    SourceField("input_tokens", "int64", False),
+    SourceField("output_tokens", "int64", False),
+    SourceField("reasoning_level", "string", False),
+    SourceField("reasoning_replay", "string", False),
+    SourceField("reasoning_wire", "int64", False, True),
+    SourceField("reasoning_wire_total", "int64", False, True),
+    SourceField("rig", "string", False),
+    SourceField("stream_retries", "int64", False),
+)
+
+
+@dataclass(frozen=True)
+class NormalizedField:
+    """Stable logical type and nullability for one publication column."""
+
+    name: str
+    logical_type: str
+    nullable: bool
+    semantics: str
+
+
+_SOURCE_NORMALIZED_SCHEMA = tuple(
+    NormalizedField(
+        source.name,
+        source.logical_type,
+        source.normalized_nullable,
+        "Source value preserved; an omitted sparse source field becomes null.",
+    )
+    for source in SOURCE_SCHEMA
+)
+
+_PROVENANCE_SCHEMA: tuple[NormalizedField, ...] = (
+    NormalizedField("source_file", "string", False, "Pinned source basename."),
+    NormalizedField("source_line", "int64", False, "One-based physical line."),
+    NormalizedField(
+        "source_file_sha256", "string", False, "SHA-256 of the complete source file."
+    ),
+    NormalizedField(
+        "source_row_sha256",
+        "string",
+        False,
+        "SHA-256 of physical line bytes excluding one LF or CRLF terminator.",
+    ),
+    NormalizedField("release", "string", False, "Pinned Forge release version."),
+    NormalizedField(
+        "generation_reference",
+        "string",
+        False,
+        "Commit or tag reference from the shared generation provenance.",
+    ),
+    NormalizedField(
+        "generation_date", "string", False, "Date from shared generation provenance."
+    ),
+    NormalizedField(
+        "generation_note", "string", False, "Note from shared generation provenance."
+    ),
+    NormalizedField(
+        "effective_reasoning_replay",
+        "string",
+        False,
+        "Raw replay policy, or full for legacy rows where it is absent.",
+    ),
+    NormalizedField(
+        "effective_reasoning_level",
+        "string",
+        False,
+        "Raw reasoning level, or default where it is absent.",
+    ),
+    NormalizedField(
+        "base_config_id",
+        "string",
+        False,
+        "Full SHA-256 of the canonically framed base configuration identity.",
+    ),
+    NormalizedField(
+        "arm_id",
+        "string",
+        False,
+        "Full SHA-256 of base identity, generation, and replay provenance.",
+    ),
+    NormalizedField(
+        "selection_status", "string", False, "One publication selection status."
+    ),
+    NormalizedField(
+        "superseded_by_scope",
+        "string",
+        True,
+        "Null when selected; otherwise explicit_policy or base_configuration.",
+    ),
+    NormalizedField(
+        "superseded_by_generation",
+        "int64",
+        True,
+        "Null when selected; otherwise the governing newer generation.",
+    ),
+    NormalizedField(
+        "selected_for_snapshot",
+        "bool",
+        False,
+        "True exactly when retained by the shared generation selector.",
+    ),
+    NormalizedField(
+        "selected_for_latest",
+        "bool",
+        False,
+        "Snapshot membership at the corpus-wide maximum generation.",
+    ),
+    NormalizedField(
+        "comparable_to_latest",
+        "bool",
+        False,
+        "Generation comparability; exactly equal to selected_for_latest.",
+    ),
+)
+
+NORMALIZED_SCHEMA: tuple[NormalizedField, ...] = (
+    _SOURCE_NORMALIZED_SCHEMA + _PROVENANCE_SCHEMA
+)
+
+_SOURCE_FIELDS = {field.name: field for field in SOURCE_SCHEMA}
+_SOURCE_FIELD_NAMES = frozenset(_SOURCE_FIELDS)
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    """One allowlisted source and its pinned release facts."""
+
+    source_file: str
+    release: str
+    generation: int
+    row_count: int
+    sha256: str
+
+
+PINNED_SOURCES: tuple[SourceSpec, ...] = (
+    SourceSpec(
+        "eval_results_v0.6.0.jsonl",
+        "v0.6.0",
+        1,
+        131_300,
+        "2e6a0135b278752cc1a1dee20f2ce20f019c515ad28642ed241960d251112e4e",
+    ),
+    SourceSpec(
+        "eval_results_v0.7.0.jsonl",
+        "v0.7.0",
+        2,
+        96_200,
+        "0dbe1ee5f76c283edf07f2c7ced3c3f410733b4e5566580bf0e8b69365baeaf7",
+    ),
+    SourceSpec(
+        "eval_results_v0.7.4.jsonl",
+        "v0.7.4",
+        2,
+        31_200,
+        "879ea1c11eae6cde6b9edb0ac2fdfe91013eb21cdcad7b289ea2c48d970835f5",
+    ),
+    SourceSpec(
+        "eval_results_v0.7.5.jsonl",
+        "v0.7.5",
+        3,
+        185_900,
+        "906ad20c816d3248a8b8218d39db8f5a04ff81dcb037b8244573244b2d20b107",
+    ),
+    SourceSpec(
+        "eval_results_v0.8.2.jsonl",
+        "v0.8.2",
+        3,
+        74_100,
+        "65c6e3a453edc5b5abf438f6534b5dc7320e9717ee6e8c9b8472e9229b195fdf",
+    ),
+)
+
+
+class PublicationError(ValueError):
+    """A compact, source-local publication-contract violation."""
+
+
+class _DuplicateKey(ValueError):
+    pass
+
+
+class _NonStandardConstant(ValueError):
+    pass
+
+
+def canonical_json(value: Any, *, sort_keys: bool) -> str:
+    """Serialize canonical compact JSON, preserving non-ASCII characters."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=sort_keys,
+        allow_nan=False,
+    )
+
+
+def canonical_json_bytes(value: Any, *, sort_keys: bool) -> bytes:
+    """Return :func:`canonical_json` encoded as strict UTF-8."""
+    return canonical_json(value, sort_keys=sort_keys).encode("utf-8")
+
+
+def _schema_payload() -> dict[str, Any]:
+    return {
+        "source_fields": [
+            {
+                "name": source.name,
+                "logical_type": source.logical_type,
+                "source_required": source.source_required,
+                "source_nullable": source.source_nullable,
+                "normalized_nullable": source.normalized_nullable,
+            }
+            for source in SOURCE_SCHEMA
+        ],
+        "normalized_fields": [
+            {
+                "name": normalized.name,
+                "logical_type": normalized.logical_type,
+                "nullable": normalized.nullable,
+                "semantics": normalized.semantics,
+            }
+            for normalized in NORMALIZED_SCHEMA
+        ],
+        "enums": {
+            "reasoning_replay": list(REASONING_REPLAY_POLICIES),
+            "selection_status": list(SELECTION_STATUSES),
+            "supersession_scope": list(SUPERSESSION_SCOPES),
+            "view": list(VIEW_NAMES),
+        },
+    }
+
+
+def schema_fingerprint() -> str:
+    """Return the SHA-256 fingerprint of the complete schema contract."""
+    return hashlib.sha256(
+        canonical_json_bytes(_schema_payload(), sort_keys=True)
+    ).hexdigest()
+
+
+def schema_manifest() -> dict[str, Any]:
+    """Return the explicit source/normalized schema and enum vocabularies."""
+    return {
+        "version": SCHEMA_VERSION,
+        "sha256": schema_fingerprint(),
+        **_schema_payload(),
+    }
+
+
+def _error(source_file: str, source_line: int, invariant: str, category: str) -> None:
+    raise PublicationError(
+        f"{source_file}:{source_line}: {invariant} [{category}]"
+    )
+
+
+def _pairs_to_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateKey
+        result[key] = value
+    return result
+
+
+def _reject_constant(_value: str) -> None:
+    raise _NonStandardConstant
+
+
+def _validate_string(
+    value: Any, source_file: str, source_line: int, field_name: str
+) -> None:
+    if not isinstance(value, str):
+        _error(source_file, source_line, f"field {field_name}", "wrong_type")
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        _error(source_file, source_line, f"field {field_name}", "invalid_unicode")
+
+
+def _validate_value(
+    value: Any, field_spec: SourceField, source_file: str, source_line: int
+) -> None:
+    if value is None:
+        if not field_spec.source_nullable:
+            _error(
+                source_file,
+                source_line,
+                f"field {field_spec.name}",
+                "null_not_allowed",
+            )
+        return
+
+    logical_type = field_spec.logical_type
+    if logical_type == "string":
+        _validate_string(value, source_file, source_line, field_spec.name)
+    elif logical_type == "bool":
+        if type(value) is not bool:
+            _error(source_file, source_line, f"field {field_spec.name}", "wrong_type")
+    elif logical_type == "int64":
+        if type(value) is not int:
+            _error(source_file, source_line, f"field {field_spec.name}", "wrong_type")
+        if not -(2**63) <= value < 2**63:
+            _error(source_file, source_line, f"field {field_spec.name}", "out_of_range")
+    elif logical_type == "float64":
+        if type(value) not in (int, float):
+            _error(source_file, source_line, f"field {field_spec.name}", "wrong_type")
+        if not math.isfinite(value):
+            _error(source_file, source_line, f"field {field_spec.name}", "non_finite")
+    else:  # pragma: no cover - schema construction invariant
+        raise AssertionError(f"unsupported logical type: {logical_type}")
+
+
+def _validate_source_object(
+    value: Any, source_file: str, source_line: int
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        _error(source_file, source_line, "source row", "non_object")
+
+    names = set(value)
+    if names - _SOURCE_FIELD_NAMES:
+        _error(source_file, source_line, "source schema", "unknown_field")
+    missing = {
+        field.name
+        for field in SOURCE_SCHEMA
+        if field.source_required and field.name not in names
+    }
+    if missing:
+        _error(source_file, source_line, "source schema", "missing_required_field")
+
+    for name, field_value in value.items():
+        _validate_value(field_value, _SOURCE_FIELDS[name], source_file, source_line)
+
+    replay = value.get("reasoning_replay")
+    if replay is not None and replay not in REASONING_REPLAY_POLICIES:
+        _error(source_file, source_line, "field reasoning_replay", "unknown_policy")
+    return value
+
+
+def parse_source_line(
+    line_bytes: bytes, source_file: str, source_line: int
+) -> dict[str, Any]:
+    """Strictly parse and validate one terminator-free physical source line."""
+    if not line_bytes:
+        _error(source_file, source_line, "source row", "blank_line")
+    try:
+        text = line_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        _error(source_file, source_line, "source row", "invalid_utf8")
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=_pairs_to_object,
+            parse_constant=_reject_constant,
+        )
+    except _DuplicateKey:
+        _error(source_file, source_line, "JSON object keys", "duplicate_key")
+    except _NonStandardConstant:
+        _error(source_file, source_line, "JSON number", "non_standard_constant")
+    except (json.JSONDecodeError, RecursionError):
+        _error(source_file, source_line, "source row", "malformed_json")
+    return _validate_source_object(value, source_file, source_line)
+
+
+@dataclass(frozen=True)
+class _ParsedRow:
+    source: dict[str, Any]
+    source_line: int
+    source_row_sha256: str
+
+
+def _without_one_terminator(raw_line: bytes) -> bytes:
+    if raw_line.endswith(b"\r\n"):
+        return raw_line[:-2]
+    if raw_line.endswith(b"\n"):
+        return raw_line[:-1]
+    return raw_line
+
+
+def _generation_info(spec: SourceSpec) -> dict[str, str]:
+    info = GEN_INFO.get(spec.generation)
+    if info is None or set(info) != {"commit", "date", "note"}:
+        _error(spec.source_file, 0, "generation metadata", "unknown_generation")
+    return info
+
+
+def _iter_validated_source(
+    source_root: Path, spec: SourceSpec
+) -> Iterator[_ParsedRow]:
+    _generation_info(spec)
+    path = source_root / spec.source_file
+    try:
+        source = path.open("rb")
+    except OSError:
+        _error(spec.source_file, 0, "source file", "unreadable")
+
+    file_digest = hashlib.sha256()
+    row_count = 0
+    with source:
+        for source_line, raw_line in enumerate(source, 1):
+            row_count = source_line
+            file_digest.update(raw_line)
+            row_bytes = _without_one_terminator(raw_line)
+            row = parse_source_line(row_bytes, spec.source_file, source_line)
+            if effective_generation(row) != spec.generation:
+                _error(
+                    spec.source_file,
+                    source_line,
+                    "field gen",
+                    "source_generation_mismatch",
+                )
+            yield _ParsedRow(
+                source=row,
+                source_line=source_line,
+                source_row_sha256=hashlib.sha256(row_bytes).hexdigest(),
+            )
+
+    if row_count != spec.row_count:
+        _error(spec.source_file, row_count, "source row count", "count_mismatch")
+    if file_digest.hexdigest() != spec.sha256:
+        _error(spec.source_file, row_count, "source file SHA-256", "hash_mismatch")
+
+
+@dataclass(frozen=True)
+class SourceFact:
+    source_file: str
+    release: str
+    generation: int
+    generation_reference: str
+    generation_date: str
+    generation_note: str
+    row_count: int
+    sha256: str
+
+    @classmethod
+    def from_spec(cls, spec: SourceSpec) -> SourceFact:
+        info = _generation_info(spec)
+        return cls(
+            source_file=spec.source_file,
+            release=spec.release,
+            generation=spec.generation,
+            generation_reference=info["commit"],
+            generation_date=info["date"],
+            generation_note=info["note"],
+            row_count=spec.row_count,
+            sha256=spec.sha256,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_file": self.source_file,
+            "release": self.release,
+            "generation": self.generation,
+            "generation_reference": self.generation_reference,
+            "generation_date": self.generation_date,
+            "generation_note": self.generation_note,
+            "row_count": self.row_count,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass(frozen=True)
+class ViewStats:
+    row_count: int
+    source_identity_sha256: str
+    source_payload_sha256: str
+    normalized_logical_sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "row_count": self.row_count,
+            "source_identity_sha256": self.source_identity_sha256,
+            "source_payload_sha256": self.source_payload_sha256,
+            "normalized_logical_sha256": self.normalized_logical_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class PublicationPlan:
+    """Verified portable facts plus private state needed for row iteration."""
+
+    sources: tuple[SourceFact, ...]
+    maximum_generation: int
+    base_configuration_count: int
+    explicit_policy_count: int
+    status_counts: Mapping[str, int]
+    views: Mapping[str, ViewStats]
+    _source_root: Path = field(repr=False, compare=False)
+    _source_specs: tuple[SourceSpec, ...] = field(repr=False, compare=False)
+    _maxima: GenerationMaxima = field(repr=False, compare=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical, host-independent machine-readable plan."""
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "schema_version": SCHEMA_VERSION,
+            "schema_sha256": schema_fingerprint(),
+            "sources": [source.to_dict() for source in self.sources],
+            "generation_maxima": {
+                "corpus": self.maximum_generation,
+                "base_configuration_count": self.base_configuration_count,
+                "explicit_policy_count": self.explicit_policy_count,
+            },
+            "status_counts": {
+                status: self.status_counts[status] for status in SELECTION_STATUSES
+            },
+            "views": {view: self.views[view].to_dict() for view in VIEW_NAMES},
+        }
+
+    def to_json(self) -> str:
+        """Return byte-stable compact JSON without a trailing newline."""
+        return canonical_json(self.to_dict(), sort_keys=True)
+
+
+def _sha256_framed_json(value: Any, *, sort_keys: bool) -> str:
+    return hashlib.sha256(canonical_json_bytes(value, sort_keys=sort_keys)).hexdigest()
+
+
+def _normalize_row(
+    parsed: _ParsedRow,
+    spec: SourceSpec,
+    maxima: GenerationMaxima,
+    maximum_generation: int,
+) -> dict[str, Any]:
+    source = parsed.source
+    generation = effective_generation(source)
+    selected_for_snapshot = is_selected_generation(maxima, source)
+    selected_for_latest = selected_for_snapshot and generation == maximum_generation
+
+    if selected_for_latest:
+        status = "latest"
+        superseded_by_scope = None
+        superseded_by_generation = None
+    elif selected_for_snapshot:
+        status = "carried"
+        superseded_by_scope = None
+        superseded_by_generation = None
+    elif "reasoning_replay" in source:
+        status = "superseded_same_policy"
+        superseded_by_scope = "explicit_policy"
+        superseded_by_generation = selection_maximum_generation(maxima, source)
+    else:
+        status = "superseded_base"
+        superseded_by_scope = "base_configuration"
+        superseded_by_generation = selection_maximum_generation(maxima, source)
+
+    base_identity = list(base_configuration_identity(source))
+    replay_provenance = (
+        f"explicit:{source['reasoning_replay']}"
+        if "reasoning_replay" in source
+        else "legacy-inferred-full"
+    )
+    info = _generation_info(spec)
+
+    normalized = {field.name: source.get(field.name) for field in SOURCE_SCHEMA}
+    normalized.update(
+        {
+            "source_file": spec.source_file,
+            "source_line": parsed.source_line,
+            "source_file_sha256": spec.sha256,
+            "source_row_sha256": parsed.source_row_sha256,
+            "release": spec.release,
+            "generation_reference": info["commit"],
+            "generation_date": info["date"],
+            "generation_note": info["note"],
+            "effective_reasoning_replay": effective_reasoning_replay(source),
+            "effective_reasoning_level": source.get("reasoning_level", "default"),
+            "base_config_id": _sha256_framed_json(base_identity, sort_keys=False),
+            "arm_id": _sha256_framed_json(
+                base_identity + [generation, replay_provenance], sort_keys=False
+            ),
+            "selection_status": status,
+            "superseded_by_scope": superseded_by_scope,
+            "superseded_by_generation": superseded_by_generation,
+            "selected_for_snapshot": selected_for_snapshot,
+            "selected_for_latest": selected_for_latest,
+            "comparable_to_latest": selected_for_latest,
+        }
+    )
+    return normalized
+
+
+@dataclass(frozen=True)
+class _ClassifiedRecord:
+    source: dict[str, Any]
+    normalized: dict[str, Any]
+
+
+def _iter_classified_records(
+    source_root: Path,
+    source_specs: Sequence[SourceSpec],
+    maxima: GenerationMaxima,
+    maximum_generation: int,
+) -> Iterator[_ClassifiedRecord]:
+    for spec in source_specs:
+        for parsed in _iter_validated_source(source_root, spec):
+            yield _ClassifiedRecord(
+                source=parsed.source,
+                normalized=_normalize_row(parsed, spec, maxima, maximum_generation),
+            )
+
+
+class _ViewAccumulator:
+    def __init__(self) -> None:
+        self.row_count = 0
+        self.source_identity = hashlib.sha256()
+        self.source_payload = hashlib.sha256()
+        self.normalized_logical = hashlib.sha256()
+
+    def update(self, source: dict[str, Any], normalized: dict[str, Any]) -> None:
+        self.row_count += 1
+        self.source_identity.update(
+            canonical_json_bytes(
+                [normalized["source_file"], normalized["source_line"]],
+                sort_keys=False,
+            )
+            + b"\n"
+        )
+        self.source_payload.update(
+            canonical_json_bytes(source, sort_keys=True) + b"\n"
+        )
+        self.normalized_logical.update(
+            canonical_json_bytes(normalized, sort_keys=True) + b"\n"
+        )
+
+    def finish(self) -> ViewStats:
+        return ViewStats(
+            row_count=self.row_count,
+            source_identity_sha256=self.source_identity.hexdigest(),
+            source_payload_sha256=self.source_payload.hexdigest(),
+            normalized_logical_sha256=self.normalized_logical.hexdigest(),
+        )
+
+
+def _validate_source_specs(source_specs: tuple[SourceSpec, ...]) -> None:
+    if not source_specs:
+        raise PublicationError("manifest:0: source allowlist [empty]")
+    names = [spec.source_file for spec in source_specs]
+    if len(names) != len(set(names)):
+        raise PublicationError("manifest:0: source allowlist [duplicate_source]")
+    for spec in source_specs:
+        _generation_info(spec)
+
+
+def _enforce_pinned_plan(views: Mapping[str, ViewStats]) -> None:
+    for view, expected_count in PINNED_VIEW_COUNTS.items():
+        if views[view].row_count != expected_count:
+            raise PublicationError(f"manifest:0: {view} row count [contract_mismatch]")
+    snapshot = views["snapshot"]
+    if (
+        snapshot.source_identity_sha256
+        != PINNED_SNAPSHOT_SOURCE_IDENTITY_SHA256
+    ):
+        raise PublicationError(
+            "manifest:0: snapshot source identity digest [contract_mismatch]"
+        )
+    if (
+        snapshot.source_payload_sha256
+        != PINNED_SNAPSHOT_SOURCE_PAYLOAD_SHA256
+    ):
+        raise PublicationError(
+            "manifest:0: snapshot source payload digest [contract_mismatch]"
+        )
+
+
+def build_publication_plan(
+    source_root: str | Path,
+    *,
+    source_specs: Sequence[SourceSpec] = PINNED_SOURCES,
+) -> PublicationPlan:
+    """Verify, classify, and digest allowlisted sources in bounded memory."""
+    root = Path(source_root)
+    specs = tuple(source_specs)
+    _validate_source_specs(specs)
+
+    maxima = GenerationMaxima()
+    maximum_generation = -1
+    for spec in specs:
+        for parsed in _iter_validated_source(root, spec):
+            accumulate_generation_maxima(maxima, parsed.source)
+            maximum_generation = max(
+                maximum_generation, effective_generation(parsed.source)
+            )
+
+    accumulators = {view: _ViewAccumulator() for view in VIEW_NAMES}
+    status_counts = {status: 0 for status in SELECTION_STATUSES}
+    for record in _iter_classified_records(root, specs, maxima, maximum_generation):
+        normalized = record.normalized
+        status_counts[normalized["selection_status"]] += 1
+        accumulators["history"].update(record.source, normalized)
+        if normalized["selected_for_snapshot"]:
+            accumulators["snapshot"].update(record.source, normalized)
+        if normalized["selected_for_latest"]:
+            accumulators["latest"].update(record.source, normalized)
+
+    views = {view: accumulators[view].finish() for view in VIEW_NAMES}
+    if specs == PINNED_SOURCES:
+        _enforce_pinned_plan(views)
+
+    return PublicationPlan(
+        sources=tuple(SourceFact.from_spec(spec) for spec in specs),
+        maximum_generation=maximum_generation,
+        base_configuration_count=len(maxima.base),
+        explicit_policy_count=len(maxima.explicit_policy),
+        status_counts=status_counts,
+        views=views,
+        _source_root=root,
+        _source_specs=specs,
+        _maxima=maxima,
+    )
+
+
+def iter_classified_history(plan: PublicationPlan) -> Iterator[dict[str, Any]]:
+    """Yield every normalized row in source order.
+
+    Exhaust the iterator to complete its strict source hash/count verification.
+    The iterator retains only one source and normalized row at a time.
+    """
+    for record in _iter_classified_records(
+        plan._source_root,
+        plan._source_specs,
+        plan._maxima,
+        plan.maximum_generation,
+    ):
+        yield record.normalized
+
+
+def row_in_view(row: Mapping[str, Any], view: str) -> bool:
+    """Return whether one classified history row belongs to a named view."""
+    if view == "history":
+        return True
+    if view == "snapshot":
+        return bool(row["selected_for_snapshot"])
+    if view == "latest":
+        return bool(row["selected_for_latest"])
+    raise ValueError(f"unknown publication view: {view}")
+
+
+def iter_view(plan: PublicationPlan, view: str) -> Iterator[dict[str, Any]]:
+    """Project one view from the single classified-history stream."""
+    if view not in VIEW_NAMES:
+        raise ValueError(f"unknown publication view: {view}")
+    for row in iter_classified_history(plan):
+        if row_in_view(row, view):
+            yield row
+
+
+def iter_history(plan: PublicationPlan) -> Iterator[dict[str, Any]]:
+    return iter_view(plan, "history")
+
+
+def iter_snapshot(plan: PublicationPlan) -> Iterator[dict[str, Any]]:
+    return iter_view(plan, "snapshot")
+
+
+def iter_latest(plan: PublicationPlan) -> Iterator[dict[str, Any]]:
+    return iter_view(plan, "latest")
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify and print the Forge eval publication plan."
+    )
+    parser.add_argument(
+        "--source-root",
+        required=True,
+        type=Path,
+        help="Directory containing the five pinned eval JSONL files.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        plan = build_publication_plan(args.source_root)
+    except PublicationError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    sys.stdout.write(plan.to_json() + "\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a command
+    raise SystemExit(main())

--- a/tests/eval/report.py
+++ b/tests/eval/report.py
@@ -27,6 +27,7 @@ from tests.eval.generation import (
     effective_reasoning_replay,
     select_latest_generation as dedup_latest_gen,
 )
+from tests.eval.provenance import GEN_INFO
 
 # Scenarios and their ideal iteration counts (from scenarios.py)
 # Hardcoded here so the report script has zero forge imports and can
@@ -677,23 +678,8 @@ def extract_quant(model: str) -> str:
 
 # ── Eval generations & deprecation ────────────────────────────
 
-# An eval generation is a comparability epoch, NOT a release version. It is
-# bumped only when a change is judged eval-material; many releases can share
-# one gen, and one gen can span several eval waves / dataset files. The gen
-# is injected per-row into the dataset (see dedup_latest_gen). This table is
-# the human-readable legend: what each gen means and the commit to reproduce
-# it. gen 0 = the v0.4.0 paper suite (intentionally not backported).
-GEN_INFO: dict[int, dict[str, str]] = {
-    1: {"commit": "2b05dc4", "date": "2026-05-08",
-        "note": "v0.6.0 suite — incl. Anthropic ablation"},
-    2: {"commit": "655e1f6", "date": "2026-05-22",
-        "note": "v0.7.0 lineup refresh (8–14B) + 32GB tier debut (v0.7.4)"},
-    # Tag ref, not a commit SHA: gen 3 landed via a branch whose squash-merge
-    # SHA didn't exist when this entry was written; the v0.7.5 tag resolves to it.
-    3: {"commit": "v0.7.5", "date": "2026-06-11",
-        "note": "reasoning-replay grid (8–14B × none/keep-last/full) + Claude thinking-on baseline"},
-}
-
+# GEN_INFO is the shared human-readable generation legend. Generation 0 is
+# the v0.4.0 paper suite and is intentionally not backported into the legend.
 # Coarse families in the "Retired" tier of docs/MODEL_REGISTRY.md. Retired
 # configs are carried forward by latest-gen dedup but hidden by default —
 # shown only via the dashboard's toggle / --include-retired. Keyed by family

--- a/tests/unit/test_eval_dataset_builder.py
+++ b/tests/unit/test_eval_dataset_builder.py
@@ -1,0 +1,352 @@
+"""Focused coverage for the offline Forge Parquet dataset builder."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.eval import dataset_builder, publication
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "ablation": "reforged",
+        "accuracy": True,
+        "backend": "backend-a",
+        "budget_tokens": 100,
+        "compaction_events": 0,
+        "completeness": True,
+        "elapsed_s": 1.25,
+        "error_message": None,
+        "error_type": None,
+        "gen": 1,
+        "ideal_iterations": 2,
+        "iterations": 2,
+        "mode": "native",
+        "model": "model-a",
+        "reasoning_msgs": 1,
+        "retry_nudges": 0,
+        "run": 1,
+        "scenario": "repeated-scenario",
+        "step_nudges": 0,
+        "tool_choice": "auto",
+        "tool_errors": 0,
+        "wasted_calls": 0,
+    }
+    row.update(overrides)
+    return row
+
+
+def _write_source(
+    root: Path, name: str, rows: list[dict[str, Any]]
+) -> publication.SourceSpec:
+    payload = b"".join(
+        json.dumps(
+            row, ensure_ascii=False, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+        + b"\n"
+        for row in rows
+    )
+    (root / name).write_bytes(payload)
+    generations = {row["gen"] for row in rows}
+    assert len(generations) == 1
+    return publication.SourceSpec(
+        name,
+        "synthetic",
+        generations.pop(),
+        len(rows),
+        hashlib.sha256(payload).hexdigest(),
+    )
+
+
+def _fixture_plan(root: Path) -> publication.PublicationPlan:
+    root.mkdir()
+    gen1 = [
+        _row(model="shared", run=1, cost_usd=0.125, reasoning_wire=None),
+        _row(model="carried", run=1, accuracy=None, elapsed_s=2.5),
+        _row(
+            model="shared",
+            run=1,
+            reasoning_replay="none",
+            elapsed_s=3.75,
+        ),
+    ]
+    gen2 = [
+        _row(model="shared", run=1, gen=2, reasoning_replay="none"),
+        _row(model="new", run=1, gen=2, cost_usd=0.5),
+        _row(model="new", run=1, gen=2, cost_usd=0.75),
+        _row(model="another", run=1, gen=2, elapsed_s=4.0),
+    ]
+    specs = [
+        _write_source(root, "gen1.jsonl", gen1),
+        _write_source(root, "gen2.jsonl", gen2),
+    ]
+    return publication.build_publication_plan(root, source_specs=specs)
+
+
+@pytest.fixture
+def metadata() -> dataset_builder.ReleaseMetadata:
+    return dataset_builder.validate_release_metadata(
+        "mit",
+        "https://example.test/citation?q=forge#paper",
+        "http://example.test/reproduce?version=1",
+    )
+
+
+def test_physical_schema_is_exact_and_pyarrow_is_lazy() -> None:
+    pa, _ = dataset_builder._require_pyarrow()
+    schema = dataset_builder._physical_schema(pa)
+    assert len(schema) == 51
+    assert [field.name for field in schema] == [
+        field.name for field in publication.NORMALIZED_SCHEMA
+    ]
+    assert [field.nullable for field in schema] == [
+        field.nullable for field in publication.NORMALIZED_SCHEMA
+    ]
+    assert schema.field("elapsed_s").type == pa.float64()
+    assert schema.field("source_line").type == pa.int64()
+
+
+def test_card_documents_replay_reasoning_and_carried_evidence_semantics(
+    metadata: dataset_builder.ReleaseMetadata,
+) -> None:
+    body = dataset_builder._card_bytes(metadata).decode("utf-8")
+    assert "missing raw `reasoning_replay` is inferred as effective `full`" in body
+    assert (
+        "legacy-inferred `full` remains distinct\n"
+        "in arm identity from an explicitly recorded raw `full`"
+    ) in body
+    assert "raw `reasoning_replay` field preserves the value recorded" in body
+    assert "in `effective_reasoning_replay`" in body
+    assert "raw\n`reasoning_level` field preserves the optional source value" in body
+    assert "`effective_reasoning_level` resolves a missing raw value to `default`" in body
+    assert (
+        "Carried\nevidence is an older selected cohort retained because no newer "
+        "matching cohort\nexists."
+    ) in body
+
+
+@pytest.mark.parametrize("license_id", ["", "other", "custom", "MIT", " mit"])
+def test_license_rejects_unsupported_identifiers(license_id: str) -> None:
+    with pytest.raises(dataset_builder.DatasetBuilderError, match="license"):
+        dataset_builder.validate_release_metadata(
+            license_id, "https://example.test/cite", "https://example.test/repro"
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["", "relative/path", "ftp://example.test/x", "https:///missing-host", " https://example.test"],
+)
+def test_metadata_rejects_malformed_urls(url: str) -> None:
+    with pytest.raises(dataset_builder.DatasetBuilderError, match="URL"):
+        dataset_builder.validate_release_metadata(
+            "mit", url, "https://example.test/repro"
+        )
+
+
+def test_build_is_deterministic_structured_and_fully_verified(
+    tmp_path: Path,
+    metadata: dataset_builder.ReleaseMetadata,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _fixture_plan(tmp_path / "source")
+    monkeypatch.setattr(dataset_builder, "SHARD_ROWS", 3)
+    monkeypatch.setattr(dataset_builder, "RECORD_BATCH_ROWS", 2)
+    observed: dict[str, int] = {name: 0 for name in dataset_builder.CONFIGURATION_NAMES}
+
+    def observe(name: str, rows: int) -> None:
+        observed[name] = max(observed[name], rows)
+
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    summary = dataset_builder._build_from_plan(
+        plan, first, metadata, observe_buffer=observe
+    )
+    dataset_builder._build_from_plan(plan, second, metadata)
+
+    assert summary["verified"] is True
+    assert summary["counts"] == {
+        name: plan.views[name].row_count
+        for name in dataset_builder.CONFIGURATION_NAMES
+    }
+    assert all(size <= 2 for size in observed.values())
+    assert (first / "manifest.json").read_bytes() == (second / "manifest.json").read_bytes()
+    assert {
+        path.relative_to(first).as_posix()
+        for path in first.rglob("*.parquet")
+    } == {
+        "data/latest/part-00001-of-00002.parquet",
+        "data/latest/part-00002-of-00002.parquet",
+        "data/snapshot/part-00001-of-00002.parquet",
+        "data/snapshot/part-00002-of-00002.parquet",
+        "data/history/part-00001-of-00003.parquet",
+        "data/history/part-00002-of-00003.parquet",
+        "data/history/part-00003-of-00003.parquet",
+    }
+
+    manifest = json.loads((first / "manifest.json").read_bytes())
+    assert manifest["publication_plan"] == plan.to_dict()
+    assert manifest["format"] == {
+        "configuration_order": ["latest", "snapshot", "history"],
+        "compression": "zstd",
+        "record_batch_rows": 2,
+        "shard_rows": 3,
+        "shard_template": "part-{index:05d}-of-{total:05d}.parquet",
+    }
+    assert "builder_source_sha256" in manifest["builder"]
+    assert len(manifest["builder"]["source_files"]) == 4
+    assert all("sha256" in fact for fact in manifest["files"])
+    assert all(
+        "rows" in fact
+        for fact in manifest["files"]
+        if fact["path"].endswith(".parquet")
+    )
+    assert "manifest.json" not in {fact["path"] for fact in manifest["files"]}
+
+    card = dataset_builder._parse_card(first / "README.md")
+    assert card["license"] == "mit"
+    assert [config["config_name"] for config in card["configs"]] == [
+        "latest",
+        "snapshot",
+        "history",
+    ]
+    assert [config["data_files"][0]["path"] for config in card["configs"]] == [
+        "data/latest/*.parquet",
+        "data/snapshot/*.parquet",
+        "data/history/*.parquet",
+    ]
+    assert [config["config_name"] for config in card["configs"] if config.get("default")] == ["latest"]
+    assert dataset_builder._verify_against_plan(plan, first)["verified"] is True
+
+
+@pytest.mark.parametrize("nonempty", [False, True])
+def test_preexisting_destination_is_never_modified(
+    tmp_path: Path,
+    metadata: dataset_builder.ReleaseMetadata,
+    nonempty: bool,
+) -> None:
+    plan = _fixture_plan(tmp_path / "source")
+    output = tmp_path / "existing"
+    output.mkdir()
+    if nonempty:
+        (output / "sentinel").write_text("keep", encoding="utf-8")
+    before = list(output.iterdir())
+    with pytest.raises(dataset_builder.DatasetBuilderError, match="already exists"):
+        dataset_builder._build_from_plan(plan, output, metadata)
+    assert list(output.iterdir()) == before
+
+
+def test_missing_output_parents_are_created_after_plan(
+    tmp_path: Path, metadata: dataset_builder.ReleaseMetadata
+) -> None:
+    plan = _fixture_plan(tmp_path / "source")
+    output = tmp_path / "new" / "nested" / "bundle"
+    dataset_builder._build_from_plan(plan, output, metadata)
+    assert (output / "manifest.json").is_file()
+
+
+def test_injected_publish_failure_retains_staging_and_not_destination(
+    tmp_path: Path,
+    metadata: dataset_builder.ReleaseMetadata,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _fixture_plan(tmp_path / "source")
+    output = tmp_path / "requested"
+
+    def fail_publish(_staging: Path, _output: Path) -> None:
+        raise OSError("injected after manifest")
+
+    monkeypatch.setattr(dataset_builder, "_publish_staging", fail_publish)
+    with pytest.raises(dataset_builder.DatasetBuilderError, match="incomplete staging retained") as exc_info:
+        dataset_builder._build_from_plan(plan, output, metadata)
+    assert "requested destination remained absent" in str(exc_info.value)
+    assert not output.exists()
+    staging = list(tmp_path.glob(".requested.incomplete-*"))
+    assert len(staging) == 1
+    assert (staging[0] / "manifest.json").is_file()
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["extra", "missing", "corrupt_parquet", "corrupt_card", "corrupt_provenance"],
+)
+def test_verifier_rejects_tree_and_content_corruption(
+    tmp_path: Path,
+    metadata: dataset_builder.ReleaseMetadata,
+    mutation: str,
+) -> None:
+    plan = _fixture_plan(tmp_path / "source")
+    output = tmp_path / "bundle"
+    dataset_builder._build_from_plan(plan, output, metadata)
+    if mutation == "extra":
+        (output / "extra.txt").write_text("extra", encoding="utf-8")
+    elif mutation == "missing":
+        (output / "provenance" / "schema.json").unlink()
+    elif mutation == "corrupt_parquet":
+        shard = next(output.rglob("*.parquet"))
+        shard.write_bytes(shard.read_bytes() + b"corrupt")
+    elif mutation == "corrupt_card":
+        (output / "README.md").write_text("---\n{}\n---\n", encoding="utf-8")
+    else:
+        (output / "provenance" / "sources.json").write_text("{}\n", encoding="utf-8")
+    with pytest.raises((dataset_builder.DatasetBuilderError, OSError)):
+        dataset_builder._verify_against_plan(plan, output)
+
+
+@pytest.mark.parametrize("mutation", ["early", "extra", "order", "schema"])
+def test_readback_rejects_row_and_schema_invariants_after_rehash(
+    tmp_path: Path,
+    metadata: dataset_builder.ReleaseMetadata,
+    mutation: str,
+) -> None:
+    """Reach read-back checks rather than stopping at the physical file hash."""
+    pa, pq = dataset_builder._require_pyarrow()
+    plan = _fixture_plan(tmp_path / "source")
+    output = tmp_path / "bundle"
+    dataset_builder._build_from_plan(plan, output, metadata)
+    relative = "data/history/part-00001-of-00001.parquet"
+    path = output / relative
+    table = pq.read_table(path)
+    if mutation == "early":
+        changed = table.slice(0, table.num_rows - 1)
+    elif mutation == "extra":
+        changed = pa.concat_tables([table, table.slice(0, 1)])
+    elif mutation == "order":
+        indices = pa.array([1, 0, *range(2, table.num_rows)])
+        changed = table.take(indices)
+    else:
+        changed = pa.Table.from_pylist(table.to_pylist())
+    pq.write_table(
+        changed,
+        path,
+        compression=dataset_builder.COMPRESSION,
+        version="2.6",
+        use_dictionary=False,
+        write_statistics=True,
+    )
+    manifest_path = output / "manifest.json"
+    manifest = json.loads(manifest_path.read_bytes())
+    fact = next(item for item in manifest["files"] if item["path"] == relative)
+    fact["sha256"] = dataset_builder._sha256_file(path)
+    fact["size_bytes"] = path.stat().st_size
+    manifest_path.write_bytes(dataset_builder._canonical_bytes(manifest))
+    with pytest.raises(dataset_builder.DatasetBuilderError):
+        dataset_builder._verify_against_plan(plan, output)
+
+
+def test_missing_pyarrow_message_is_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = dataset_builder.importlib.import_module
+
+    def missing(name: str) -> Any:
+        if name == "pyarrow":
+            raise ImportError("not installed")
+        return real_import(name)
+
+    monkeypatch.setattr(dataset_builder.importlib, "import_module", missing)
+    with pytest.raises(dataset_builder.DatasetBuilderError, match=r"\.\[dataset-builder\]"):
+        dataset_builder._require_pyarrow()

--- a/tests/unit/test_eval_generation.py
+++ b/tests/unit/test_eval_generation.py
@@ -11,12 +11,17 @@ import pytest
 
 from tests.eval import report
 from tests.eval.generation import (
+    GenerationMaxima,
+    accumulate_generation_maxima,
     base_configuration_identity,
     effective_generation,
     effective_reasoning_replay,
     explicit_policy_identity,
+    is_selected_generation,
+    selection_maximum_generation,
     select_latest_generation,
 )
+from tests.eval.provenance import GEN_INFO as SHARED_GEN_INFO
 
 
 def _row(marker: str, **overrides: Any) -> dict[str, Any]:
@@ -140,6 +145,35 @@ def test_equal_generation_explicit_rows_and_interleaved_order_are_retained() -> 
 
 def test_report_reexports_shared_selector() -> None:
     assert report.dedup_latest_gen is select_latest_generation
+
+
+def test_bounded_maxima_and_predicate_match_selector() -> None:
+    old_none = _row("old-none", gen=1, reasoning_replay="none")
+    carried_full = _row("carried-full", gen=1, reasoning_replay="full")
+    legacy = _row("legacy", gen=1)
+    new_none = _row("new-none", gen=2, reasoning_replay="none")
+    rows = [old_none, carried_full, legacy, new_none]
+    maxima = GenerationMaxima()
+    for row in rows:
+        accumulate_generation_maxima(maxima, row)
+
+    assert [row for row in rows if is_selected_generation(maxima, row)] == [
+        carried_full,
+        new_none,
+    ]
+    assert selection_maximum_generation(maxima, old_none) == 2
+    assert selection_maximum_generation(maxima, legacy) == 2
+    assert len(maxima.base) == 1
+    assert len(maxima.explicit_policy) == 2
+
+
+def test_report_uses_shared_generation_provenance_object() -> None:
+    assert report.GEN_INFO is SHARED_GEN_INFO
+    assert report.GEN_INFO[2] == {
+        "commit": "655e1f6",
+        "date": "2026-05-22",
+        "note": "v0.7.0 lineup refresh (8–14B) + 32GB tier debut (v0.7.4)",
+    }
 
 
 def test_report_groups_legacy_replay_as_full() -> None:

--- a/tests/unit/test_eval_publication.py
+++ b/tests/unit/test_eval_publication.py
@@ -1,0 +1,404 @@
+"""Focused regression coverage for the eval publication contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.eval import publication, report
+from tests.eval.provenance import GEN_INFO
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "ablation": "reforged",
+        "accuracy": True,
+        "backend": "backend-a",
+        "budget_tokens": 100,
+        "compaction_events": 0,
+        "completeness": True,
+        "elapsed_s": 1.25,
+        "error_message": None,
+        "error_type": None,
+        "gen": 1,
+        "ideal_iterations": 2,
+        "iterations": 2,
+        "mode": "native",
+        "model": "model-a",
+        "reasoning_msgs": 1,
+        "retry_nudges": 0,
+        "run": 1,
+        "scenario": "same-scenario",
+        "step_nudges": 0,
+        "tool_choice": "auto",
+        "tool_errors": 0,
+        "wasted_calls": 0,
+    }
+    row.update(overrides)
+    return row
+
+
+def _encode(row: Any) -> bytes:
+    return json.dumps(
+        row,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _write_source(
+    root: Path,
+    name: str,
+    rows: list[dict[str, Any]],
+    *,
+    terminator: bytes = b"\n",
+    final_terminator: bool = True,
+) -> publication.SourceSpec:
+    chunks = []
+    for index, row in enumerate(rows):
+        suffix = terminator if final_terminator or index < len(rows) - 1 else b""
+        chunks.append(_encode(row) + suffix)
+    payload = b"".join(chunks)
+    (root / name).write_bytes(payload)
+    generations = {row["gen"] for row in rows}
+    assert len(generations) == 1
+    generation = generations.pop()
+    return publication.SourceSpec(
+        name,
+        "synthetic",
+        generation,
+        len(rows),
+        hashlib.sha256(payload).hexdigest(),
+    )
+
+
+def _single_plan(
+    tmp_path: Path,
+    row: dict[str, Any] | None = None,
+    *,
+    terminator: bytes = b"\n",
+    final_terminator: bool = True,
+) -> tuple[publication.PublicationPlan, publication.SourceSpec]:
+    source_row = row or _row()
+    spec = _write_source(
+        tmp_path,
+        "synthetic.jsonl",
+        [source_row],
+        terminator=terminator,
+        final_terminator=final_terminator,
+    )
+    return publication.build_publication_plan(tmp_path, source_specs=[spec]), spec
+
+
+def test_schema_is_exact_and_shared_provenance_has_object_identity() -> None:
+    assert len(publication.SOURCE_SCHEMA) == 33
+    assert len(publication.NORMALIZED_SCHEMA) == 51
+    assert [field.name for field in publication.SOURCE_SCHEMA] == [
+        "ablation",
+        "accuracy",
+        "backend",
+        "budget_tokens",
+        "compaction_events",
+        "completeness",
+        "elapsed_s",
+        "error_message",
+        "error_type",
+        "gen",
+        "ideal_iterations",
+        "iterations",
+        "mode",
+        "model",
+        "reasoning_msgs",
+        "retry_nudges",
+        "run",
+        "scenario",
+        "step_nudges",
+        "tool_choice",
+        "tool_errors",
+        "wasted_calls",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "cost_usd",
+        "input_tokens",
+        "output_tokens",
+        "reasoning_level",
+        "reasoning_replay",
+        "reasoning_wire",
+        "reasoning_wire_total",
+        "rig",
+        "stream_retries",
+    ]
+    assert report.GEN_INFO is publication.GEN_INFO is GEN_INFO
+
+    fields = {field.name: field for field in publication.SOURCE_SCHEMA}
+    assert {name for name, field in fields.items() if not field.source_required} == {
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "cost_usd",
+        "input_tokens",
+        "output_tokens",
+        "reasoning_level",
+        "reasoning_replay",
+        "reasoning_wire",
+        "reasoning_wire_total",
+        "rig",
+        "stream_retries",
+    }
+    assert {name for name, field in fields.items() if field.source_nullable} == {
+        "accuracy",
+        "error_message",
+        "error_type",
+        "reasoning_msgs",
+        "reasoning_wire",
+        "reasoning_wire_total",
+        "retry_nudges",
+        "step_nudges",
+        "tool_errors",
+        "wasted_calls",
+    }
+    assert {name for name, field in fields.items() if field.logical_type == "bool"} == {
+        "accuracy",
+        "completeness",
+    }
+    assert {name for name, field in fields.items() if field.logical_type == "float64"} == {
+        "cost_usd",
+        "elapsed_s",
+    }
+    assert fields["accuracy"].source_nullable
+    assert fields["reasoning_wire"].source_nullable
+    assert not fields["rig"].source_required
+    assert not fields["rig"].source_nullable
+    assert fields["rig"].normalized_nullable
+    assert fields["run"].source_required
+    assert not fields["run"].source_nullable
+
+    manifest = publication.schema_manifest()
+    assert manifest["sha256"] == publication.schema_fingerprint()
+    assert manifest["enums"]["reasoning_replay"] == ["none", "keep-last", "full"]
+
+
+def test_sparse_fields_normalize_to_null_and_run_is_untouched(tmp_path: Path) -> None:
+    plan, _ = _single_plan(tmp_path, _row(run=-7, accuracy=None, wasted_calls=None))
+    normalized = list(publication.iter_history(plan))[0]
+
+    for name in (
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "cost_usd",
+        "input_tokens",
+        "output_tokens",
+        "reasoning_level",
+        "reasoning_replay",
+        "reasoning_wire",
+        "reasoning_wire_total",
+        "rig",
+        "stream_retries",
+    ):
+        assert normalized[name] is None
+    assert normalized["effective_reasoning_replay"] == "full"
+    assert normalized["effective_reasoning_level"] == "default"
+    assert normalized["run"] == -7
+
+
+@pytest.mark.parametrize(
+    ("line", "category"),
+    [
+        (b"", "blank_line"),
+        (b"{", "malformed_json"),
+        (b"[]", "non_object"),
+        (b'{"x":1,"x":2}', "duplicate_key"),
+        (b'{"elapsed_s":NaN}', "non_standard_constant"),
+        (b'{"elapsed_s":Infinity}', "non_standard_constant"),
+        (b"\xff", "invalid_utf8"),
+    ],
+)
+def test_strict_parser_rejects_invalid_json(
+    line: bytes, category: str
+) -> None:
+    with pytest.raises(publication.PublicationError, match=category) as exc_info:
+        publication.parse_source_line(line, "fixture.jsonl", 9)
+    assert str(exc_info.value).startswith("fixture.jsonl:9:")
+
+
+def test_overflow_float_is_rejected_as_non_finite() -> None:
+    raw = _encode(_row()).replace(b'"elapsed_s":1.25', b'"elapsed_s":1e999')
+    with pytest.raises(publication.PublicationError, match="non_finite"):
+        publication.parse_source_line(raw, "fixture.jsonl", 1)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "category"),
+    [
+        (lambda row: row.__setitem__("unknown", "secret-host-value"), "unknown_field"),
+        (lambda row: row.pop("backend"), "missing_required_field"),
+        (lambda row: row.__setitem__("budget_tokens", True), "wrong_type"),
+        (lambda row: row.__setitem__("rig", None), "null_not_allowed"),
+        (lambda row: row.__setitem__("reasoning_replay", "mystery"), "unknown_policy"),
+    ],
+)
+def test_schema_errors_fail_closed_and_are_redacted(mutate: Any, category: str) -> None:
+    row = _row()
+    mutate(row)
+    with pytest.raises(publication.PublicationError, match=category) as exc_info:
+        publication.parse_source_line(_encode(row), "fixture.jsonl", 3)
+    message = str(exc_info.value)
+    assert "secret-host-value" not in message
+    assert "model-a" not in message
+
+
+def test_source_generation_and_generation_metadata_are_strict(tmp_path: Path) -> None:
+    spec = _write_source(tmp_path, "wrong-gen.jsonl", [_row(gen=1)])
+    mismatched = publication.SourceSpec(
+        spec.source_file, spec.release, 2, spec.row_count, spec.sha256
+    )
+    with pytest.raises(
+        publication.PublicationError, match="source_generation_mismatch"
+    ):
+        publication.build_publication_plan(tmp_path, source_specs=[mismatched])
+
+    unknown = publication.SourceSpec("unused.jsonl", "synthetic", 99, 0, "0" * 64)
+    with pytest.raises(publication.PublicationError, match="unknown_generation"):
+        publication.build_publication_plan(tmp_path, source_specs=[unknown])
+
+
+@pytest.mark.parametrize(
+    ("terminator", "final_terminator"),
+    [(b"\n", True), (b"\r\n", True), (b"\n", False)],
+)
+def test_physical_line_terminators_do_not_enter_source_row_hash(
+    tmp_path: Path, terminator: bytes, final_terminator: bool
+) -> None:
+    row = _row(model="mödèl")
+    plan, _ = _single_plan(
+        tmp_path,
+        row,
+        terminator=terminator,
+        final_terminator=final_terminator,
+    )
+    normalized = list(publication.iter_history(plan))[0]
+    assert normalized["source_row_sha256"] == (
+        "38ce2cddbf8797d3109338e2f0524e5a041890ad25a305cdfc6f9f26239eb9fc"
+    )
+
+
+def test_canonical_json_and_non_ascii_id_framing(tmp_path: Path) -> None:
+    assert publication.canonical_json({"z": "é", "a": 1}, sort_keys=True) == (
+        '{"a":1,"z":"é"}'
+    )
+    with pytest.raises(ValueError):
+        publication.canonical_json({"bad": float("nan")}, sort_keys=True)
+
+    plan, _ = _single_plan(tmp_path, _row(model="mödèl"))
+    normalized = list(publication.iter_history(plan))[0]
+    base_frame = '["mödèl","backend-a","native","reforged","auto","default"]'
+    arm_frame = (
+        '["mödèl","backend-a","native","reforged","auto","default",'
+        '1,"legacy-inferred-full"]'
+    )
+    assert normalized["base_config_id"] == hashlib.sha256(
+        base_frame.encode("utf-8")
+    ).hexdigest()
+    assert normalized["arm_id"] == hashlib.sha256(
+        arm_frame.encode("utf-8")
+    ).hexdigest()
+
+
+def test_all_statuses_truth_table_order_and_repeated_labels(tmp_path: Path) -> None:
+    gen1_rows = [
+        _row(model="shared", gen=1),
+        _row(model="shared", gen=1, reasoning_replay="full"),
+        _row(model="shared", gen=1, reasoning_replay="none"),
+        _row(model="carried", gen=1),
+    ]
+    gen2_rows = [
+        _row(model="shared", gen=2, reasoning_replay="none"),
+        _row(model="equal", gen=2, reasoning_replay="full"),
+        _row(model="equal", gen=2, reasoning_replay="full"),
+    ]
+    specs = [
+        _write_source(tmp_path, "gen1.jsonl", gen1_rows),
+        _write_source(tmp_path, "gen2.jsonl", gen2_rows),
+    ]
+    plan = publication.build_publication_plan(tmp_path, source_specs=specs)
+    rows = list(publication.iter_classified_history(plan))
+
+    assert [row["selection_status"] for row in rows] == [
+        "superseded_base",
+        "carried",
+        "superseded_same_policy",
+        "carried",
+        "latest",
+        "latest",
+        "latest",
+    ]
+    assert [row["source_file"] for row in rows] == ["gen1.jsonl"] * 4 + [
+        "gen2.jsonl"
+    ] * 3
+    assert [row["source_line"] for row in rows] == [1, 2, 3, 4, 1, 2, 3]
+    assert all(row["run"] == 1 and row["scenario"] == "same-scenario" for row in rows)
+
+    legacy, explicit_full, old_none = rows[:3]
+    assert legacy["superseded_by_scope"] == "base_configuration"
+    assert legacy["superseded_by_generation"] == 2
+    assert explicit_full["selected_for_snapshot"]
+    assert explicit_full["superseded_by_scope"] is None
+    assert old_none["superseded_by_scope"] == "explicit_policy"
+    assert old_none["superseded_by_generation"] == 2
+    assert legacy["base_config_id"] == explicit_full["base_config_id"]
+    assert legacy["arm_id"] != explicit_full["arm_id"]
+    assert all(
+        row["comparable_to_latest"] == row["selected_for_latest"] for row in rows
+    )
+
+    assert list(plan.status_counts.values()) == [3, 2, 1, 1]
+    assert len(list(publication.iter_snapshot(plan))) == 5
+    assert len(list(publication.iter_latest(plan))) == 3
+    assert [row["model"] for row in publication.iter_snapshot(plan)] == [
+        "shared",
+        "carried",
+        "shared",
+        "equal",
+        "equal",
+    ]
+
+
+def test_plan_and_logical_digest_are_deterministic_golden(tmp_path: Path) -> None:
+    plan, _ = _single_plan(tmp_path, _row(model="mödèl"), final_terminator=False)
+    again = publication.build_publication_plan(
+        tmp_path, source_specs=plan._source_specs
+    )
+    assert plan.to_json() == again.to_json()
+    assert plan.views["history"].source_identity_sha256 == (
+        "b5bd1fe2a7c3ad03dcdbe4d4d56fb19b7cb580efe2d8a9faeffd5b7fab447784"
+    )
+    assert plan.views["history"].source_payload_sha256 == (
+        "13acbcacb2ce55e8a8e0e0d9b31eef9dcf2307d3990849a1092de77153166d11"
+    )
+    assert plan.views["history"].normalized_logical_sha256 == (
+        "c682dd15cee85edd884f7cc7c89fef84201bd032f67c4355ed8fa6240b7d875f"
+    )
+
+
+def test_changed_or_truncated_source_fails_when_iterators_are_exhausted(
+    tmp_path: Path,
+) -> None:
+    original = _row()
+    plan, spec = _single_plan(tmp_path, original)
+    (tmp_path / spec.source_file).write_bytes(_encode(_row(run=2)) + b"\n")
+    with pytest.raises(publication.PublicationError, match="hash_mismatch"):
+        list(publication.iter_classified_history(plan))
+
+    plan, spec = _single_plan(tmp_path, original)
+    (tmp_path / spec.source_file).write_bytes(b"")
+    with pytest.raises(publication.PublicationError, match="count_mismatch"):
+        list(publication.iter_snapshot(plan))
+
+
+def test_unknown_view_fails() -> None:
+    with pytest.raises(ValueError, match="unknown publication view"):
+        publication.row_in_view({}, "other")


### PR DESCRIPTION
## Summary

- add a strict, streaming publication contract for the five released Forge eval datasets
- expose deterministic `history`, `snapshot`, and `latest` dataset views using one normalized 51-field schema
- add an offline Parquet builder with atomic publication, provenance, manifests, and full read-back verification
- share generation-selection and provenance logic with the existing report pipeline
- document local bundle construction, verification, scoring semantics, and Dataset Card metadata

The builder operates entirely from a Forge source checkout. It performs no Hugging Face network access and requires no credentials.

## Dataset bundle

The generated layout contains:

- `README.md`
- `data/latest/*.parquet`
- `data/snapshot/*.parquet`
- `data/history/*.parquet`
- `provenance/sources.json`
- `provenance/schema.json`
- `manifest.json`

Bundles use Zstandard compression, 8,192-row record batches, deterministic 100,000-row shards, pinned source identities, and an exact finished-tree allowlist.

## Validation

- focused generation/publication/builder suite: 67 passed
- full unit suite: 1,490 passed
- existing dashboard and Markdown reports reproduced without substantive differences
- complete pinned bundle built successfully:
  - history: 518,700 rows
  - snapshot: 378,300 rows
  - latest: 260,000 rows
  - 17 files, 52.29 MB
- internal build verification passed
- independent standalone bundle verification passed
- manifest records commit `4f1d8624fa0053afdb198da80a5fb70d1e1616f1`
- `git diff --check` and Git LFS status clean

Generated bundles remain ignored local artifacts and are not included in this PR.