### PR TITLE
fix(proxy): preserve request-local Anthropic model routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to forge are documented here.
 
+## [0.8.3] — 2026-08-03
+
+A proxy-correctness and evaluation-publication release. Forge restores model identity handling across vLLM and Anthropic proxy paths while making evaluation collection and publication deterministic and provenance-safe.
+
+### Added
+- **Deterministic Hugging Face dataset publication tooling.** A new offline `tests.eval.dataset_builder` command produces verified Parquet bundles with `latest`, `snapshot`, and `history` views, a fixed schema, source provenance, content hashes, and an upload-ready Dataset Card. Builds are verified and published atomically, with PyArrow available through the dedicated `dataset-builder` extra. #136
+
+### Changed
+- **Eval-generation provenance is explicit and resume-safe.** `batch_eval --generation` stamps every collected row with its comparability epoch. Existing JSONL outputs are validated before collection begins, rejecting malformed data, mixed or mismatched generations, and ambiguous resume identities. Shared generation and replay-policy semantics now govern collection, reporting, and publication. #135
+
+### Fixed
+- **Unpinned external vLLM proxies discover their served model before listing it.** The first `GET /v1/models` can use the caller's credential to complete lazy discovery, adopt and latch the backend's served identity, and return Forge's existing one-entry model list instead of the temporary `default` placeholder. Explicit pins and non-vLLM backends remain unchanged. #100, #137
+- **Anthropic proxy requests preserve their request-local model identity.** Unpinned Anthropic backends now use each request's opaque model name instead of the fabricated `claude` default; an explicit `--model` remains authoritative, and a request with neither source fails with HTTP 400 before dispatch. Concurrent request models remain isolated, clean Anthropic passthrough preserves fields such as `cache_control` without mutating the caller-owned request body, and `/v1/models` returns an empty list when no proxy-wide model is pinned.
+
 ## [0.8.2] — 2026-07-28
 
 A maintenance and eval-publication release. Forge hardens malformed llama.cpp 500 recovery, adds compatibility with clients that use llama-server’s unversioned chat endpoint, and publishes an expanded evaluation dashboard covering 378,300 runs across 291 configurations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forge-guardrails"
-version = "0.8.2"
+version = "0.8.3"
 description = "A reliability layer for self-hosted LLM tool-calling. Guardrails, context management, and backend adapters for multi-step agentic workflows."
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/forge/clients/anthropic.py
+++ b/src/forge/clients/anthropic.py
@@ -25,7 +25,7 @@ from forge.clients.base import (
     static_auth_present,
 )
 from forge.core.workflow import LLMResponse, TextResponse, ToolCall, ToolSpec
