### PR TITLE
fix(proxy): restore vLLM identity discovery on /v1/models

### DIFF
--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -71,6 +71,9 @@ class LazyDiscovery:
     - ``apply_budget``: whether the discovered context length should be written
       to the context manager. False when ``--budget-tokens`` was given explicitly
       (the discovery still runs, but only to adopt vLLM's served identity).
+    - ``adopt_model_identity``: whether the deferred work includes adopting
+      vLLM's served-model identity. Unlike ``apply_budget``, this is False for
+      pinned vLLM and llama.cpp budget-only discovery.
     - ``done``: latched True once discovery succeeds. Only success latches; a
       failed probe leaves it False so a later credentialed request retries.
     """
@@ -78,6 +81,7 @@ class LazyDiscovery:
     deferred: bool
     apply_budget: bool
     done: bool = False
+    adopt_model_identity: bool = False
 
 
 async def run_lazy_discovery(

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -404,7 +404,11 @@ class ProxyServer:
                 else self._budget_tokens
             )
             lazy_discovery: LazyDiscovery | None = LazyDiscovery(
-                deferred=True, apply_budget=apply_budget,
+                deferred=True,
+                apply_budget=apply_budget,
+                adopt_model_identity=(
+                    self._backend == "vllm" and self._model is None
+                ),
             )
         else:
             lazy_discovery = None

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -189,7 +189,7 @@ class HTTPServer:
             if method == "GET" and path == "/health":
                 await self._handle_health(writer)
             elif method == "GET" and path == "/v1/models":
-                await self._handle_models(writer)
+                await self._handle_models(writer, headers)
             elif method == "POST" and path in ("/v1/chat/completions", "/chat/completions"):
                 # llama.cpp serves the OpenAI chat endpoint on both spellings;
                 # llama.cpp-native clients (pi-llama-cpp) POST the unprefixed
@@ -245,8 +245,37 @@ class HTTPServer:
         body = json.dumps({"status": "ok"})
         await self._send_json(writer, 200, body)
 
-    async def _handle_models(self, writer: asyncio.StreamWriter) -> None:
+    async def _handle_models(
+        self,
+        writer: asyncio.StreamWriter,
+        headers: dict[str, str],
+    ) -> None:
         """GET /v1/models — report the backend model the proxy is fronting."""
+        lazy = self._lazy_discovery
+        if (
+            lazy is not None
+            and lazy.deferred
+            and lazy.adopt_model_identity
+            and not lazy.done
+        ):
+            try:
+                extra_headers = resolve_inbound_credential(
+                    headers,
+                    source_protocol="openai",
+                    target_protocol=self._backend_protocol,
+                    backend_api_key_present=self._backend_api_key_present,
+                )
+                await run_lazy_discovery(
+                    self._client,
+                    self._context_manager,
+                    lazy,
+                    extra_headers,
+                )
+            except Exception as exc:
+                await self._send_exception(
+                    writer, exc, protocol="openai", as_stream=False,
+                )
+                return
         body = json.dumps({
             "object": "list",
             "data": [{"id": self._client.model, "object": "model"}],

--- a/tests/unit/test_proxy_proxy.py
+++ b/tests/unit/test_proxy_proxy.py
@@ -372,6 +372,7 @@ class TestExternalDeferredDiscovery:
         assert lazy is not None
         assert lazy.deferred is True
         assert lazy.apply_budget is True  # no explicit budget → discovery sets it
+        assert lazy.adopt_model_identity is False
         assert lazy.done is False
 
     @pytest.mark.asyncio
@@ -388,6 +389,7 @@ class TestExternalDeferredDiscovery:
         assert client.model == "default"  # identity deferred → still placeholder
         assert lazy.deferred is True
         assert lazy.apply_budget is True
+        assert lazy.adopt_model_identity is True
 
     @pytest.mark.asyncio
     async def test_vllm_passthrough_with_budget_still_defers_for_identity(self) -> None:
@@ -405,6 +407,7 @@ class TestExternalDeferredDiscovery:
         assert ctx.budget_tokens == 4096
         assert lazy.deferred is True
         assert lazy.apply_budget is False
+        assert lazy.adopt_model_identity is True
 
     @pytest.mark.asyncio
     async def test_llamacpp_passthrough_with_budget_not_deferred(self) -> None:
@@ -451,6 +454,7 @@ class TestExternalDeferredDiscovery:
         assert lazy is not None
         assert lazy.deferred is True
         assert lazy.apply_budget is True
+        assert lazy.adopt_model_identity is False
         assert client.model == "nv-mistral-large"
         assert client._adopt_served_identity is False
 

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -385,6 +385,29 @@ async def _raw_request(port, header_lines, body):
         await writer.wait_closed()
 
 
+async def _raw_models_request(port, header_lines=()):
+    """GET /v1/models with arbitrary headers; return (status, body_str)."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        extra = "".join(f"{line}\r\n" for line in header_lines)
+        request = (
+            f"GET /v1/models HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{port}\r\n"
+            f"{extra}"
+            f"\r\n"
+        ).encode()
+        writer.write(request)
+        await writer.drain()
+        data = await asyncio.wait_for(reader.read(65536), timeout=10.0)
+        text = data.decode("utf-8", errors="replace")
+        status = int(text.split("\r\n", 1)[0].split(" ", 2)[1])
+        start = text.find("\r\n\r\n")
+        return status, (text[start + 4:] if start >= 0 else "")
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
 class TestInboundCredentialThreading:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("serialize", [False, True])
@@ -464,6 +487,205 @@ async def _discovery_server(*, side_effect=None, budget=50000, apply_budget=True
     await srv.start()
     port = srv._server.sockets[0].getsockname()[1]
     return srv, port, client, ctx
+
+
+async def _model_discovery_server(
+    *,
+    side_effect=None,
+    budget=50000,
+    apply_budget=True,
+    adopt_model_identity=True,
+    model="default",
+):
+    """A server whose model list may trigger deferred identity discovery."""
+    client = _mock_client(TextResponse(content="ok"))
+    client.model = model
+
+    if side_effect is not None:
+        client.discover_backend_metadata = AsyncMock(side_effect=side_effect)
+    else:
+        async def discover(extra_headers=None):
+            client.model = "served-model"
+            return budget
+
+        client.discover_backend_metadata = AsyncMock(side_effect=discover)
+
+    ctx = ContextManager(strategy=NoCompact(), budget_tokens=8192)
+    lazy = LazyDiscovery(
+        deferred=True,
+        apply_budget=apply_budget,
+        adopt_model_identity=adopt_model_identity,
+    )
+    srv = HTTPServer(
+        client=client,
+        context_manager=ctx,
+        host="127.0.0.1",
+        port=0,
+        serialize_requests=False,
+        backend_protocol="openai",
+        lazy_discovery=lazy,
+    )
+    await srv.start()
+    port = srv._server.sockets[0].getsockname()[1]
+    return srv, port, client, ctx, lazy
+
+
+class TestModelsLazyIdentityDiscovery:
+    @pytest.mark.asyncio
+    async def test_discovers_before_local_response_and_latches(self):
+        srv, port, client, ctx, lazy = await _model_discovery_server()
+        try:
+            status, body = await _raw_models_request(
+                port, ["Authorization: Bearer INBOUND"],
+            )
+            assert status == 200
+            assert json.loads(body) == {
+                "object": "list",
+                "data": [{"id": "served-model", "object": "model"}],
+            }
+            client.discover_backend_metadata.assert_awaited_once_with(
+                extra_headers={"authorization": "Bearer INBOUND"},
+            )
+            assert ctx.budget_tokens == 50000
+            assert lazy.done is True
+
+            second_status, second_body = await _raw_models_request(port)
+            assert second_status == 200
+            assert json.loads(second_body) == {
+                "object": "list",
+                "data": [{"id": "served-model", "object": "model"}],
+            }
+
+            completion_status, _ = await _raw_request(
+                port, [], {"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert completion_status == 200
+            assert client.discover_backend_metadata.await_count == 1
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_identity_only_discovery_preserves_explicit_budget(self):
+        srv, port, client, ctx, lazy = await _model_discovery_server(
+            budget=99999, apply_budget=False,
+        )
+        try:
+            status, body = await _raw_models_request(port)
+            assert status == 200
+            assert json.loads(body)["data"][0]["id"] == "served-model"
+            assert ctx.budget_tokens == 8192
+            assert lazy.done is True
+            client.discover_backend_metadata.assert_awaited_once()
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_conflicting_credentials_map_400_without_probe(self):
+        srv, port, client, _, lazy = await _model_discovery_server()
+        try:
+            status, body = await _raw_models_request(
+                port,
+                ["Authorization: Bearer SECRET-ONE", "x-api-key: SECRET-TWO"],
+            )
+            assert status == 400
+            assert "SECRET-ONE" not in body and "SECRET-TWO" not in body
+            client.discover_backend_metadata.assert_not_awaited()
+            assert lazy.done is False
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("backend_status", "expected_status"),
+        [(401, 401), (403, 401), (502, 502)],
+    )
+    async def test_discovery_failure_status_mapping(
+        self, backend_status, expected_status,
+    ):
+        srv, port, client, _, lazy = await _model_discovery_server(
+            side_effect=BackendError(backend_status, "discovery failed"),
+        )
+        try:
+            status, body = await _raw_models_request(port)
+            assert status == expected_status
+            assert "\"object\": \"list\"" not in body
+            client.discover_backend_metadata.assert_awaited_once()
+            assert lazy.done is False
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_failed_model_list_retries_on_next_full_request(self):
+        srv, port, client, ctx, lazy = await _model_discovery_server()
+        attempts = 0
+
+        async def fail_then_succeed(extra_headers=None):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise BackendError(502, "temporarily unavailable")
+            client.model = "served-after-retry"
+            return 64000
+
+        client.discover_backend_metadata = AsyncMock(side_effect=fail_then_succeed)
+        try:
+            first_status, first_body = await _raw_models_request(port)
+            assert first_status == 502
+            assert "\"object\": \"list\"" not in first_body
+            assert lazy.done is False
+            assert client.model == "default"
+
+            second_status, second_body = await _raw_models_request(port)
+            assert second_status == 200
+            assert json.loads(second_body) == {
+                "object": "list",
+                "data": [{"id": "served-after-retry", "object": "model"}],
+            }
+            assert client.discover_backend_metadata.await_count == 2
+            assert ctx.budget_tokens == 64000
+            assert lazy.done is True
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_pinned_budget_only_list_skips_credentials_and_probe(self):
+        srv, port, client, ctx, lazy = await _model_discovery_server(
+            adopt_model_identity=False,
+            model="pinned-model",
+        )
+        try:
+            status, body = await _raw_models_request(
+                port,
+                ["Authorization: Bearer ONE", "x-api-key: TWO"],
+            )
+            assert status == 200
+            assert json.loads(body) == {
+                "object": "list",
+                "data": [{"id": "pinned-model", "object": "model"}],
+            }
+            client.discover_backend_metadata.assert_not_awaited()
+            assert ctx.budget_tokens == 8192
+            assert lazy.done is False
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_non_vllm_lazy_budget_list_stays_local_and_probe_free(self):
+        srv, port, client, _, lazy = await _model_discovery_server(
+            adopt_model_identity=False,
+            model="llama.cpp-model",
+        )
+        try:
+            status, body = await _raw_models_request(port)
+            assert status == 200
+            assert json.loads(body) == {
+                "object": "list",
+                "data": [{"id": "llama.cpp-model", "object": "model"}],
+            }
+            client.discover_backend_metadata.assert_not_awaited()
+            assert lazy.done is False
+        finally:
+            await srv.stop()
 
 
 class TestDeferredDiscoveryStatusMapping:


### PR DESCRIPTION
## What

Restore the real served-model identity from `GET /v1/models` for an unpinned external vLLM proxy when lazy discovery is still pending.

When that narrow condition applies, the model-list request now:

- resolves and forwards its inbound credential using Forge's existing one-credential rules;
- runs the existing vLLM metadata-discovery path;
- adopts the backend's first served-model identity;
- applies the discovered context budget when needed; and
- latches successful discovery before returning Forge's existing one-entry model list.

Pinned models and non-vLLM backends remain unchanged.

## Why

PR #101 changed Forge's synthetic `/v1/models` response to report the proxy client's real model identity.

Forge v0.8.0 subsequently moved unauthenticated external-vLLM discovery from startup to the first completion request, allowing gated backends to use the caller's credential. `/v1/models` did not join that lazy-discovery path, so clients probing it before their first completion could receive the construction placeholder `default`.

This restores the previously shipped single-effective-model behavior for the regression reported again in #100.

Closes #100.

## Scope

This is a narrow regression patch, not the larger model-list redesign.

It does not:

- forward the backend's complete model catalog;
- introduce multi-model routing;
- implement the deferred PR #130 plus #132 work; or
- change pinned, managed, eager-discovery, llama.cpp, Ollama, or Anthropic behavior.

Discovery failures retain the existing mappings: credential conflicts return 400, backend authentication rejection returns 401, and other discovery failures return 502. Failed discovery remains retryable.

## Validation

- Focused proxy suite: 203 passed
- Full unit suite before squash: 1,499 passed
- Full unit suite after squash: 1,499 passed
- Independent native review: no findings; 74 focused tests passed
- `scripts/smoke_test_proxy.py`: all mocked scenarios passed
- Direct gated-vLLM mock using the real `ProxyServer` and `VLLMClient`:
  - unauthenticated discovery failed without latching;
  - authenticated retry returned the backend's served identity;
  - the discovered budget was applied; and
  - subsequent model-list requests used the latched local identity without another backend probe.