-from forge.errors import BackendError, MissingCredentialError
+from forge.errors import BackendError, MissingCredentialError, MissingModelError
 
 log = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ class AnthropicClient:
 
     def __init__(
         self,
-        model: str,
+        model: str | None,
         api_key: str | None = None,
         max_tokens: int = 4096,
         timeout: float = 300.0,
@@ -407,17 +407,23 @@ class AnthropicClient:
         if inbound_anthropic_body is not None:
             # Verbatim emit. Drop the proxy-internal ``stream`` field; the
             # SDK call shape (messages.create vs messages.stream) selects
-            # streaming. ``model`` defaults to the inbound value but the
-            # client's configured model wins if the inbound omitted it.
+            # streaming. A fixed client model is authoritative; a dynamic
+            # proxy client keeps the already-resolved request-local model.
             kwargs = dict(inbound_anthropic_body)
             kwargs.pop("stream", None)
-            kwargs.setdefault("model", self.model)
+            if self.model is not None:
+                kwargs["model"] = self.model
+            if kwargs.get("model") in (None, ""):
+                raise MissingModelError()
             return kwargs
 
         system, converted = self._convert_messages(messages)
         kwargs = dict(passthrough or {})
+        model = self.model if self.model is not None else kwargs.get("model")
+        if model in (None, ""):
+            raise MissingModelError()
         kwargs.update({
-            "model": self.model,
+            "model": model,
             "messages": converted,
         })
         kwargs.setdefault("max_tokens", self.max_tokens)

--- a/src/forge/clients/base.py
+++ b/src/forge/clients/base.py
@@ -263,9 +263,10 @@ class LLMClient(Protocol):
     api_format: str
     """Wire format for Message.to_api_dict(): 'ollama' or 'openai'."""
 
-    model: str
+    model: str | None
     """The backend model identity, sent verbatim as the wire "model" field
-    (the served-model-name, gguf stem, or model tag depending on backend).
+    (the served-model-name, gguf stem, or model tag depending on backend), or
+    None for a request-routed client whose identity is supplied per call.
     Distinct from any sampling-registry lookup key a client also derives."""
 
     async def send(

--- a/src/forge/errors.py
+++ b/src/forge/errors.py
@@ -7,6 +7,16 @@ class ForgeError(Exception):
     pass
 
 
+class MissingModelError(ForgeError):
+    """No model identity was available for a request-routed backend call."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "No model was supplied: provide a request model or configure "
+            "the proxy with --model."
+        )
+
+
 class UnsupportedModelError(ForgeError):
     """Caller opted into recommended sampling for a model not in the map.
 

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -16,7 +16,12 @@ from forge.core.reasoning import (
     validate_reasoning_replay,
 )
 from forge.core.workflow import ToolCall, ToolSpec, TextResponse
-from forge.errors import BackendDiscoveryError, BackendError, ToolCallError
+from forge.errors import (
+    BackendDiscoveryError,
+    BackendError,
+    MissingModelError,
+    ToolCallError,
+)
 from forge.guardrails import ErrorTracker, ResponseValidator
 from forge.proxy.auth import resolve_inbound_credential
 from forge.proxy.convert import (
@@ -160,6 +165,26 @@ def _extract_passthrough(body: dict[str, Any]) -> dict[str, Any] | None:
     return extras or None
 
 
+def resolve_effective_model(
+    body: dict[str, Any],
+    client: LLMClient,
+    backend_protocol: str,
+) -> Any:
+    """Resolve this request's downstream and response model identity.
+
+    Anthropic-shaped downstreams may be request-routed: a configured client
+    model is a pin, otherwise the inbound model remains request-local. Other
+    backends retain the proxy's existing response-label behavior.
+    """
+    if backend_protocol != "anthropic":
+        return body.get("model", "forge")
+
+    model = client.model if client.model not in (None, "") else body.get("model")
+    if model in (None, ""):
+        raise MissingModelError()
+    return model
+
+
 def _extract_tool_specs(request_tools: list[dict[str, Any]] | None) -> list[ToolSpec]:
     """Extract ToolSpec objects from the OpenAI tools array in the request."""
     if not request_tools:
@@ -259,7 +284,7 @@ async def handle_chat_completions(
     """
     reasoning_replay = validate_reasoning_replay(reasoning_replay)
     is_stream = body.get("stream", False)
-    model_name = body.get("model", "forge")
+    model_name = resolve_effective_model(body, client, backend_protocol)
 
     # Resolve the single credential forge forwards to the backend: relocate an
     # inbound auth header into the backend's canonical slot, or None when the
@@ -303,7 +328,7 @@ async def handle_chat_completions(
         # the runner hasn't mutated messages (clean first-attempt call);
         # OpenAI-shape clients (LlamafileClient) accept and ignore. See
         # ADR-015.
-        inbound_anthropic_body = body
+        inbound_anthropic_body = deepcopy(body)
     else:
         request_messages = body.get("messages", [])
         request_tools = body.get("tools")
@@ -333,6 +358,13 @@ async def handle_chat_completions(
     if protocol == "anthropic":
         raw_tools_for_backend = None
         raw_messages_for_backend = None
+
+    if backend_protocol == "anthropic":
+        if passthrough is None:
+            passthrough = {}
+        passthrough["model"] = model_name
+        if inbound_anthropic_body is not None:
+            inbound_anthropic_body["model"] = model_name
 
     # Optionally inject the respond tool (default off). When on, the model
     # calls respond(message="...") instead of producing bare text, keeping it

--- a/src/forge/proxy/handler.py
+++ b/src/forge/proxy/handler.py
@@ -328,7 +328,7 @@ async def handle_chat_completions(
         # the runner hasn't mutated messages (clean first-attempt call);
         # OpenAI-shape clients (LlamafileClient) accept and ignore. See
         # ADR-015.
-        inbound_anthropic_body = deepcopy(body)
+        inbound_anthropic_body = dict(body)
     else:
         request_messages = body.get("messages", [])
         request_tools = body.get("tools")

--- a/src/forge/proxy/proxy.py
+++ b/src/forge/proxy/proxy.py
@@ -331,7 +331,7 @@ class ProxyServer:
                     "Install it with: pip install 'forge-guardrails[anthropic]'"
                 ) from exc
             client: LLMClient = AnthropicClient(
-                model=self._model or "claude",
+                model=self._model,
                 base_url=self._backend_url.rstrip("/"),
                 timeout=self._backend_timeout,
                 # Explicit key (or "" for pure passthrough) so an ambient

--- a/src/forge/proxy/server.py
+++ b/src/forge/proxy/server.py
@@ -20,12 +20,14 @@ from forge.errors import (
     BackendDiscoveryError,
     BackendError,
     MissingCredentialError,
+    MissingModelError,
     MultipleCredentialsError,
 )
 from forge.proxy.auth import DUPLICATE_AUTH_MARKER, resolve_inbound_credential
 from forge.proxy.handler import (
     LazyDiscovery,
     handle_chat_completions,
+    resolve_effective_model,
     run_lazy_discovery,
 )
 
@@ -276,9 +278,14 @@ class HTTPServer:
                     writer, exc, protocol="openai", as_stream=False,
                 )
                 return
+        models = (
+            []
+            if self._client.model is None
+            else [{"id": self._client.model, "object": "model"}]
+        )
         body = json.dumps({
             "object": "list",
-            "data": [{"id": self._client.model, "object": "model"}],
+            "data": models,
         })
         await self._send_json(writer, 200, body)
 
@@ -311,15 +318,15 @@ class HTTPServer:
 
         # Streaming responses flush a 200 + SSE header before the handler runs
         # (so a queued client knows the connection is alive). Run the checks that
-        # must be able to fail with a real HTTP status — credential resolution
-        # and the first-request discovery probe — BEFORE that flush, so a bad/
-        # missing/duplicate credential returns 400/401 rather than 200 + an SSE
-        # error event. On success they latch, so the handler skips re-running
-        # discovery; its credential resolution is pure and repeats harmlessly.
+        # must be able to fail with a real HTTP status — model and credential
+        # resolution plus the first-request discovery probe — BEFORE that flush,
+        # so a bad request returns 400/401 rather than 200 + an SSE error event.
+        # On success discovery latches; both resolvers are pure and repeat
+        # harmlessly in the handler.
         # Non-streaming needs no pre-check — it never flushes early, so its
         # errors already carry a real status.
         if is_stream:
-            predispatch_error = await self._predispatch(protocol, headers)
+            predispatch_error = await self._predispatch(body, protocol, headers)
             if predispatch_error is not None:
                 await self._send_exception(
                     writer, predispatch_error, protocol, as_stream=False,
@@ -364,17 +371,18 @@ class HTTPServer:
             await self._send_json(writer, 200, json.dumps(result))
 
     async def _predispatch(
-        self, protocol: str, headers: dict[str, str],
+        self, body: dict[str, Any], protocol: str, headers: dict[str, str],
     ) -> Exception | None:
         """Pre-flush validation for a streaming request.
 
-        Resolves the inbound credential and runs first-request backend discovery
-        — the checks that must be able to fail with a real HTTP status — and
-        returns the Exception to surface, or None to proceed. Idempotent: the
-        handler re-resolves the (pure) credential and sees discovery latched, so
-        running this first changes nothing on the success path.
+        Resolves the effective model and inbound credential, then runs
+        first-request backend discovery — the checks that must be able to fail
+        with a real HTTP status — and returns the Exception to surface, or None
+        to proceed. Idempotent: the handler repeats the pure resolution and sees
+        discovery latched, so running this first changes nothing on success.
         """
         try:
+            resolve_effective_model(body, self._client, self._backend_protocol)
             extra_headers = resolve_inbound_credential(
                 headers,
                 source_protocol=protocol,
@@ -405,10 +413,10 @@ class HTTPServer:
         """
         error_msg = str(exc)
         logger.info("<< ERROR: %s", error_msg[:120])
-        # Credential problems are client errors (two credentials / one colliding
-        # with --backend-api-key → 400, or none to an auth-required backend →
-        # 401), not backend failures. These messages carry only slot names.
-        if isinstance(exc, MultipleCredentialsError):
+        # Missing models and credential conflicts are client errors (400); no
+        # credential for an auth-required backend is 401, not a backend fault.
+        # These messages carry no secret values.
+        if isinstance(exc, (MissingModelError, MultipleCredentialsError)):
             status = 400
         elif isinstance(exc, MissingCredentialError):
             status = 401

--- a/tests/unit/test_anthropic_client.py
+++ b/tests/unit/test_anthropic_client.py
@@ -4,6 +4,7 @@ All tests exercise the static conversion methods directly.
 No API calls or mocks needed.
 """
 
+import asyncio
 import json
 from typing import Literal
 from unittest.mock import AsyncMock, MagicMock
@@ -15,6 +16,7 @@ from forge.clients.anthropic import AnthropicClient
 from forge.clients.base import TokenUsage
 from forge.core.inference import _get_usage
 from forge.core.workflow import TextResponse, ToolCall, ToolSpec
+from forge.errors import MissingModelError
 
 
 class CityParams(BaseModel):
@@ -520,6 +522,80 @@ class TestPromptCaching:
         assert tu.prompt_tokens == 5
         assert tu.cache_creation_input_tokens == 100
         assert tu.cache_read_input_tokens == 200
+
+
+class TestRequestRoutedModel:
+    def test_dynamic_client_uses_verbatim_request_model(self) -> None:
+        client = AnthropicClient(model=None, api_key="dummy")
+        kwargs = client._build_kwargs(
+            [], None, inbound_anthropic_body={"model": "route-a", "messages": []},
+        )
+        assert kwargs["model"] == "route-a"
+
+    def test_dynamic_client_uses_rebuild_passthrough_model(self) -> None:
+        client = AnthropicClient(model=None, api_key="dummy")
+        kwargs = client._build_kwargs(
+            [{"role": "user", "content": "hi"}], None,
+            passthrough={"model": "route-b"},
+        )
+        assert kwargs["model"] == "route-b"
+
+    @pytest.mark.parametrize("verbatim", [False, True])
+    def test_dynamic_client_fails_without_request_model(self, verbatim) -> None:
+        client = AnthropicClient(model=None, api_key="dummy")
+        with pytest.raises(MissingModelError):
+            client._build_kwargs(
+                [{"role": "user", "content": "hi"}], None,
+                inbound_anthropic_body={"messages": []} if verbatim else None,
+            )
+
+    def test_direct_fixed_client_overrides_passthrough_model(self) -> None:
+        client = AnthropicClient(model="fixed-model", api_key="dummy")
+        kwargs = client._build_kwargs(
+            [{"role": "user", "content": "hi"}], None,
+            passthrough={"model": "request-model"},
+        )
+        assert kwargs["model"] == "fixed-model"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_clean_and_rebuilt_models_stay_isolated(self) -> None:
+        client = AnthropicClient(model=None, api_key="dummy")
+        both_arrived = asyncio.Event()
+        release = asyncio.Event()
+        recorded = []
+
+        async def gated_create(**kwargs):
+            recorded.append(kwargs)
+            if len(recorded) == 2:
+                both_arrived.set()
+            await release.wait()
+            response = MagicMock()
+            response.content = [MagicMock(type="text", text="ok")]
+            response.usage.input_tokens = 1
+            response.usage.output_tokens = 1
+            response.usage.cache_creation_input_tokens = 0
+            response.usage.cache_read_input_tokens = 0
+            return response
+
+        client._client.messages.create = AsyncMock(side_effect=gated_create)
+        clean = asyncio.create_task(client.send(
+            [], inbound_anthropic_body={
+                "model": "route-opus",
+                "messages": [{"role": "user", "content": "one"}],
+            },
+        ))
+        rebuilt = asyncio.create_task(client.send(
+            [{"role": "user", "content": "two"}],
+            passthrough={"model": "route-sonnet"},
+        ))
+        await both_arrived.wait()
+        release.set()
+        await asyncio.gather(clean, rebuilt)
+
+        assert {kwargs["model"] for kwargs in recorded} == {
+            "route-opus", "route-sonnet",
+        }
+        assert client.model is None
 
 
 class TestThinking:

--- a/tests/unit/test_proxy_handler.py
+++ b/tests/unit/test_proxy_handler.py
@@ -10,7 +10,7 @@ from forge.context.manager import ContextManager
 from forge.context.strategies import NoCompact
 from forge.core.workflow import TextResponse, ToolCall
 from forge.clients.base import TokenUsage
-from forge.errors import BackendDiscoveryError, BackendError
+from forge.errors import BackendDiscoveryError, BackendError, MissingModelError
 from forge.proxy.handler import (
     LazyDiscovery,
     handle_chat_completions,
@@ -645,6 +645,92 @@ class TestAnthropicProtocol:
         api_messages = client.send.call_args.args[0]
         assert api_messages[0]["role"] == "system"
         assert api_messages[0]["content"] == "You are helpful."
+
+
+class TestAnthropicBackendModelRouting:
+    @pytest.mark.asyncio
+    async def test_unpinned_openai_request_uses_opaque_inbound_model(self):
+        client = _mock_client(TextResponse(content="ok"))
+        client.model = None
+        result = await handle_chat_completions(
+            _body(model="nemtoron-120b"), client, _context_manager(),
+            backend_protocol="anthropic",
+        )
+        assert client.send.call_args.kwargs["passthrough"]["model"] == "nemtoron-120b"
+        assert result["model"] == "nemtoron-120b"
+        assert client.model is None
+
+    @pytest.mark.asyncio
+    async def test_literal_claude_is_preserved_when_supplied(self):
+        client = _mock_client(TextResponse(content="ok"))
+        client.model = None
+        result = await handle_chat_completions(
+            _body(model="claude"), client, _context_manager(),
+            backend_protocol="anthropic",
+        )
+        assert client.send.call_args.kwargs["passthrough"]["model"] == "claude"
+        assert result["model"] == "claude"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("protocol", ["openai", "anthropic"])
+    async def test_configured_pin_overrides_both_inbound_wire_shapes(self, protocol):
+        client = _mock_client(TextResponse(content="ok"))
+        client.model = "gateway-pin"
+        body = (
+            _body(model="caller-model")
+            if protocol == "openai"
+            else {
+                "model": "caller-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 32,
+            }
+        )
+        result = await handle_chat_completions(
+            body, client, _context_manager(), protocol=protocol,
+            backend_protocol="anthropic",
+        )
+        sent = client.send.call_args.kwargs
+        assert sent["passthrough"]["model"] == "gateway-pin"
+        if protocol == "anthropic":
+            assert sent["inbound_anthropic_body"]["model"] == "gateway-pin"
+        assert result["model"] == "gateway-pin"
+        assert body["model"] == "caller-model"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("protocol", ["openai", "anthropic"])
+    @pytest.mark.parametrize("stream", [False, True])
+    async def test_response_identity_uses_effective_model(self, protocol, stream):
+        client = _mock_client(TextResponse(content="ok"))
+        client.model = "pinned-model"
+        body = {
+            "model": "caller-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": stream,
+        }
+        result = await handle_chat_completions(
+            body, client, _context_manager(), protocol=protocol,
+            backend_protocol="anthropic",
+        )
+        if not stream:
+            assert result["model"] == "pinned-model"
+        elif protocol == "openai":
+            assert all(event["model"] == "pinned-model" for event in result)
+        else:
+            assert result[0]["message"]["model"] == "pinned-model"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("protocol", ["openai", "anthropic"])
+    @pytest.mark.parametrize("model", [None, ""])
+    async def test_missing_model_fails_closed(self, model, protocol):
+        client = _mock_client(TextResponse(content="ok"))
+        client.model = None
+        body = {"messages": [{"role": "user", "content": "hi"}], "model": model}
+        with pytest.raises(MissingModelError):
+            await handle_chat_completions(
+                body, client, _context_manager(), protocol=protocol,
+                backend_protocol="anthropic",
+            )
+        client.send.assert_not_awaited()
 
 
 # ── Native transparent passthrough ──────────────────────────

--- a/tests/unit/test_proxy_path1.py
+++ b/tests/unit/test_proxy_path1.py
@@ -18,6 +18,7 @@ import pytest
 
 from forge.clients.anthropic import AnthropicClient
 from forge.core.workflow import TextResponse
+from forge.proxy.handler import handle_chat_completions
 from forge.proxy.proxy import ProxyServer
 
 
@@ -65,13 +66,29 @@ class TestProxyServerValidation:
         assert ctx.budget_tokens == 200000
         assert lazy is None  # Anthropic path is never deferred
         mock_client_cls.assert_called_once_with(
-            model="claude",
+            model=None,
             base_url="http://localhost:8080",
             timeout=1800.0,
             # explicit "" → no static credential and ambient ANTHROPIC_* env is
             # suppressed at construction (one credential per request).
             api_key="",
         )
+
+    @pytest.mark.asyncio
+    async def test_anthropic_external_literal_claude_pin_is_preserved(self):
+        proxy = ProxyServer(
+            backend_url="http://localhost:8080",
+            backend_protocol="anthropic",
+            model="claude",
+        )
+        with patch("forge.clients.anthropic.AnthropicClient") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.get_context_length = AsyncMock(return_value=200000)
+            mock_client_cls.return_value = mock_client
+
+            await proxy._setup_external()
+
+        assert mock_client_cls.call_args.kwargs["model"] == "claude"
 
 
 # ── AnthropicClient verbatim path ────────────────────────────
@@ -131,8 +148,8 @@ class TestAnthropicClientVerbatim:
         )
         assert kwargs["model"] == "claude-3-5-sonnet"
 
-    def test_inbound_model_wins_over_client_model(self):
-        """If inbound carries a model, it wins."""
+    def test_fixed_client_model_wins_over_inbound_model(self):
+        """A direct fixed-model client remains authoritative."""
         client = AnthropicClient(model="claude-default")
         inbound = {"model": "claude-opus-4-7", "messages": []}
         kwargs = client._build_kwargs(
@@ -140,7 +157,7 @@ class TestAnthropicClientVerbatim:
             tools=None,
             inbound_anthropic_body=inbound,
         )
-        assert kwargs["model"] == "claude-opus-4-7"
+        assert kwargs["model"] == "claude-default"
 
     def test_none_inbound_uses_convert_messages_path(self):
         """When inbound_anthropic_body is None, falls back to rebuild path."""
@@ -185,6 +202,16 @@ def _stub_anthropic_response():
     """Build a minimal Anthropic-shape response object for AsyncMock."""
     msg = MagicMock()
     msg.content = [MagicMock(type="text", text="ok")]
+    msg.usage.input_tokens = 1
+    msg.usage.output_tokens = 1
+    msg.usage.cache_creation_input_tokens = 0
+    msg.usage.cache_read_input_tokens = 0
+    return msg
+
+
+def _stub_tool_response(name="search", **tool_input):
+    msg = MagicMock()
+    msg.content = [MagicMock(type="tool_use", name=name, input=tool_input)]
     msg.usage.input_tokens = 1
     msg.usage.output_tokens = 1
     msg.usage.cache_creation_input_tokens = 0
@@ -295,3 +322,80 @@ class TestCacheControlSurvivesWire:
         # System is a plain string (no blocks, no cache_control)
         assert kwargs["system"] == "large stable system prompt"
         assert not isinstance(kwargs["system"], list)
+
+
+class TestRequestLocalModelSurvivesMutation:
+    @staticmethod
+    def _body(model):
+        return {
+            "model": model,
+            "max_tokens": 128,
+            "messages": [{"role": "user", "content": "search"}],
+            "tools": [{
+                "name": "search",
+                "description": "Search.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                },
+            }],
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("client_model", "inbound_model", "effective_model"),
+        [(None, "route-opus", "route-opus"), ("claude", "caller-model", "claude")],
+    )
+    async def test_model_survives_every_retry_rebuild(
+        self, client_model, inbound_model, effective_model,
+    ):
+        client = AnthropicClient(model=client_model, api_key="dummy")
+        client._client.messages.create = AsyncMock(side_effect=[
+            _stub_anthropic_response(),
+            _stub_anthropic_response(),
+            _stub_tool_response(q="done"),
+        ])
+
+        result = await handle_chat_completions(
+            self._body(inbound_model), client, MagicMock(
+                maybe_compact=MagicMock(side_effect=lambda messages, **_: messages),
+                check_thresholds=MagicMock(return_value=None),
+            ),
+            protocol="anthropic", backend_protocol="anthropic", max_retries=2,
+        )
+
+        calls = client._client.messages.create.call_args_list
+        assert [call.kwargs["model"] for call in calls] == [
+            effective_model, effective_model, effective_model,
+        ]
+        assert calls[0].kwargs["messages"] == self._body(inbound_model)["messages"]
+        assert result["model"] == effective_model
+        assert client.model == client_model
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("client_model", "inbound_model", "effective_model"),
+        [(None, "route-sonnet", "route-sonnet"), ("pinned", "caller", "pinned")],
+    )
+    async def test_model_survives_forced_compaction_rebuild(
+        self, client_model, inbound_model, effective_model,
+    ):
+        client = AnthropicClient(model=client_model, api_key="dummy")
+        client._client.messages.create = AsyncMock(
+            return_value=_stub_tool_response(q="done"),
+        )
+        context_manager = MagicMock()
+        context_manager.maybe_compact.side_effect = (
+            lambda messages, **_: list(messages)
+        )
+        context_manager.check_thresholds.return_value = None
+
+        result = await handle_chat_completions(
+            self._body(inbound_model), client, context_manager,
+            protocol="anthropic", backend_protocol="anthropic",
+        )
+
+        kwargs = client._client.messages.create.call_args.kwargs
+        assert kwargs["model"] == effective_model
+        assert result["model"] == effective_model
+        assert client.model == client_model

--- a/tests/unit/test_proxy_server.py
+++ b/tests/unit/test_proxy_server.py
@@ -127,6 +127,22 @@ async def _sse_request(port, body):
         await writer.wait_closed()
 
 
+async def _anthropic_backend_server(model):
+    client = _mock_client(TextResponse(content="ok"))
+    client.model = model
+    ctx = ContextManager(strategy=NoCompact(), budget_tokens=8192)
+    srv = HTTPServer(
+        client=client,
+        context_manager=ctx,
+        host="127.0.0.1",
+        port=0,
+        serialize_requests=False,
+        backend_protocol="anthropic",
+    )
+    await srv.start()
+    return srv, srv._server.sockets[0].getsockname()[1], client
+
+
 # ── Health & Models ──────────────────────────────────────────
 
 
@@ -147,6 +163,16 @@ class TestHealthAndModels:
         data = json.loads(body)
         assert data["object"] == "list"
         assert data["data"][0]["id"] == "mock-model"
+
+    @pytest.mark.asyncio
+    async def test_models_endpoint_empty_for_request_routed_client(self):
+        srv, port, _ = await _anthropic_backend_server(None)
+        try:
+            status, body = await _http_request(port, "GET", "/v1/models")
+            assert status == 200
+            assert json.loads(body) == {"object": "list", "data": []}
+        finally:
+            await srv.stop()
 
     @pytest.mark.asyncio
     async def test_not_found(self, server_factory):
@@ -296,6 +322,31 @@ class TestSSEStreaming:
             for e in json_events
         )
         assert has_tool_call
+
+
+class TestMissingAnthropicModel:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path", ["/v1/chat/completions", "/v1/messages"])
+    @pytest.mark.parametrize("stream", [False, True])
+    async def test_missing_model_returns_http_400_before_dispatch(self, stream, path):
+        srv, port, client = await _anthropic_backend_server(None)
+        try:
+            status, body = await _http_request(
+                port,
+                "POST",
+                path,
+                {
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": stream,
+                },
+            )
+            assert status == 400
+            assert "No model was supplied" in body
+            assert "text/event-stream" not in body
+            assert "data:" not in body
+            client.send.assert_not_awaited()
+        finally:
+            await srv.stop()
 
 
 # ── Serialization ───────────────────────────────────────────


### PR DESCRIPTION
## What

Fix model routing when Forge proxies to an Anthropic-protocol backend.

For an unpinned proxy, Forge now preserves each request's inbound model name through retries, compaction, downstream dispatch, and the client-facing response. An explicit `--model` is consistently authoritative and overrides the inbound name from the first attempt onward.

The complete behavior is:

- no `--model`: use the request's opaque model name;
- explicit `--model`: use the configured pin on every dispatch path;
- neither source supplies a model: return HTTP 400 before backend dispatch;
- unpinned `/v1/models`: return an empty list because the proxy has no single global model identity; and
- pinned `/v1/models`: continue returning the configured model.

The clean Anthropic passthrough path also works on a shallow copy of the inbound body, preserving fields such as `cache_control` without mutating caller-owned request data.

## Why

On the clean first attempt, Forge's verbatim Anthropic passthrough preserved the inbound model name. However, an unpinned proxy still constructed its shared Anthropic client with `claude` as a fallback model.

When Forge had to rebuild the request—such as after a retry or compaction—the rebuilt payload took its model from that shared client and replaced the request-selected model with `claude`. Routing could therefore change mid-request on Anthropic-compatible gateways.

Explicit model pins were similarly inconsistent: the inbound model won on the clean passthrough path, while the configured pin won after a rebuild. This patch resolves the effective model once per request and preserves it across every dispatch path, while making an explicit `--model` consistently authoritative.

## Compatibility

- Unpinned Anthropic proxies preserve their existing clean first-attempt routing and now retain it through rebuilds.
- Explicit `--model` values now behave as pins consistently from the first attempt onward.
- Requests with neither a configured nor inbound model fail clearly instead of inventing one.
- OpenAI-protocol and managed backend behavior is unchanged.
- Streaming requests validate the effective model before emitting HTTP 200/SSE headers.

## Release metadata

Bumps `forge-guardrails` to v0.8.3 and adds the corresponding changelog entry.

## Validation

- Native code review: no findings; ship verdict
- Focused Anthropic/vLLM proxy suite: 270 passed
- Full unit suite: 1,527 passed
- Mocked-backend proxy smoke: all scenarios passed
- Rebased cleanly onto current `main`, including the merged vLLM `/v1/models` regression fix